### PR TITLE
设置filterTransactionEntry后，导致MetaManager中client得cursor 得不到更新

### DIFF
--- a/server/src/main/java/com/alibaba/otter/canal/server/embeded/CanalServerWithEmbeded.java
+++ b/server/src/main/java/com/alibaba/otter/canal/server/embeded/CanalServerWithEmbeded.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import com.alibaba.otter.canal.sink.CanalEventSink;
+import com.alibaba.otter.canal.sink.entry.EntryEventSink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -345,7 +347,19 @@ public class CanalServerWithEmbeded extends AbstractCanalLifeCycle implements Ca
         // }
 
         // 更新cursor
-        if (positionRanges.getAck() != null) {
+        boolean updateCursor = false;
+        if(positionRanges.getAck() == null) {
+            CanalEventSink eventSink = canalInstance.getEventSink();
+            if(eventSink instanceof EntryEventSink ) {
+                if(((EntryEventSink) eventSink).isFilterTransactionEntry()){
+                    updateCursor = true;
+                }
+            }
+        }else{
+            updateCursor = true;
+        }
+        if(updateCursor)
+        {
             canalInstance.getMetaManager().updateCursor(clientIdentity, positionRanges.getAck());
             logger.info("ack successfully, clientId:{} batchId:{} position:{}",
                         new Object[] { clientIdentity.getClientId(), batchId, positionRanges });

--- a/sink/src/main/java/com/alibaba/otter/canal/sink/entry/EntryEventSink.java
+++ b/sink/src/main/java/com/alibaba/otter/canal/sink/entry/EntryEventSink.java
@@ -191,6 +191,10 @@ public class EntryEventSink extends AbstractCanalEventSink<List<CanalEntry.Entry
         this.filterTransactionEntry = filterTransactionEntry;
     }
 
+    public boolean isFilterTransactionEntry() {
+        return filterTransactionEntry;
+    }
+
     public void setFilterEmtryTransactionEntry(boolean filterEmtryTransactionEntry) {
         this.filterEmtryTransactionEntry = filterEmtryTransactionEntry;
     }


### PR DESCRIPTION
在EvenSink中，https://github.com/alibaba/canal/blob/master/sink/src/main/java/com/alibaba/otter/canal/sink/entry/EntryEventSink.java#L77

此处代码会在filterTransactionEntry设置为true的时候过滤到TRANSACTION_BEGIN和END的event。

而在getWithoutAck ->  getEvents -> com/alibaba/otter/canal/store/memory/MemoryEventStoreWithBuffer.java 中，的 doGet 方法中可以看到，设置LogPositionRange 的ack属性是根据这个range中是否存在TRANSACTION_BEGIN 和END的event来进行设置的。

如果设置了filterTransactionEntry,那么这里返回给client的message对应的positionRange的ack为null。

在client确认的时候，服务端执行ack方法：
https://github.com/alibaba/canal/blob/master/server/src/main/java/com/alibaba/otter/canal/server/embeded/CanalServerWithEmbeded.java#L348

这里会发现如果ack为null，则不更新meta信息
