### PR TITLE
Fix a minor fault: Canal instance reload again after startup.

### DIFF
--- a/deployer/src/main/java/com/alibaba/otter/canal/deployer/monitor/SpringInstanceConfigMonitor.java
+++ b/deployer/src/main/java/com/alibaba/otter/canal/deployer/monitor/SpringInstanceConfigMonitor.java
@@ -175,6 +175,7 @@ public class SpringInstanceConfigMonitor extends AbstractCanalLifeCycle implemen
         InstanceAction action = actions.remove(destination);
         try {
             action.stop(destination);
+            lastFiles.remove(destination);
             logger.info("auto notify stop {} successful.", destination);
         } catch (Throwable e) {
             logger.error("scan delete found[{}] but stop failed", destination, ExceptionUtils.getFullStackTrace(e));


### PR DESCRIPTION
说一下大致的场景：
用户在使用增量同步之前会先进行全量初始化。在初始化的过程中，可以随时中断并重新初始化。我们会将原来instance的config文件夹删除重新生成instance文件夹和配置文件（内容一致）。这时候，启动成功后的下一次扫描间隔（5s）会又reload一次，因为初始化transaction比较大，所以会同步给client一些duplicate的binlog。日志如下：
2016-10-02 13:28:35.103 [canal-instance-scan-0] INFO  c.a.o.canal.deployer.monitor.SpringInstanceConfigMonitor - auto notify start example successful.
2016-10-02 13:28:40.138 [canal-instance-scan-0] INFO  c.a.o.canal.deployer.monitor.SpringInstanceConfigMonitor - auto notify reload example successful.
所以，stop成功以后是不是应该把lastFiles里的remove掉？
若有不对的地方请指教，谢谢！