### PR TITLE
修复rename table命令中包含多个表，解析失败问题

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvert.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvert.java
@@ -216,20 +216,20 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
             if (tableMetaCache != null
                 && (result.getType() == EventType.ALTER || result.getType() == EventType.ERASE || result.getType() == EventType.RENAME)) {
 
-                for( ;result!=null; result = result.getRenameTableResult()) {
-                    schemaName = event.getDbName();
-                    if (StringUtils.isNotEmpty(result.getSchemaName())) {
-                        schemaName = result.getSchemaName();
+                for(DdlResult renameResult=result ;renameResult!=null; renameResult = renameResult.getRenameTableResult()) {
+                    String schemaName0 = event.getDbName();  //防止 rename语句后产生 schema变更带来影响
+                    if (StringUtils.isNotEmpty(renameResult.getSchemaName())) {
+                        schemaName0 = renameResult.getSchemaName();
                     }
 
-                    tableName = result.getTableName();
+                    tableName = renameResult.getTableName();
 
                     if (StringUtils.isNotEmpty(tableName)) {
                         // 如果解析到了正确的表信息，则根据全名进行清除
-                        tableMetaCache.clearTableMeta(schemaName, tableName);
+                        tableMetaCache.clearTableMeta(schemaName0, tableName);
                     } else {
                         // 如果无法解析正确的表信息，则根据schema进行清除
-                        tableMetaCache.clearTableMetaWithSchemaName(schemaName);
+                        tableMetaCache.clearTableMetaWithSchemaName(schemaName0);
                     }
                 }
             }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvert.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvert.java
@@ -215,12 +215,22 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
             // 更新下table meta cache
             if (tableMetaCache != null
                 && (result.getType() == EventType.ALTER || result.getType() == EventType.ERASE || result.getType() == EventType.RENAME)) {
-                if (StringUtils.isNotEmpty(tableName)) {
-                    // 如果解析到了正确的表信息，则根据全名进行清除
-                    tableMetaCache.clearTableMeta(schemaName, tableName);
-                } else {
-                    // 如果无法解析正确的表信息，则根据schema进行清除
-                    tableMetaCache.clearTableMetaWithSchemaName(schemaName);
+
+                for( ;result!=null; result = result.getRenameTableResult()) {
+                    schemaName = event.getDbName();
+                    if (StringUtils.isNotEmpty(result.getSchemaName())) {
+                        schemaName = result.getSchemaName();
+                    }
+
+                    tableName = result.getTableName();
+
+                    if (StringUtils.isNotEmpty(tableName)) {
+                        // 如果解析到了正确的表信息，则根据全名进行清除
+                        tableMetaCache.clearTableMeta(schemaName, tableName);
+                    } else {
+                        // 如果无法解析正确的表信息，则根据schema进行清除
+                        tableMetaCache.clearTableMetaWithSchemaName(schemaName);
+                    }
                 }
             }
 

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/SimpleDdlParser.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/SimpleDdlParser.java
@@ -299,11 +299,10 @@ public class SimpleDdlParser {
             DdlResult ddlResult = this;
             StringBuffer sb = new StringBuffer();
             do{
-                String.format("DdlResult [schemaName=%s , tableName=%s , oriSchemaName=%s , oriTableName=%s , type=%s ;",
-                        ddlResult.schemaName, ddlResult.tableName, ddlResult.oriSchemaName, ddlResult.oriTableName, ddlResult.type);
+                sb.append(String.format("DdlResult [schemaName=%s , tableName=%s , oriSchemaName=%s , oriTableName=%s , type=%s ];",
+                        ddlResult.schemaName, ddlResult.tableName, ddlResult.oriSchemaName, ddlResult.oriTableName, ddlResult.type));
                 ddlResult = ddlResult.renameTableResult;
-            }while (ddlResult.renameTableResult!=null);
-            sb.append("]");
+            }while (ddlResult!=null);
 
             return sb.toString();
         }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/SimpleDdlParser.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/SimpleDdlParser.java
@@ -32,6 +32,7 @@ public class SimpleDdlParser {
     public static final String UPDATE_PATTERN       = "^\\s*UPDATE(.*)$";
     public static final String DELETE_PATTERN       = "^\\s*DELETE(.*)$";
     public static final String RENAME_PATTERN       = "^\\s*RENAME\\s*TABLE\\s*(.*?)\\s*TO\\s*(.*?)$";
+    public static final String RENAME_REMNANT_PATTERN = "^\\s*(.*?)\\s*TO\\s*(.*?)$";
     /**
      * <pre>
      * CREATE [UNIQUE|FULLTEXT|SPATIAL] INDEX index_name
@@ -74,6 +75,18 @@ public class SimpleDdlParser {
         result = parseRename(queryString, schmeaName, RENAME_PATTERN);
         if (result != null) {
             result.setType(EventType.RENAME);
+
+            String[] renameStrings =  queryString.split(",");
+            if (renameStrings.length > 1){
+                DdlResult lastResult = result;
+                for (int i=1; i<renameStrings.length; i++){
+                    DdlResult ddlResult = parseRename(renameStrings[i], schmeaName, RENAME_REMNANT_PATTERN);
+                    ddlResult.setType(EventType.RENAME);
+                    lastResult.setRenameTableResult(ddlResult);
+                    lastResult = ddlResult;
+                }
+            }
+
             return result;
         }
 
@@ -205,6 +218,14 @@ public class SimpleDdlParser {
         private String    oriSchemaName; // rename ddl中的源表
         private String    oriTableName; // rename ddl中的目标表
         private EventType type;
+        private DdlResult renameTableResult; // 多个rename table的存储
+
+        /*
+        RENAME TABLE tbl_name TO new_tbl_name
+              [, tbl_name2 TO new_tbl_name2] ...
+
+         */
+
 
         public DdlResult(){
         }
@@ -265,10 +286,26 @@ public class SimpleDdlParser {
             this.oriTableName = oriTableName;
         }
 
+        public DdlResult getRenameTableResult() {
+            return renameTableResult;
+        }
+
+        public void setRenameTableResult(DdlResult renameTableResult) {
+            this.renameTableResult = renameTableResult;
+        }
+
         @Override
         public String toString() {
-            return "DdlResult [schemaName=" + schemaName + ", tableName=" + tableName + ", oriSchemaName="
-                   + oriSchemaName + ", oriTableName=" + oriTableName + ", type=" + type + "]";
+            DdlResult ddlResult = this;
+            StringBuffer sb = new StringBuffer();
+            do{
+                String.format("DdlResult [schemaName=%s , tableName=%s , oriSchemaName=%s , oriTableName=%s , type=%s ;",
+                        ddlResult.schemaName, ddlResult.tableName, ddlResult.oriSchemaName, ddlResult.oriTableName, ddlResult.type);
+                ddlResult = ddlResult.renameTableResult;
+            }while (ddlResult.renameTableResult!=null);
+            sb.append("]");
+
+            return sb.toString();
         }
 
     }


### PR DESCRIPTION
简单的修复下 rename table命令中包含多个表的问题。

如 https://github.com/alibaba/canal/issues/79 中提到的：
后续完美解决：使用类似druid/cobar的mysql sql语法解析，提取对应的表.
是比较理想解决方案。

由于canal获取binlog存在延迟，可能拿到binlog的时候通过desc命令获取的表结构实际是和binlog产生时的表结构有差距的。

最好的解决方案是ddl语句都直接触发tablemeta cache的对应变化，而不是clear tablemetacache。

1.只有drop table 会clear tablemeta cache
2.只有收集到table metacache 中没有的表的binlog时才会desc 获取表结构。
3.ddl语句都直接作用在tablemeta cache上

这个才能最大程度的减少错误的发生，这个是个临时的修补方案，解决目前遇到的 rename table命令中包含多个表的问题。