### PR TITLE
对于binlog dump本身就是阻塞式的读写，使用更简单的BIO

### DIFF
--- a/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/socket/SocketChannel.java
+++ b/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/socket/SocketChannel.java
@@ -18,7 +18,7 @@ public class SocketChannel {
     private static final int period  = 10;
     private Channel channel = null;
     private Object  lock    = new Object();
-    private ByteBuf cache   = PooledByteBufAllocator.DEFAULT.directBuffer(1024 * 1024); // 缓存大小
+    private ByteBuf cache   = PooledByteBufAllocator.DEFAULT.directBuffer(20 * 1024 * 1024); // 设置一个稍大于Mysql maxThreeBytes的capacity，确保能写入一个完整的包。
 
     public Channel getChannel() {
         return channel;

--- a/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/socket/SocketChannelPool.java
+++ b/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/socket/SocketChannelPool.java
@@ -1,110 +1,27 @@
 package com.alibaba.otter.canal.parse.driver.mysql.socket;
 
-import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.channel.AdaptiveRecvByteBufAllocator;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.nio.NioSocketChannel;
-
-import java.io.IOException;
+import java.net.Socket;
 import java.net.SocketAddress;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.alibaba.otter.canal.parse.driver.mysql.socket.SocketChannel.DEFAULT_CONNECT_TIMEOUT;
+import static com.alibaba.otter.canal.parse.driver.mysql.socket.SocketChannel.SO_TIMEOUT;
 
 /**
  * @author luoyaogui 实现channel的管理（监听连接、读数据、回收） 2016-12-28
+ * @author chuanyi 2018-3-3
+ * 保留<code>open</code>减少文件变更数量
  */
-@SuppressWarnings({ "rawtypes", "deprecation" })
 public abstract class SocketChannelPool {
 
-    private static EventLoopGroup              group     = new NioEventLoopGroup();                         // 非阻塞IO线程组
-    private static Bootstrap                   boot      = new Bootstrap();                                 // 主
-    private static Map<Channel, SocketChannel> chManager = new ConcurrentHashMap<Channel, SocketChannel>();
-    private static final Logger                logger    = LoggerFactory.getLogger(SocketChannelPool.class);
-
-    static {
-        boot.group(group)
-            .channel(NioSocketChannel.class)
-            .option(ChannelOption.SO_RCVBUF, 32 * 1024)
-            .option(ChannelOption.SO_SNDBUF, 32 * 1024)
-            .option(ChannelOption.TCP_NODELAY, true)
-            // 如果是延时敏感型应用，建议关闭Nagle算法
-            .option(ChannelOption.SO_KEEPALIVE, true)
-            .option(ChannelOption.RCVBUF_ALLOCATOR, AdaptiveRecvByteBufAllocator.DEFAULT)
-            .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
-            //
-            .handler(new ChannelInitializer() {
-
-                @Override
-                protected void initChannel(Channel arg0) throws Exception {
-                    arg0.pipeline().addLast(new BusinessHandler());// 命令过滤和handler添加管理
-                }
-            });
-    }
-
     public static SocketChannel open(SocketAddress address) throws Exception {
-        SocketChannel socket = null;
-        ChannelFuture future = boot.connect(address).sync();
-
-        if (future.isSuccess()) {
-            future.channel().pipeline().get(BusinessHandler.class).latch.await();
-            socket = chManager.get(future.channel());
-        }
-
-        if (null == socket) {
-            throw new IOException("can't create socket!");
-        }
-
-        return socket;
+        Socket socket = new Socket();
+        socket.setReceiveBufferSize(32 * 1024);
+        socket.setSendBufferSize(32 * 1024);
+        socket.setSoTimeout(SO_TIMEOUT);
+        socket.setTcpNoDelay(true);
+        socket.setKeepAlive(true);
+        socket.setReuseAddress(true);
+        socket.connect(address, DEFAULT_CONNECT_TIMEOUT);
+        return new SocketChannel(socket);
     }
 
-    public static class BusinessHandler extends SimpleChannelInboundHandler<ByteBuf> {
-
-        private SocketChannel        socket = null;
-        private final CountDownLatch latch  = new CountDownLatch(1);
-
-        @Override
-        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-            socket.setChannel(null);
-            chManager.remove(ctx.channel());// 移除
-        }
-
-        @Override
-        public void channelActive(ChannelHandlerContext ctx) throws Exception {
-            socket = new SocketChannel();
-            socket.setChannel(ctx.channel());
-            chManager.put(ctx.channel(), socket);
-            latch.countDown();
-            super.channelActive(ctx);
-        }
-
-        @Override
-        protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
-            if (socket != null) {
-                socket.writeCache(msg);
-            } else {
-                // TODO: need graceful error handler.
-                logger.error("no socket available.");
-            }
-        }
-
-        @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            // need output error for troubeshooting.
-            logger.error("business error.", cause);
-            ctx.close();
-        }
-    }
 }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/DirectLogFetcher.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/DirectLogFetcher.java
@@ -23,8 +23,8 @@ public class DirectLogFetcher extends LogFetcher {
 
     // Master heartbeat interval
     public static final int MASTER_HEARTBEAT_PERIOD_SECONDS = 15;
-    // +1s 确保 timeout > heartbeat interval
-    private static final int READ_TIMEOUT_MILLISECONDS = (MASTER_HEARTBEAT_PERIOD_SECONDS + 1) * 1000;
+    // +10s 确保 timeout > heartbeat interval
+    private static final int READ_TIMEOUT_MILLISECONDS = (MASTER_HEARTBEAT_PERIOD_SECONDS + 10) * 1000;
 
     /** Command to dump binlog */
     public static final byte      COM_BINLOG_DUMP   = 18;


### PR DESCRIPTION
这个pr会覆盖其他open的pr 536，539。
最近进行的测试，发现了SocketChannel的一些其他问题：
在构建新SocketChannel时，EventLoopGroup调next()就近分配EventLoop进行注册，经过长时间运行，某一个instance的channel如果期间中断过多次，可能round到一个其他instance的channel注册的EventLoop。由于没有在记录log前后设置MDC，日志会记到其他instance的日志文件中。多个channel共享一个EventLoop，轮流使用时间片会使读性能变差（如果消费的快）。

BIO使用较小的SO_TIMEOUT(1s)，处理闪断和interrupt。

其他改动：READ_TIMEOUT_MILLISECONDS修改为(MASTER_HEARTBEAT_PERIOD_SECONDS + 10) * 1000.
+1s的情况，在一个instance无traffic放置一天的测试中，出现了几次读取header timeout，频率大致几小时一次。