### PR TITLE
fixed issue #227 , fixed Mysql5.1.73 throw NullPointerException

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/MysqlConnection.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/MysqlConnection.java
@@ -279,8 +279,9 @@ public class MysqlConnection implements ErosaConnection {
         }
 
         List<String> columnValues = rs.getFieldValues();
-        if(columnValues.get(0).toUpperCase().equals("CRC32")){
-        	binlogChecksum = LogEvent.BINLOG_CHECKSUM_ALG_CRC32;
+        if (columnValues.size() > 0 && columnValues.get(0) != null
+                && columnValues.get(0).toUpperCase().equals("CRC32")) {
+                binlogChecksum = LogEvent.BINLOG_CHECKSUM_ALG_CRC32;
         }else{
         	binlogChecksum = LogEvent.BINLOG_CHECKSUM_ALG_OFF;
         }


### PR DESCRIPTION
`select @master_binlog_checksum` 在mysql5.1版本中返回null
会触发NullPointerException