### PR TITLE
Fix issue #586 event size不准确的问题

### DIFF
--- a/store/src/main/java/com/alibaba/otter/canal/store/memory/MemoryEventStoreWithBuffer.java
+++ b/store/src/main/java/com/alibaba/otter/canal/store/memory/MemoryEventStoreWithBuffer.java
@@ -531,8 +531,7 @@ public class MemoryEventStoreWithBuffer extends AbstractCanalStoreScavenge imple
     }
 
     private long calculateSize(Event event) {
-        // 直接返回binlog中的事件大小
-        return event.getEntry().getHeader().getEventLength();
+        return event.getEntry().getSerializedSize();
     }
 
     private int getIndex(long sequcnce) {


### PR DESCRIPTION
calculateSize由binlog事件大小改为返回serializedSize，内存大小更准确可控