### PR TITLE
fix bug in test OS with 64bit (follow symbole link files)

### DIFF
--- a/deployer/src/main/bin/startup.sh
+++ b/deployer/src/main/bin/startup.sh
@@ -70,7 +70,7 @@ in
 	exit;;
 esac
 
-str=`file $JAVA_HOME/bin/java | grep 64-bit`
+str=`file -L $JAVA | grep 64-bit`
 if [ -n "$str" ]; then
 	JAVA_OPTS="-server -Xms2048m -Xmx3072m -Xmn1024m -XX:SurvivorRatio=2 -XX:PermSize=96m -XX:MaxPermSize=256m -Xss256k -XX:-UseAdaptiveSizePolicy -XX:MaxTenuringThreshold=15 -XX:+DisableExplicitGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSCompactAtFullCollection -XX:+UseFastAccessorMethods -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError"
 else


### PR DESCRIPTION
修正探测OS 是否为64bit的bug:
1. 当$JAVA 为符号链接文件时 无法识别
2. `$JAVA_HOME/bin/java  /=  $JAVA`
