### PR TITLE
支持通过GTID同步binlog

### DIFF
--- a/dbsync/src/main/java/com/taobao/tddl/dbsync/binlog/event/GtidLogEvent.java
+++ b/dbsync/src/main/java/com/taobao/tddl/dbsync/binlog/event/GtidLogEvent.java
@@ -3,6 +3,9 @@ package com.taobao.tddl.dbsync.binlog.event;
 import com.taobao.tddl.dbsync.binlog.LogBuffer;
 import com.taobao.tddl.dbsync.binlog.LogEvent;
 
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
 /**
  * @author jianghang 2013-4-8 上午12:36:29
  * @version 1.0.3
@@ -16,6 +19,8 @@ public class GtidLogEvent extends LogEvent {
     public static final int ENCODED_SID_LENGTH  = 16;
 
     private boolean         commitFlag;
+    private UUID            sid;
+    private long            gno;
 
     public GtidLogEvent(LogHeader header, LogBuffer buffer, FormatDescriptionLogEvent descriptionEvent){
         super(header);
@@ -26,6 +31,14 @@ public class GtidLogEvent extends LogEvent {
 
         buffer.position(commonHeaderLen);
         commitFlag = (buffer.getUint8() != 0); // ENCODED_FLAG_LENGTH
+
+        byte[] bs = buffer.getData(ENCODED_SID_LENGTH);
+        ByteBuffer bb = ByteBuffer.wrap(bs);
+        long high = bb.getLong();
+        long low = bb.getLong();
+        sid = new UUID(high, low);
+
+        gno = buffer.getLong64();
 
         // ignore gtid info read
         // sid.copy_from((uchar *)ptr_buffer);
@@ -42,4 +55,11 @@ public class GtidLogEvent extends LogEvent {
         return commitFlag;
     }
 
+    public UUID getSid() {
+        return sid;
+    }
+
+    public long getGno() {
+        return gno;
+    }
 }

--- a/deployer/src/main/resources/example/instance.properties
+++ b/deployer/src/main/resources/example/instance.properties
@@ -6,7 +6,9 @@ canal.instance.master.address=127.0.0.1:3306
 canal.instance.master.journal.name=
 canal.instance.master.position=
 canal.instance.master.timestamp=
+canal.instance.master.gtid=
 
+canal.instance.gtidon=true
 
 # table meta tsdb info
 canal.instance.tsdb.enable=true
@@ -20,7 +22,8 @@ canal.instance.tsdb.dbPassword=canal
 #canal.instance.standby.address =
 #canal.instance.standby.journal.name =
 #canal.instance.standby.position = 
-#canal.instance.standby.timestamp = 
+#canal.instance.standby.timestamp =
+#canal.instance.standby.gtid=
 # username/password
 canal.instance.dbUsername=canal
 canal.instance.dbPassword=canal

--- a/deployer/src/main/resources/spring/file-instance.xml
+++ b/deployer/src/main/resources/spring/file-instance.xml
@@ -151,6 +151,7 @@
 				<property name="journalName" value="${canal.instance.master.journal.name}" />
 				<property name="position" value="${canal.instance.master.position}" />
 				<property name="timestamp" value="${canal.instance.master.timestamp}" />
+				<property name="gtid" value="${canal.instance.master.gtid}" />
 			</bean>
 		</property>
 		<property name="standbyPosition">
@@ -158,6 +159,7 @@
 				<property name="journalName" value="${canal.instance.standby.journal.name}" />
 				<property name="position" value="${canal.instance.standby.position}" />
 				<property name="timestamp" value="${canal.instance.standby.timestamp}" />
+				<property name="gtid" value="${canal.instance.standby.gtid}" />
 			</bean>
 		</property>
 		<property name="filterQueryDml" value="${canal.instance.filter.query.dml:false}" />
@@ -172,5 +174,8 @@
 		<!--表结构相关-->
 		<property name="enableTsdb" value="${canal.instance.tsdb.enable:true}"/>
 		<property name="tsdbSpringXml" value="${canal.instance.tsdb.spring.xml:}"/>
+
+		<!--是否启用GTID模式-->
+		<property name="isGTIDMode" value="${canal.instance.gtidon}"/>
 	</bean>
 </beans>

--- a/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/GTIDSet.java
+++ b/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/GTIDSet.java
@@ -1,0 +1,24 @@
+package com.alibaba.otter.canal.parse.driver.mysql.packets;
+
+import java.io.IOException;
+
+/**
+ * Created by hiwjd on 2018/4/23.
+ * hiwjd0@gmail.com
+ */
+public interface GTIDSet {
+
+    /**
+     * 序列化成字节数组
+     *
+     * @return
+     */
+    byte[] encode() throws IOException;
+
+    /**
+     * 更新当前实例
+     * @param str
+     * @throws Exception
+     */
+    void update(String str);
+}

--- a/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/MysqlGTIDSet.java
+++ b/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/MysqlGTIDSet.java
@@ -1,0 +1,151 @@
+package com.alibaba.otter.canal.parse.driver.mysql.packets;
+
+import com.alibaba.otter.canal.parse.driver.mysql.utils.ByteHelper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Created by hiwjd on 2018/4/23.
+ * hiwjd0@gmail.com
+ */
+public class MysqlGTIDSet implements GTIDSet {
+
+    public Map<String, UUIDSet> sets;
+
+    @Override
+    public byte[] encode() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteHelper.writeUnsignedInt64LittleEndian(sets.size(), out);
+
+        for (Map.Entry<String, UUIDSet> entry : sets.entrySet()) {
+            out.write(entry.getValue().encode());
+        }
+
+        return out.toByteArray();
+    }
+
+    @Override
+    public void update(String str) {
+        UUIDSet us = UUIDSet.parse(str);
+        String sid = us.SID.toString();
+        if (sets.containsKey(sid)) {
+            sets.get(sid).intervals.addAll(us.intervals);
+            sets.get(sid).intervals = UUIDSet.combine(sets.get(sid).intervals);
+        } else {
+            sets.put(sid, us);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        if (this == o) return true;
+
+        MysqlGTIDSet gs = (MysqlGTIDSet) o;
+        if (gs.sets == null) return false;
+
+        for (Map.Entry<String, UUIDSet> entry : sets.entrySet()) {
+            if (!entry.getValue().equals(gs.sets.get(entry.getKey()))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * 解析如下格式的字符串为MysqlGTIDSet:
+     *
+     * 726757ad-4455-11e8-ae04-0242ac110002:1 =>
+     *   MysqlGTIDSet{
+     *     sets: {
+     *       726757ad-4455-11e8-ae04-0242ac110002: UUIDSet{
+     *         SID: 726757ad-4455-11e8-ae04-0242ac110002,
+     *         intervals: [{start:1, stop:2}]
+     *       }
+     *     }
+     *   }
+     *
+     * 726757ad-4455-11e8-ae04-0242ac110002:1-3 =>
+     *   MysqlGTIDSet{
+     *     sets: {
+     *       726757ad-4455-11e8-ae04-0242ac110002: UUIDSet{
+     *         SID: 726757ad-4455-11e8-ae04-0242ac110002,
+     *         intervals: [{start:1, stop:4}]
+     *       }
+     *     }
+     *   }
+     *
+     * 726757ad-4455-11e8-ae04-0242ac110002:1-3:4 =>
+     *   MysqlGTIDSet{
+     *     sets: {
+     *       726757ad-4455-11e8-ae04-0242ac110002: UUIDSet{
+     *         SID: 726757ad-4455-11e8-ae04-0242ac110002,
+     *         intervals: [{start:1, stop:5}]
+     *       }
+     *     }
+     *   }
+     *
+     * 726757ad-4455-11e8-ae04-0242ac110002:1-3:7-9 =>
+     *   MysqlGTIDSet{
+     *     sets: {
+     *       726757ad-4455-11e8-ae04-0242ac110002: UUIDSet{
+     *         SID: 726757ad-4455-11e8-ae04-0242ac110002,
+     *         intervals: [{start:1, stop:4}, {start:7, stop: 10}]
+     *       }
+     *     }
+     *   }
+     *
+     * 726757ad-4455-11e8-ae04-0242ac110002:1-3,726757ad-4455-11e8-ae04-0242ac110003:4 =>
+     *   MysqlGTIDSet{
+     *     sets: {
+     *       726757ad-4455-11e8-ae04-0242ac110002: UUIDSet{
+     *         SID: 726757ad-4455-11e8-ae04-0242ac110002,
+     *         intervals: [{start:1, stop:4}]
+     *       },
+     *       726757ad-4455-11e8-ae04-0242ac110003: UUIDSet{
+     *         SID: 726757ad-4455-11e8-ae04-0242ac110002,
+     *         intervals: [{start:4, stop:5}]
+     *       }
+     *     }
+     *   }
+     *
+     * @param gtidData
+     * @return
+     */
+    public static MysqlGTIDSet parse(String gtidData) {
+        Map<String, UUIDSet> m;
+
+        if (gtidData == null || gtidData.length() < 1) {
+            m = new HashMap<String, UUIDSet>();
+        } else {
+            String[] uuidStrs = gtidData.split(",");
+            m = new HashMap<String, UUIDSet>(uuidStrs.length);
+            for (int i = 0; i < uuidStrs.length; i++) {
+                UUIDSet uuidSet = UUIDSet.parse(uuidStrs[i]);
+                m.put(uuidSet.SID.toString(), uuidSet);
+            }
+        }
+
+        MysqlGTIDSet gs = new MysqlGTIDSet();
+        gs.sets = m;
+
+        return gs;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        for (Map.Entry<String, UUIDSet> entry : sets.entrySet()) {
+            if (sb.length() > 0) {
+                sb.append(",");
+            }
+            sb.append(entry.getValue().toString());
+        }
+
+        return sb.toString();
+    }
+}

--- a/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/UUIDSet.java
+++ b/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/UUIDSet.java
@@ -1,0 +1,202 @@
+package com.alibaba.otter.canal.parse.driver.mysql.packets;
+
+import com.alibaba.otter.canal.parse.driver.mysql.utils.ByteHelper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Created by hiwjd on 2018/4/23.
+ * hiwjd0@gmail.com
+ */
+public class UUIDSet {
+
+    public UUID SID;
+    public List<Interval> intervals;
+
+    public byte[] encode() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(SID.getMostSignificantBits());
+        bb.putLong(SID.getLeastSignificantBits());
+
+        out.write(bb.array());
+
+        ByteHelper.writeUnsignedInt64LittleEndian(intervals.size(), out);
+
+        for (Interval interval : intervals) {
+            ByteHelper.writeUnsignedInt64LittleEndian(interval.start, out);
+            ByteHelper.writeUnsignedInt64LittleEndian(interval.stop, out);
+        }
+
+        return out.toByteArray();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        if (this == o) return true;
+
+        UUIDSet us = (UUIDSet) o;
+        Collections.sort(intervals);
+        Collections.sort(us.intervals);
+        if (SID.equals(us.SID) && intervals.equals(us.intervals)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static class Interval implements Comparable<Interval> {
+        public long start;
+        public long stop;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Interval interval = (Interval) o;
+
+            if (start != interval.start) return false;
+            return stop == interval.stop;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = (int) (start ^ (start >>> 32));
+            result = 31 * result + (int) (stop ^ (stop >>> 32));
+            return result;
+        }
+
+        @Override
+        public int compareTo(Interval o) {
+            if (equals(o)) {
+                return 1;
+            }
+            return start > o.start ? 1 : (start == o.start ? 0 : -1);
+        }
+    }
+
+    /**
+     * 解析如下格式字符串为UUIDSet:
+     *
+     * 726757ad-4455-11e8-ae04-0242ac110002:1 =>
+     *   UUIDSet{SID: 726757ad-4455-11e8-ae04-0242ac110002, intervals: [{start:1, stop:2}]}
+     *
+     * 726757ad-4455-11e8-ae04-0242ac110002:1-3 =>
+     *   UUIDSet{SID: 726757ad-4455-11e8-ae04-0242ac110002, intervals: [{start:1, stop:4}]}
+     *
+     * 726757ad-4455-11e8-ae04-0242ac110002:1-3:4
+     *   UUIDSet{SID: 726757ad-4455-11e8-ae04-0242ac110002, intervals: [{start:1, stop:5}]}
+     *
+     * 726757ad-4455-11e8-ae04-0242ac110002:1-3:7-9
+     *   UUIDSet{SID: 726757ad-4455-11e8-ae04-0242ac110002, intervals: [{start:1, stop:4}, {start:7, stop:10}]}
+     *
+     * @param str
+     * @return
+     */
+    public static UUIDSet parse(String str) {
+        String[] ss = str.split(":");
+
+        if (ss.length < 2) {
+            throw new RuntimeException(String.format("parseUUIDSet failed due to wrong format: %s", str));
+        }
+
+        List<Interval> intervals = new ArrayList<Interval>();
+        for (int i=1; i<ss.length; i++) {
+            intervals.add(parseInterval(ss[i]));
+        }
+
+        UUIDSet uuidSet = new UUIDSet();
+        uuidSet.SID = UUID.fromString(ss[0]);
+        uuidSet.intervals = combine(intervals);
+
+        return uuidSet;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(SID.toString());
+        for (Interval interval : intervals) {
+            if (interval.start == interval.stop - 1) {
+                sb.append(":");
+                sb.append(interval.start);
+            } else {
+                sb.append(":");
+                sb.append(interval.start);
+                sb.append("-");
+                sb.append(interval.stop-1);
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * 解析如下格式字符串为Interval:
+     *
+     * 1 => Interval{start:1, stop:2}
+     * 1-3 => Interval{start:1, stop:4}
+     *
+     * 注意！字符串格式表达时[n,m]是两侧都包含的，Interval表达时[n,m)右侧开
+     *
+     * @param str
+     * @return
+     */
+    public static Interval parseInterval(String str) {
+        String[] ss = str.split("-");
+
+        Interval interval = new Interval();
+        switch (ss.length) {
+            case 1:
+                interval.start = Long.parseLong(ss[0]);
+                interval.stop = interval.start + 1;
+                break;
+            case 2:
+                interval.start = Long.parseLong(ss[0]);
+                interval.stop = Long.parseLong(ss[1]) + 1;
+                break;
+            default:
+                throw new RuntimeException(String.format("parseInterval failed due to wrong format: %s", str));
+        }
+
+        return interval;
+    }
+
+    /**
+     * 把{start,stop}连续的合并掉:
+     * [{start:1, stop:4},{start:4, stop:5}] => [{start:1, stop:5}]
+     *
+     * @param intervals
+     * @return
+     */
+    public static List<Interval> combine(List<Interval> intervals) {
+        List<Interval> combined = new ArrayList<Interval>();
+        Collections.sort(intervals);
+        int len = intervals.size();
+        for (int i=0; i<len; i++) {
+            combined.add(intervals.get(i));
+
+            int j;
+            for (j=i+1; j<len; j++) {
+                if (intervals.get(i).stop >= intervals.get(j).start) {
+                    intervals.get(i).stop = intervals.get(j).stop;
+                } else {
+                    break;
+                }
+            }
+            i = j - 1;
+        }
+
+        return combined;
+    }
+}

--- a/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/client/BinlogDumpGTIDCommandPacket.java
+++ b/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/client/BinlogDumpGTIDCommandPacket.java
@@ -1,0 +1,68 @@
+package com.alibaba.otter.canal.parse.driver.mysql.packets.client;
+
+import com.alibaba.otter.canal.parse.driver.mysql.packets.CommandPacket;
+import com.alibaba.otter.canal.parse.driver.mysql.packets.GTIDSet;
+import com.alibaba.otter.canal.parse.driver.mysql.utils.ByteHelper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/**
+ * Created by hiwjd on 2018/4/24.
+ * hiwjd0@gmail.com
+ *
+ * https://dev.mysql.com/doc/internals/en/com-binlog-dump-gtid.html
+ */
+public class BinlogDumpGTIDCommandPacket extends CommandPacket {
+
+    public static final int BINLOG_DUMP_NON_BLOCK = 0x01;
+    public static final int BINLOG_THROUGH_POSITION = 0x02;
+    public static final int BINLOG_THROUGH_GTID = 0x04;
+
+    public long    slaveServerId;
+    public GTIDSet gtidSet;
+
+    public BinlogDumpGTIDCommandPacket() {
+        setCommand((byte) 0x1e);
+    }
+
+    @Override
+    public void fromBytes(byte[] data) throws IOException {
+    }
+
+    @Override
+    public byte[] toBytes() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // 0. [1] write command number
+        out.write(getCommand());
+        // 1. [2] flags
+        ByteHelper.writeUnsignedShortLittleEndian(BINLOG_THROUGH_GTID, out);
+        // 2. [4] server-id
+        ByteHelper.writeUnsignedIntLittleEndian(slaveServerId, out);
+        // 3. [4] binlog-filename-len
+        ByteHelper.writeUnsignedIntLittleEndian(0, out);
+        // 4. [] binlog-filename
+        // skip
+        // 5. [8] binlog-pos
+        ByteHelper.writeUnsignedInt64LittleEndian(4, out);
+        // if flags & BINLOG_THROUGH_GTID {
+        byte[] bs = gtidSet.encode();
+        // 6. [4] data-size
+        ByteHelper.writeUnsignedIntLittleEndian(bs.length, out);
+        // 7, [] data
+        //       [8] n_sids // 文档写的是4个字节，其实是8个字节
+        //       for n_sids {
+        //          [16] SID
+        //          [8] n_intervals
+        //          for n_intervals {
+        //             [8] start (signed)
+        //             [8] end (signed)
+        //          }
+        //       }
+        out.write(bs);
+        // }
+
+        return out.toByteArray();
+    }
+}

--- a/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/utils/ByteHelper.java
+++ b/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/utils/ByteHelper.java
@@ -127,6 +127,17 @@ public abstract class ByteHelper {
         out.write((byte) (data >>> 24));
     }
 
+    public static void writeUnsignedInt64LittleEndian(long data, ByteArrayOutputStream out) {
+        out.write((byte) (data & 0xFF));
+        out.write((byte) (data >>> 8));
+        out.write((byte) (data >>> 16));
+        out.write((byte) (data >>> 24));
+        out.write((byte) (data >>> 32));
+        out.write((byte) (data >>> 40));
+        out.write((byte) (data >>> 48));
+        out.write((byte) (data >>> 56));
+    }
+
     public static void writeUnsignedShortLittleEndian(int data, ByteArrayOutputStream out) {
         out.write((byte) (data & 0xFF));
         out.write((byte) ((data >>> 8) & 0xFF));

--- a/driver/src/test/java/com/alibaba/otter/canal/parse/driver/mysql/MysqlGTIDSetTest.java
+++ b/driver/src/test/java/com/alibaba/otter/canal/parse/driver/mysql/MysqlGTIDSetTest.java
@@ -1,0 +1,129 @@
+package com.alibaba.otter.canal.parse.driver.mysql;
+
+import com.alibaba.otter.canal.parse.driver.mysql.packets.GTIDSet;
+import com.alibaba.otter.canal.parse.driver.mysql.packets.MysqlGTIDSet;
+import com.alibaba.otter.canal.parse.driver.mysql.packets.UUIDSet;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Created by hiwjd on 2018/4/25.
+ * hiwjd0@gmail.com
+ */
+public class MysqlGTIDSetTest {
+
+    @Test
+    public void testEncode() throws IOException {
+        GTIDSet gtidSet = MysqlGTIDSet.parse("726757ad-4455-11e8-ae04-0242ac110002:1");
+        byte[] bytes = gtidSet.encode();
+
+        byte[] expected = {
+                0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x72, 0x67, 0x57, (byte)0xad,
+                0x44, 0x55, 0x11, (byte)0xe8, (byte)0xae, 0x04, 0x02, 0x42, (byte)0xac, 0x11, 0x00, 0x02,
+                0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        };
+
+        for (int i=0; i<bytes.length; i++) {
+            assertEquals(expected[i], bytes[i]);
+        }
+    }
+
+    @Test
+    public void testParse() {
+        Map<String, MysqlGTIDSet> cases = new HashMap<String, MysqlGTIDSet>(5);
+        cases.put(
+                "726757ad-4455-11e8-ae04-0242ac110002:1",
+                buildForTest(new Material("726757ad-4455-11e8-ae04-0242ac110002", 1, 2))
+        );
+        cases.put(
+                "726757ad-4455-11e8-ae04-0242ac110002:1-3",
+                buildForTest(new Material("726757ad-4455-11e8-ae04-0242ac110002", 1, 4))
+        );
+        cases.put(
+                "726757ad-4455-11e8-ae04-0242ac110002:1-3:4",
+                buildForTest(new Material("726757ad-4455-11e8-ae04-0242ac110002", 1, 5))
+        );
+        cases.put(
+                "726757ad-4455-11e8-ae04-0242ac110002:1-3:7-9",
+                buildForTest(new Material("726757ad-4455-11e8-ae04-0242ac110002", 1, 4, 7, 10))
+        );
+        cases.put(
+                "726757ad-4455-11e8-ae04-0242ac110002:1-3,726757ad-4455-11e8-ae04-0242ac110003:4",
+                buildForTest(
+                        Arrays.asList(
+                            new Material("726757ad-4455-11e8-ae04-0242ac110002", 1, 4),
+                                new Material("726757ad-4455-11e8-ae04-0242ac110003", 4, 5)
+                        )
+                )
+        );
+
+        for (Map.Entry<String, MysqlGTIDSet> entry : cases.entrySet()) {
+            MysqlGTIDSet expected = entry.getValue();
+            MysqlGTIDSet actual = MysqlGTIDSet.parse(entry.getKey());
+
+            assertEquals(expected, actual);
+        }
+    }
+
+    private static class Material {
+
+        public Material(String uuid, long start, long stop) {
+            this.uuid = uuid;
+            this.start = start;
+            this.stop = stop;
+            this.start1 = 0;
+            this.stop1 = 0;
+        }
+
+        public Material(String uuid, long start, long stop, long start1, long stop1) {
+            this.uuid = uuid;
+            this.start = start;
+            this.stop = stop;
+            this.start1 = start1;
+            this.stop1 = stop1;
+        }
+
+        public String uuid;
+        public long start;
+        public long stop;
+        public long start1;
+        public long stop1;
+    }
+
+    private MysqlGTIDSet buildForTest(Material material) {
+        return buildForTest(Arrays.asList(material));
+    }
+
+    private MysqlGTIDSet buildForTest(List<Material> materials) {
+        Map<String, UUIDSet> sets = new HashMap<String, UUIDSet>();
+        for (Material a : materials) {
+            UUIDSet.Interval interval = new UUIDSet.Interval();
+            interval.start = a.start;
+            interval.stop = a.stop;
+            List<UUIDSet.Interval> intervals = new ArrayList<UUIDSet.Interval>();
+            intervals.add(interval);
+
+            if (a.start1 > 0 && a.stop1 > 0) {
+                UUIDSet.Interval interval1 = new UUIDSet.Interval();
+                interval1.start = a.start1;
+                interval1.stop = a.stop1;
+                intervals.add(interval1);
+            }
+
+            UUIDSet us = new UUIDSet();
+            us.SID = UUID.fromString(a.uuid);
+            us.intervals = intervals;
+
+            sets.put(a.uuid, us);
+        }
+
+        MysqlGTIDSet gs = new MysqlGTIDSet();
+        gs.sets = sets;
+
+        return gs;
+    }
+}

--- a/driver/src/test/java/com/alibaba/otter/canal/parse/driver/mysql/UUIDSetTest.java
+++ b/driver/src/test/java/com/alibaba/otter/canal/parse/driver/mysql/UUIDSetTest.java
@@ -1,0 +1,30 @@
+package com.alibaba.otter.canal.parse.driver.mysql;
+
+import com.alibaba.otter.canal.parse.driver.mysql.packets.UUIDSet;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by hiwjd on 2018/4/26.
+ * hiwjd0@gmail.com
+ */
+public class UUIDSetTest {
+
+    @Test
+    public void testToString() {
+        Map<String, String> cases = new HashMap<String, String>(4);
+        cases.put("726757ad-4455-11e8-ae04-0242ac110002:1", "726757ad-4455-11e8-ae04-0242ac110002:1");
+        cases.put("726757ad-4455-11e8-ae04-0242ac110002:1-3", "726757ad-4455-11e8-ae04-0242ac110002:1-3");
+        cases.put("726757ad-4455-11e8-ae04-0242ac110002:1-3:4-6", "726757ad-4455-11e8-ae04-0242ac110002:1-6");
+        cases.put("726757ad-4455-11e8-ae04-0242ac110002:1-3:5-7", "726757ad-4455-11e8-ae04-0242ac110002:1-3:5-7");
+
+        for (Map.Entry<String, String> entry : cases.entrySet()) {
+            String expected = entry.getValue();
+            assertEquals(expected, UUIDSet.parse(entry.getKey()).toString());
+        }
+    }
+}

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/ErosaConnection.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/ErosaConnection.java
@@ -1,5 +1,7 @@
 package com.alibaba.otter.canal.parse.inbound;
 
+import com.alibaba.otter.canal.parse.driver.mysql.packets.GTIDSet;
+
 import java.io.IOException;
 
 /**
@@ -23,6 +25,15 @@ public interface ErosaConnection {
     public void dump(String binlogfilename, Long binlogPosition, SinkFunction func) throws IOException;
 
     public void dump(long timestamp, SinkFunction func) throws IOException;
+
+    /**
+     * 通过GTID同步binlog
+     *
+     * @param gtidSet
+     * @param func
+     * @throws IOException
+     */
+    public void dump(GTIDSet gtidSet, SinkFunction func) throws IOException;
 
     ErosaConnection fork();
 }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/LocalBinLogConnection.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/LocalBinLogConnection.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import com.alibaba.otter.canal.parse.driver.mysql.packets.GTIDSet;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,6 +200,11 @@ public class LocalBinLogConnection implements ErosaConnection {
         }
 
         dump(binlogFilename, binlogFileOffset, func);
+    }
+
+    @Override
+    public void dump(GTIDSet gtidSet, SinkFunction func) throws IOException {
+        throw new NotImplementedException();
     }
 
     public ErosaConnection fork() {

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/MysqlEventParser.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/MysqlEventParser.java
@@ -10,6 +10,10 @@ import java.util.Map;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.alibaba.otter.canal.filter.aviater.AviaterRegexFilter;
+import com.alibaba.otter.canal.parse.driver.mysql.packets.MysqlGTIDSet;
+import com.alibaba.otter.canal.parse.inbound.BinlogParser;
+import com.alibaba.otter.canal.parse.inbound.mysql.dbsync.LogEventConvertGTID;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.util.CollectionUtils;
 
@@ -344,6 +348,14 @@ public class MysqlEventParser extends AbstractMysqlEventParser implements CanalE
     }
 
     protected EntryPosition findStartPosition(ErosaConnection connection) throws IOException {
+        if (isGTIDMode()) {
+            // GTID模式下，CanalLogPositionManager里取最后的gtid，没有则取instanc配置中的
+            LogPosition logPosition = getLogPositionManager().getLatestIndexBy(destination);
+            if (logPosition != null) {
+                return logPosition.getPostion();
+            }
+            return masterPosition;
+        }
         EntryPosition startPosition = findStartPositionInternal(connection);
         if (needTransactionPosition.get()) {
             logger.warn("prepare to find last position : {}", startPosition.toString());

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvert.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvert.java
@@ -56,6 +56,7 @@ import com.taobao.tddl.dbsync.binlog.event.UserVarLogEvent;
 import com.taobao.tddl.dbsync.binlog.event.WriteRowsLogEvent;
 import com.taobao.tddl.dbsync.binlog.event.XidLogEvent;
 import com.taobao.tddl.dbsync.binlog.event.mariadb.AnnotateRowsEvent;
+import com.taobao.tddl.dbsync.binlog.event.GtidLogEvent;
 
 /**
  * 基于{@linkplain LogEvent}转化为Entry对象的处理
@@ -128,6 +129,8 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
                 return parseIntrvarLogEvent((IntvarLogEvent) logEvent);
             case LogEvent.RAND_EVENT:
                 return parseRandLogEvent((RandLogEvent) logEvent);
+            case LogEvent.GTID_LOG_EVENT:
+                return parseGTIDLogEvent((GtidLogEvent) logEvent);
             default:
                 break;
         }
@@ -141,6 +144,15 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
         if (tableMetaCache != null) {
             tableMetaCache.clearTableMeta();
         }
+    }
+
+    private Entry parseGTIDLogEvent(GtidLogEvent logEvent) {
+        LogHeader logHeader = logEvent.getHeader();
+        Header header = createHeader("", logHeader, "", "", EventType.GTID);
+        Pair.Builder builder = Pair.newBuilder();
+        builder.setKey("gtid");
+        builder.setValue(String.format("%s:%d", logEvent.getSid(), logEvent.getGno()));
+        return createEntry(header, EntryType.GTIDLOG, builder.build().toByteString());
     }
 
     private Entry parseQueryEvent(QueryLogEvent event, boolean isSeek) {

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvertGTID.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvertGTID.java
@@ -1,0 +1,55 @@
+package com.alibaba.otter.canal.parse.inbound.mysql.dbsync;
+
+import com.alibaba.otter.canal.parse.driver.mysql.packets.GTIDSet;
+import com.alibaba.otter.canal.parse.exception.CanalParseException;
+import com.alibaba.otter.canal.parse.inbound.BinlogParser;
+import com.alibaba.otter.canal.protocol.CanalEntry;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.taobao.tddl.dbsync.binlog.LogEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by hiwjd on 2018/5/2.
+ * hiwjd0@gmail.com
+ */
+public class LogEventConvertGTID extends LogEventConvert implements BinlogParser<LogEvent> {
+
+    public static final Logger logger = LoggerFactory.getLogger(LogEventConvertGTID.class);
+
+    // latest gtid
+    private GTIDSet gtidSet;
+
+    public LogEventConvertGTID(GTIDSet gtidSet) {
+        this.gtidSet = gtidSet;
+    }
+
+    @Override
+    public CanalEntry.Entry parse(LogEvent event, boolean isSeek) throws CanalParseException {
+        CanalEntry.Entry entry = super.parse(event, isSeek);
+        if (entry == null) {
+            return null;
+        }
+
+        if (entry.getEntryType() == CanalEntry.EntryType.GTIDLOG) {
+            try {
+                CanalEntry.Pair pair = CanalEntry.Pair.parseFrom(entry.getStoreValue());
+                gtidSet.update(pair.getValue());
+
+            } catch (InvalidProtocolBufferException e) {
+                logger.error("retrive gtid failed.", e);
+                throw new CanalParseException("retrive gtid failed.", e);
+            }
+
+            return null;
+        }
+
+        if (gtidSet != null) {
+            String gtid = gtidSet.toString();
+            CanalEntry.Header header = entry.getHeader().toBuilder().setGtid(gtid).build();
+            entry = entry.toBuilder().setHeader(header).build();
+        }
+
+        return entry;
+    }
+}

--- a/protocol/src/main/java/com/alibaba/otter/canal/protocol/CanalEntry.java
+++ b/protocol/src/main/java/com/alibaba/otter/canal/protocol/CanalEntry.java
@@ -4,12778 +4,12801 @@
 package com.alibaba.otter.canal.protocol;
 
 public final class CanalEntry {
-
-    private CanalEntry(){
-    }
-
-    public static void registerAllExtensions(com.google.protobuf.ExtensionRegistry registry) {
-    }
-
+  private CanalEntry() {}
+  public static void registerAllExtensions(
+      com.google.protobuf.ExtensionRegistry registry) {
+  }
+  /**
+   * Protobuf enum {@code com.alibaba.otter.canal.protocol.EntryType}
+   *
+   * <pre>
+   **打散后的事件类型，主要用于标识事务的开始，变更数据，结束*
+   * </pre>
+   */
+  public enum EntryType
+      implements com.google.protobuf.ProtocolMessageEnum {
     /**
-     * Protobuf enum {@code com.alibaba.otter.canal.protocol.EntryType}
+     * <code>TRANSACTIONBEGIN = 1;</code>
+     */
+    TRANSACTIONBEGIN(0, 1),
+    /**
+     * <code>ROWDATA = 2;</code>
+     */
+    ROWDATA(1, 2),
+    /**
+     * <code>TRANSACTIONEND = 3;</code>
+     */
+    TRANSACTIONEND(2, 3),
+    /**
+     * <code>HEARTBEAT = 4;</code>
      *
      * <pre>
-     * *打散后的事件类型，主要用于标识事务的开始，变更数据，结束*
+     ** 心跳类型，内部使用，外部暂不可见，可忽略 *
      * </pre>
      */
-    public enum EntryType implements com.google.protobuf.ProtocolMessageEnum {
-        /**
-         * <code>TRANSACTIONBEGIN = 1;</code>
-         */
-        TRANSACTIONBEGIN(0, 1),
-        /**
-         * <code>ROWDATA = 2;</code>
-         */
-        ROWDATA(1, 2),
-        /**
-         * <code>TRANSACTIONEND = 3;</code>
-         */
-        TRANSACTIONEND(2, 3),
-        /**
-         * <code>HEARTBEAT = 4;</code>
-         *
-         * <pre>
-         * * 心跳类型，内部使用，外部暂不可见，可忽略 *
-         * </pre>
-         */
-        HEARTBEAT(3, 4), ;
-
-        /**
-         * <code>TRANSACTIONBEGIN = 1;</code>
-         */
-        public static final int TRANSACTIONBEGIN_VALUE = 1;
-        /**
-         * <code>ROWDATA = 2;</code>
-         */
-        public static final int ROWDATA_VALUE          = 2;
-        /**
-         * <code>TRANSACTIONEND = 3;</code>
-         */
-        public static final int TRANSACTIONEND_VALUE   = 3;
-        /**
-         * <code>HEARTBEAT = 4;</code>
-         *
-         * <pre>
-         * * 心跳类型，内部使用，外部暂不可见，可忽略 *
-         * </pre>
-         */
-        public static final int HEARTBEAT_VALUE        = 4;
-
-        public final int getNumber() {
-            return value;
-        }
-
-        public static EntryType valueOf(int value) {
-            switch (value) {
-                case 1:
-                    return TRANSACTIONBEGIN;
-                case 2:
-                    return ROWDATA;
-                case 3:
-                    return TRANSACTIONEND;
-                case 4:
-                    return HEARTBEAT;
-                default:
-                    return null;
-            }
-        }
-
-        public static com.google.protobuf.Internal.EnumLiteMap<EntryType> internalGetValueMap() {
-            return internalValueMap;
-        }
-
-        private static com.google.protobuf.Internal.EnumLiteMap<EntryType> internalValueMap = new com.google.protobuf.Internal.EnumLiteMap<EntryType>() {
-
-                                                                                                public EntryType findValueByNumber(int number) {
-                                                                                                    return EntryType.valueOf(number);
-                                                                                                }
-                                                                                            };
-
-        public final com.google.protobuf.Descriptors.EnumValueDescriptor getValueDescriptor() {
-            return getDescriptor().getValues().get(index);
-        }
-
-        public final com.google.protobuf.Descriptors.EnumDescriptor getDescriptorForType() {
-            return getDescriptor();
-        }
-
-        public static final com.google.protobuf.Descriptors.EnumDescriptor getDescriptor() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.getDescriptor().getEnumTypes().get(0);
-        }
-
-        private static final EntryType[] VALUES = values();
-
-        public static EntryType valueOf(com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-            if (desc.getType() != getDescriptor()) {
-                throw new java.lang.IllegalArgumentException("EnumValueDescriptor is not for this type.");
-            }
-            return VALUES[desc.getIndex()];
-        }
-
-        private final int index;
-        private final int value;
-
-        private EntryType(int index, int value){
-            this.index = index;
-            this.value = value;
-        }
-
-        // @@protoc_insertion_point(enum_scope:com.alibaba.otter.canal.protocol.EntryType)
-    }
+    HEARTBEAT(3, 4),
+    /**
+     * <code>GTIDLOG = 5;</code>
+     */
+    GTIDLOG(4, 5),
+    ;
 
     /**
-     * Protobuf enum {@code com.alibaba.otter.canal.protocol.EventType}
+     * <code>TRANSACTIONBEGIN = 1;</code>
+     */
+    public static final int TRANSACTIONBEGIN_VALUE = 1;
+    /**
+     * <code>ROWDATA = 2;</code>
+     */
+    public static final int ROWDATA_VALUE = 2;
+    /**
+     * <code>TRANSACTIONEND = 3;</code>
+     */
+    public static final int TRANSACTIONEND_VALUE = 3;
+    /**
+     * <code>HEARTBEAT = 4;</code>
      *
      * <pre>
-     * * 事件类型 *
+     ** 心跳类型，内部使用，外部暂不可见，可忽略 *
      * </pre>
      */
-    public enum EventType implements com.google.protobuf.ProtocolMessageEnum {
-        /**
-         * <code>INSERT = 1;</code>
-         */
-        INSERT(0, 1),
-        /**
-         * <code>UPDATE = 2;</code>
-         */
-        UPDATE(1, 2),
-        /**
-         * <code>DELETE = 3;</code>
-         */
-        DELETE(2, 3),
-        /**
-         * <code>CREATE = 4;</code>
-         */
-        CREATE(3, 4),
-        /**
-         * <code>ALTER = 5;</code>
-         */
-        ALTER(4, 5),
-        /**
-         * <code>ERASE = 6;</code>
-         */
-        ERASE(5, 6),
-        /**
-         * <code>QUERY = 7;</code>
-         */
-        QUERY(6, 7),
-        /**
-         * <code>TRUNCATE = 8;</code>
-         */
-        TRUNCATE(7, 8),
-        /**
-         * <code>RENAME = 9;</code>
-         */
-        RENAME(8, 9),
-        /**
-         * <code>CINDEX = 10;</code>
-         *
-         * <pre>
-         * *CREATE INDEX*
-         * </pre>
-         */
-        CINDEX(9, 10),
-        /**
-         * <code>DINDEX = 11;</code>
-         */
-        DINDEX(10, 11), ;
+    public static final int HEARTBEAT_VALUE = 4;
+    /**
+     * <code>GTIDLOG = 5;</code>
+     */
+    public static final int GTIDLOG_VALUE = 5;
 
-        /**
-         * <code>INSERT = 1;</code>
-         */
-        public static final int INSERT_VALUE   = 1;
-        /**
-         * <code>UPDATE = 2;</code>
-         */
-        public static final int UPDATE_VALUE   = 2;
-        /**
-         * <code>DELETE = 3;</code>
-         */
-        public static final int DELETE_VALUE   = 3;
-        /**
-         * <code>CREATE = 4;</code>
-         */
-        public static final int CREATE_VALUE   = 4;
-        /**
-         * <code>ALTER = 5;</code>
-         */
-        public static final int ALTER_VALUE    = 5;
-        /**
-         * <code>ERASE = 6;</code>
-         */
-        public static final int ERASE_VALUE    = 6;
-        /**
-         * <code>QUERY = 7;</code>
-         */
-        public static final int QUERY_VALUE    = 7;
-        /**
-         * <code>TRUNCATE = 8;</code>
-         */
-        public static final int TRUNCATE_VALUE = 8;
-        /**
-         * <code>RENAME = 9;</code>
-         */
-        public static final int RENAME_VALUE   = 9;
-        /**
-         * <code>CINDEX = 10;</code>
-         *
-         * <pre>
-         * *CREATE INDEX*
-         * </pre>
-         */
-        public static final int CINDEX_VALUE   = 10;
-        /**
-         * <code>DINDEX = 11;</code>
-         */
-        public static final int DINDEX_VALUE   = 11;
 
-        public final int getNumber() {
-            return value;
-        }
+    public final int getNumber() { return value; }
 
-        public static EventType valueOf(int value) {
-            switch (value) {
-                case 1:
-                    return INSERT;
-                case 2:
-                    return UPDATE;
-                case 3:
-                    return DELETE;
-                case 4:
-                    return CREATE;
-                case 5:
-                    return ALTER;
-                case 6:
-                    return ERASE;
-                case 7:
-                    return QUERY;
-                case 8:
-                    return TRUNCATE;
-                case 9:
-                    return RENAME;
-                case 10:
-                    return CINDEX;
-                case 11:
-                    return DINDEX;
-                default:
-                    return null;
-            }
-        }
-
-        public static com.google.protobuf.Internal.EnumLiteMap<EventType> internalGetValueMap() {
-            return internalValueMap;
-        }
-
-        private static com.google.protobuf.Internal.EnumLiteMap<EventType> internalValueMap = new com.google.protobuf.Internal.EnumLiteMap<EventType>() {
-
-                                                                                                public EventType findValueByNumber(int number) {
-                                                                                                    return EventType.valueOf(number);
-                                                                                                }
-                                                                                            };
-
-        public final com.google.protobuf.Descriptors.EnumValueDescriptor getValueDescriptor() {
-            return getDescriptor().getValues().get(index);
-        }
-
-        public final com.google.protobuf.Descriptors.EnumDescriptor getDescriptorForType() {
-            return getDescriptor();
-        }
-
-        public static final com.google.protobuf.Descriptors.EnumDescriptor getDescriptor() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.getDescriptor().getEnumTypes().get(1);
-        }
-
-        private static final EventType[] VALUES = values();
-
-        public static EventType valueOf(com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-            if (desc.getType() != getDescriptor()) {
-                throw new java.lang.IllegalArgumentException("EnumValueDescriptor is not for this type.");
-            }
-            return VALUES[desc.getIndex()];
-        }
-
-        private final int index;
-        private final int value;
-
-        private EventType(int index, int value){
-            this.index = index;
-            this.value = value;
-        }
-
-        // @@protoc_insertion_point(enum_scope:com.alibaba.otter.canal.protocol.EventType)
+    public static EntryType valueOf(int value) {
+      switch (value) {
+        case 1: return TRANSACTIONBEGIN;
+        case 2: return ROWDATA;
+        case 3: return TRANSACTIONEND;
+        case 4: return HEARTBEAT;
+        case 5: return GTIDLOG;
+        default: return null;
+      }
     }
+
+    public static com.google.protobuf.Internal.EnumLiteMap<EntryType>
+        internalGetValueMap() {
+      return internalValueMap;
+    }
+    private static com.google.protobuf.Internal.EnumLiteMap<EntryType>
+        internalValueMap =
+          new com.google.protobuf.Internal.EnumLiteMap<EntryType>() {
+            public EntryType findValueByNumber(int number) {
+              return EntryType.valueOf(number);
+            }
+          };
+
+    public final com.google.protobuf.Descriptors.EnumValueDescriptor
+        getValueDescriptor() {
+      return getDescriptor().getValues().get(index);
+    }
+    public final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptorForType() {
+      return getDescriptor();
+    }
+    public static final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptor() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.getDescriptor().getEnumTypes().get(0);
+    }
+
+    private static final EntryType[] VALUES = values();
+
+    public static EntryType valueOf(
+        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+      if (desc.getType() != getDescriptor()) {
+        throw new java.lang.IllegalArgumentException(
+          "EnumValueDescriptor is not for this type.");
+      }
+      return VALUES[desc.getIndex()];
+    }
+
+    private final int index;
+    private final int value;
+
+    private EntryType(int index, int value) {
+      this.index = index;
+      this.value = value;
+    }
+
+    // @@protoc_insertion_point(enum_scope:com.alibaba.otter.canal.protocol.EntryType)
+  }
+
+  /**
+   * Protobuf enum {@code com.alibaba.otter.canal.protocol.EventType}
+   *
+   * <pre>
+   ** 事件类型 *
+   * </pre>
+   */
+  public enum EventType
+      implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>INSERT = 1;</code>
+     */
+    INSERT(0, 1),
+    /**
+     * <code>UPDATE = 2;</code>
+     */
+    UPDATE(1, 2),
+    /**
+     * <code>DELETE = 3;</code>
+     */
+    DELETE(2, 3),
+    /**
+     * <code>CREATE = 4;</code>
+     */
+    CREATE(3, 4),
+    /**
+     * <code>ALTER = 5;</code>
+     */
+    ALTER(4, 5),
+    /**
+     * <code>ERASE = 6;</code>
+     */
+    ERASE(5, 6),
+    /**
+     * <code>QUERY = 7;</code>
+     */
+    QUERY(6, 7),
+    /**
+     * <code>TRUNCATE = 8;</code>
+     */
+    TRUNCATE(7, 8),
+    /**
+     * <code>RENAME = 9;</code>
+     */
+    RENAME(8, 9),
+    /**
+     * <code>CINDEX = 10;</code>
+     *
+     * <pre>
+     **CREATE INDEX*
+     * </pre>
+     */
+    CINDEX(9, 10),
+    /**
+     * <code>DINDEX = 11;</code>
+     */
+    DINDEX(10, 11),
+    /**
+     * <code>GTID = 12;</code>
+     */
+    GTID(11, 12),
+    ;
 
     /**
-     * Protobuf enum {@code com.alibaba.otter.canal.protocol.Type}
+     * <code>INSERT = 1;</code>
+     */
+    public static final int INSERT_VALUE = 1;
+    /**
+     * <code>UPDATE = 2;</code>
+     */
+    public static final int UPDATE_VALUE = 2;
+    /**
+     * <code>DELETE = 3;</code>
+     */
+    public static final int DELETE_VALUE = 3;
+    /**
+     * <code>CREATE = 4;</code>
+     */
+    public static final int CREATE_VALUE = 4;
+    /**
+     * <code>ALTER = 5;</code>
+     */
+    public static final int ALTER_VALUE = 5;
+    /**
+     * <code>ERASE = 6;</code>
+     */
+    public static final int ERASE_VALUE = 6;
+    /**
+     * <code>QUERY = 7;</code>
+     */
+    public static final int QUERY_VALUE = 7;
+    /**
+     * <code>TRUNCATE = 8;</code>
+     */
+    public static final int TRUNCATE_VALUE = 8;
+    /**
+     * <code>RENAME = 9;</code>
+     */
+    public static final int RENAME_VALUE = 9;
+    /**
+     * <code>CINDEX = 10;</code>
      *
      * <pre>
-     * *数据库类型*
+     **CREATE INDEX*
      * </pre>
      */
-    public enum Type implements com.google.protobuf.ProtocolMessageEnum {
-        /**
-         * <code>ORACLE = 1;</code>
-         */
-        ORACLE(0, 1),
-        /**
-         * <code>MYSQL = 2;</code>
-         */
-        MYSQL(1, 2),
-        /**
-         * <code>PGSQL = 3;</code>
-         */
-        PGSQL(2, 3), ;
+    public static final int CINDEX_VALUE = 10;
+    /**
+     * <code>DINDEX = 11;</code>
+     */
+    public static final int DINDEX_VALUE = 11;
+    /**
+     * <code>GTID = 12;</code>
+     */
+    public static final int GTID_VALUE = 12;
 
-        /**
-         * <code>ORACLE = 1;</code>
-         */
-        public static final int ORACLE_VALUE = 1;
-        /**
-         * <code>MYSQL = 2;</code>
-         */
-        public static final int MYSQL_VALUE  = 2;
-        /**
-         * <code>PGSQL = 3;</code>
-         */
-        public static final int PGSQL_VALUE  = 3;
 
-        public final int getNumber() {
-            return value;
-        }
+    public final int getNumber() { return value; }
 
-        public static Type valueOf(int value) {
-            switch (value) {
-                case 1:
-                    return ORACLE;
-                case 2:
-                    return MYSQL;
-                case 3:
-                    return PGSQL;
-                default:
-                    return null;
-            }
-        }
-
-        public static com.google.protobuf.Internal.EnumLiteMap<Type> internalGetValueMap() {
-            return internalValueMap;
-        }
-
-        private static com.google.protobuf.Internal.EnumLiteMap<Type> internalValueMap = new com.google.protobuf.Internal.EnumLiteMap<Type>() {
-
-                                                                                           public Type findValueByNumber(int number) {
-                                                                                               return Type.valueOf(number);
-                                                                                           }
-                                                                                       };
-
-        public final com.google.protobuf.Descriptors.EnumValueDescriptor getValueDescriptor() {
-            return getDescriptor().getValues().get(index);
-        }
-
-        public final com.google.protobuf.Descriptors.EnumDescriptor getDescriptorForType() {
-            return getDescriptor();
-        }
-
-        public static final com.google.protobuf.Descriptors.EnumDescriptor getDescriptor() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.getDescriptor().getEnumTypes().get(2);
-        }
-
-        private static final Type[] VALUES = values();
-
-        public static Type valueOf(com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-            if (desc.getType() != getDescriptor()) {
-                throw new java.lang.IllegalArgumentException("EnumValueDescriptor is not for this type.");
-            }
-            return VALUES[desc.getIndex()];
-        }
-
-        private final int index;
-        private final int value;
-
-        private Type(int index, int value){
-            this.index = index;
-            this.value = value;
-        }
-
-        // @@protoc_insertion_point(enum_scope:com.alibaba.otter.canal.protocol.Type)
+    public static EventType valueOf(int value) {
+      switch (value) {
+        case 1: return INSERT;
+        case 2: return UPDATE;
+        case 3: return DELETE;
+        case 4: return CREATE;
+        case 5: return ALTER;
+        case 6: return ERASE;
+        case 7: return QUERY;
+        case 8: return TRUNCATE;
+        case 9: return RENAME;
+        case 10: return CINDEX;
+        case 11: return DINDEX;
+        case 12: return GTID;
+        default: return null;
+      }
     }
 
-    public interface EntryOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.Entry)
-    com.google.protobuf.MessageOrBuilder {
+    public static com.google.protobuf.Internal.EnumLiteMap<EventType>
+        internalGetValueMap() {
+      return internalValueMap;
+    }
+    private static com.google.protobuf.Internal.EnumLiteMap<EventType>
+        internalValueMap =
+          new com.google.protobuf.Internal.EnumLiteMap<EventType>() {
+            public EventType findValueByNumber(int number) {
+              return EventType.valueOf(number);
+            }
+          };
 
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-         *
-         * <pre>
-         * *协议头部信息*
-         * </pre>
-         */
-        boolean hasHeader();
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-         *
-         * <pre>
-         * *协议头部信息*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.Header getHeader();
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-         *
-         * <pre>
-         * *协议头部信息*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder getHeaderOrBuilder();
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
-         *
-         * <pre>
-         * *打散后的事件类型*
-         * </pre>
-         */
-        boolean hasEntryType();
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
-         *
-         * <pre>
-         * *打散后的事件类型*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.EntryType getEntryType();
-
-        /**
-         * <code>optional bytes storeValue = 3;</code>
-         *
-         * <pre>
-         * *传输的二进制数组*
-         * </pre>
-         */
-        boolean hasStoreValue();
-
-        /**
-         * <code>optional bytes storeValue = 3;</code>
-         *
-         * <pre>
-         * *传输的二进制数组*
-         * </pre>
-         */
-        com.google.protobuf.ByteString getStoreValue();
+    public final com.google.protobuf.Descriptors.EnumValueDescriptor
+        getValueDescriptor() {
+      return getDescriptor().getValues().get(index);
+    }
+    public final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptorForType() {
+      return getDescriptor();
+    }
+    public static final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptor() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.getDescriptor().getEnumTypes().get(1);
     }
 
+    private static final EventType[] VALUES = values();
+
+    public static EventType valueOf(
+        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+      if (desc.getType() != getDescriptor()) {
+        throw new java.lang.IllegalArgumentException(
+          "EnumValueDescriptor is not for this type.");
+      }
+      return VALUES[desc.getIndex()];
+    }
+
+    private final int index;
+    private final int value;
+
+    private EventType(int index, int value) {
+      this.index = index;
+      this.value = value;
+    }
+
+    // @@protoc_insertion_point(enum_scope:com.alibaba.otter.canal.protocol.EventType)
+  }
+
+  /**
+   * Protobuf enum {@code com.alibaba.otter.canal.protocol.Type}
+   *
+   * <pre>
+   **数据库类型*
+   * </pre>
+   */
+  public enum Type
+      implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>ORACLE = 1;</code>
+     */
+    ORACLE(0, 1),
+    /**
+     * <code>MYSQL = 2;</code>
+     */
+    MYSQL(1, 2),
+    /**
+     * <code>PGSQL = 3;</code>
+     */
+    PGSQL(2, 3),
+    ;
+
+    /**
+     * <code>ORACLE = 1;</code>
+     */
+    public static final int ORACLE_VALUE = 1;
+    /**
+     * <code>MYSQL = 2;</code>
+     */
+    public static final int MYSQL_VALUE = 2;
+    /**
+     * <code>PGSQL = 3;</code>
+     */
+    public static final int PGSQL_VALUE = 3;
+
+
+    public final int getNumber() { return value; }
+
+    public static Type valueOf(int value) {
+      switch (value) {
+        case 1: return ORACLE;
+        case 2: return MYSQL;
+        case 3: return PGSQL;
+        default: return null;
+      }
+    }
+
+    public static com.google.protobuf.Internal.EnumLiteMap<Type>
+        internalGetValueMap() {
+      return internalValueMap;
+    }
+    private static com.google.protobuf.Internal.EnumLiteMap<Type>
+        internalValueMap =
+          new com.google.protobuf.Internal.EnumLiteMap<Type>() {
+            public Type findValueByNumber(int number) {
+              return Type.valueOf(number);
+            }
+          };
+
+    public final com.google.protobuf.Descriptors.EnumValueDescriptor
+        getValueDescriptor() {
+      return getDescriptor().getValues().get(index);
+    }
+    public final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptorForType() {
+      return getDescriptor();
+    }
+    public static final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptor() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.getDescriptor().getEnumTypes().get(2);
+    }
+
+    private static final Type[] VALUES = values();
+
+    public static Type valueOf(
+        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+      if (desc.getType() != getDescriptor()) {
+        throw new java.lang.IllegalArgumentException(
+          "EnumValueDescriptor is not for this type.");
+      }
+      return VALUES[desc.getIndex()];
+    }
+
+    private final int index;
+    private final int value;
+
+    private Type(int index, int value) {
+      this.index = index;
+      this.value = value;
+    }
+
+    // @@protoc_insertion_point(enum_scope:com.alibaba.otter.canal.protocol.Type)
+  }
+
+  public interface EntryOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.Entry)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+     *
+     * <pre>
+     **协议头部信息*
+     * </pre>
+     */
+    boolean hasHeader();
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+     *
+     * <pre>
+     **协议头部信息*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.Header getHeader();
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+     *
+     * <pre>
+     **协议头部信息*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder getHeaderOrBuilder();
+
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
+     *
+     * <pre>
+     **打散后的事件类型*
+     * </pre>
+     */
+    boolean hasEntryType();
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
+     *
+     * <pre>
+     **打散后的事件类型*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.EntryType getEntryType();
+
+    /**
+     * <code>optional bytes storeValue = 3;</code>
+     *
+     * <pre>
+     **传输的二进制数组*
+     * </pre>
+     */
+    boolean hasStoreValue();
+    /**
+     * <code>optional bytes storeValue = 3;</code>
+     *
+     * <pre>
+     **传输的二进制数组*
+     * </pre>
+     */
+    com.google.protobuf.ByteString getStoreValue();
+  }
+  /**
+   * Protobuf type {@code com.alibaba.otter.canal.protocol.Entry}
+   *
+   * <pre>
+   ****************************************************************
+   * message model
+   *如果要在Enum中新增类型，确保以前的类型的下标值不变.
+   ***************************************************************
+   * </pre>
+   */
+  public static final class Entry extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.Entry)
+      EntryOrBuilder {
+    // Use Entry.newBuilder() to construct.
+    private Entry(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private Entry(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final Entry defaultInstance;
+    public static Entry getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public Entry getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private Entry(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                subBuilder = header_.toBuilder();
+              }
+              header_ = input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Header.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(header_);
+                header_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000001;
+              break;
+            }
+            case 16: {
+              int rawValue = input.readEnum();
+              com.alibaba.otter.canal.protocol.CanalEntry.EntryType value = com.alibaba.otter.canal.protocol.CanalEntry.EntryType.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(2, rawValue);
+              } else {
+                bitField0_ |= 0x00000002;
+                entryType_ = value;
+              }
+              break;
+            }
+            case 26: {
+              bitField0_ |= 0x00000004;
+              storeValue_ = input.readBytes();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Entry_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.alibaba.otter.canal.protocol.CanalEntry.Entry.class, com.alibaba.otter.canal.protocol.CanalEntry.Entry.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<Entry> PARSER =
+        new com.google.protobuf.AbstractParser<Entry>() {
+      public Entry parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new Entry(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<Entry> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int HEADER_FIELD_NUMBER = 1;
+    private com.alibaba.otter.canal.protocol.CanalEntry.Header header_;
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+     *
+     * <pre>
+     **协议头部信息*
+     * </pre>
+     */
+    public boolean hasHeader() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+     *
+     * <pre>
+     **协议头部信息*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.Header getHeader() {
+      return header_;
+    }
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+     *
+     * <pre>
+     **协议头部信息*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder getHeaderOrBuilder() {
+      return header_;
+    }
+
+    public static final int ENTRYTYPE_FIELD_NUMBER = 2;
+    private com.alibaba.otter.canal.protocol.CanalEntry.EntryType entryType_;
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
+     *
+     * <pre>
+     **打散后的事件类型*
+     * </pre>
+     */
+    public boolean hasEntryType() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
+     *
+     * <pre>
+     **打散后的事件类型*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.EntryType getEntryType() {
+      return entryType_;
+    }
+
+    public static final int STOREVALUE_FIELD_NUMBER = 3;
+    private com.google.protobuf.ByteString storeValue_;
+    /**
+     * <code>optional bytes storeValue = 3;</code>
+     *
+     * <pre>
+     **传输的二进制数组*
+     * </pre>
+     */
+    public boolean hasStoreValue() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional bytes storeValue = 3;</code>
+     *
+     * <pre>
+     **传输的二进制数组*
+     * </pre>
+     */
+    public com.google.protobuf.ByteString getStoreValue() {
+      return storeValue_;
+    }
+
+    private void initFields() {
+      header_ = com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance();
+      entryType_ = com.alibaba.otter.canal.protocol.CanalEntry.EntryType.ROWDATA;
+      storeValue_ = com.google.protobuf.ByteString.EMPTY;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeMessage(1, header_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeEnum(2, entryType_.getNumber());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeBytes(3, storeValue_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, header_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(2, entryType_.getNumber());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(3, storeValue_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Entry prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
     /**
      * Protobuf type {@code com.alibaba.otter.canal.protocol.Entry}
      *
      * <pre>
      ****************************************************************
-     *  message model
-     * 如果要在Enum中新增类型，确保以前的类型的下标值不变.
+     * message model
+     *如果要在Enum中新增类型，确保以前的类型的下标值不变.
      ***************************************************************
      * </pre>
      */
-    public static final class Entry extends com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.Entry)
-    EntryOrBuilder {
-
-        // Use Entry.newBuilder() to construct.
-        private Entry(com.google.protobuf.GeneratedMessage.Builder<?> builder){
-            super(builder);
-            this.unknownFields = builder.getUnknownFields();
-        }
-
-        private Entry(boolean noInit){
-            this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance();
-        }
-
-        private static final Entry defaultInstance;
-
-        public static Entry getDefaultInstance() {
-            return defaultInstance;
-        }
-
-        public Entry getDefaultInstanceForType() {
-            return defaultInstance;
-        }
-
-        private final com.google.protobuf.UnknownFieldSet unknownFields;
-
-        @java.lang.Override
-        public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
-            return this.unknownFields;
-        }
-
-        private Entry(com.google.protobuf.CodedInputStream input,
-                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                  throws com.google.protobuf.InvalidProtocolBufferException{
-            initFields();
-            int mutable_bitField0_ = 0;
-            com.google.protobuf.UnknownFieldSet.Builder unknownFields = com.google.protobuf.UnknownFieldSet.newBuilder();
-            try {
-                boolean done = false;
-                while (!done) {
-                    int tag = input.readTag();
-                    switch (tag) {
-                        case 0:
-                            done = true;
-                            break;
-                        default: {
-                            if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                                done = true;
-                            }
-                            break;
-                        }
-                        case 10: {
-                            com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder subBuilder = null;
-                            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                                subBuilder = header_.toBuilder();
-                            }
-                            header_ = input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Header.PARSER,
-                                extensionRegistry);
-                            if (subBuilder != null) {
-                                subBuilder.mergeFrom(header_);
-                                header_ = subBuilder.buildPartial();
-                            }
-                            bitField0_ |= 0x00000001;
-                            break;
-                        }
-                        case 16: {
-                            int rawValue = input.readEnum();
-                            com.alibaba.otter.canal.protocol.CanalEntry.EntryType value = com.alibaba.otter.canal.protocol.CanalEntry.EntryType.valueOf(rawValue);
-                            if (value == null) {
-                                unknownFields.mergeVarintField(2, rawValue);
-                            } else {
-                                bitField0_ |= 0x00000002;
-                                entryType_ = value;
-                            }
-                            break;
-                        }
-                        case 26: {
-                            bitField0_ |= 0x00000004;
-                            storeValue_ = input.readBytes();
-                            break;
-                        }
-                    }
-                }
-            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                throw e.setUnfinishedMessage(this);
-            } catch (java.io.IOException e) {
-                throw new com.google.protobuf.InvalidProtocolBufferException(e.getMessage()).setUnfinishedMessage(this);
-            } finally {
-                this.unknownFields = unknownFields.build();
-                makeExtensionsImmutable();
-            }
-        }
-
-        public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor;
-        }
-
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Entry_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.Entry.class,
-                com.alibaba.otter.canal.protocol.CanalEntry.Entry.Builder.class);
-        }
-
-        public static com.google.protobuf.Parser<Entry> PARSER = new com.google.protobuf.AbstractParser<Entry>() {
-
-                                                                   public Entry parsePartialFrom(com.google.protobuf.CodedInputStream input,
-                                                                                                 com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                             throws com.google.protobuf.InvalidProtocolBufferException {
-                                                                       return new Entry(input, extensionRegistry);
-                                                                   }
-                                                               };
-
-        @java.lang.Override
-        public com.google.protobuf.Parser<Entry> getParserForType() {
-            return PARSER;
-        }
-
-        private int                                                bitField0_;
-        public static final int                                    HEADER_FIELD_NUMBER = 1;
-        private com.alibaba.otter.canal.protocol.CanalEntry.Header header_;
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-         *
-         * <pre>
-         * *协议头部信息*
-         * </pre>
-         */
-        public boolean hasHeader() {
-            return ((bitField0_ & 0x00000001) == 0x00000001);
-        }
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-         *
-         * <pre>
-         * *协议头部信息*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.Header getHeader() {
-            return header_;
-        }
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-         *
-         * <pre>
-         * *协议头部信息*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder getHeaderOrBuilder() {
-            return header_;
-        }
-
-        public static final int                                       ENTRYTYPE_FIELD_NUMBER = 2;
-        private com.alibaba.otter.canal.protocol.CanalEntry.EntryType entryType_;
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
-         *
-         * <pre>
-         * *打散后的事件类型*
-         * </pre>
-         */
-        public boolean hasEntryType() {
-            return ((bitField0_ & 0x00000002) == 0x00000002);
-        }
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
-         *
-         * <pre>
-         * *打散后的事件类型*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.EntryType getEntryType() {
-            return entryType_;
-        }
-
-        public static final int                STOREVALUE_FIELD_NUMBER = 3;
-        private com.google.protobuf.ByteString storeValue_;
-
-        /**
-         * <code>optional bytes storeValue = 3;</code>
-         *
-         * <pre>
-         * *传输的二进制数组*
-         * </pre>
-         */
-        public boolean hasStoreValue() {
-            return ((bitField0_ & 0x00000004) == 0x00000004);
-        }
-
-        /**
-         * <code>optional bytes storeValue = 3;</code>
-         *
-         * <pre>
-         * *传输的二进制数组*
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getStoreValue() {
-            return storeValue_;
-        }
-
-        private void initFields() {
-            header_ = com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance();
-            entryType_ = com.alibaba.otter.canal.protocol.CanalEntry.EntryType.ROWDATA;
-            storeValue_ = com.google.protobuf.ByteString.EMPTY;
-        }
-
-        private byte memoizedIsInitialized = -1;
-
-        public final boolean isInitialized() {
-            byte isInitialized = memoizedIsInitialized;
-            if (isInitialized == 1) return true;
-            if (isInitialized == 0) return false;
-
-            memoizedIsInitialized = 1;
-            return true;
-        }
-
-        public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
-            getSerializedSize();
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                output.writeMessage(1, header_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                output.writeEnum(2, entryType_.getNumber());
-            }
-            if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                output.writeBytes(3, storeValue_);
-            }
-            getUnknownFields().writeTo(output);
-        }
-
-        private int memoizedSerializedSize = -1;
-
-        public int getSerializedSize() {
-            int size = memoizedSerializedSize;
-            if (size != -1) return size;
-
-            size = 0;
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, header_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                size += com.google.protobuf.CodedOutputStream.computeEnumSize(2, entryType_.getNumber());
-            }
-            if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(3, storeValue_);
-            }
-            size += getUnknownFields().getSerializedSize();
-            memoizedSerializedSize = size;
-            return size;
-        }
-
-        private static final long serialVersionUID = 0L;
-
-        @java.lang.Override
-        protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-            return super.writeReplace();
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(com.google.protobuf.ByteString data)
-                                                                                                                      throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(com.google.protobuf.ByteString data,
-                                                                                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                              throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(byte[] data)
-                                                                                              throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(byte[] data,
-                                                                                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                              throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(java.io.InputStream input)
-                                                                                                            throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(java.io.InputStream input,
-                                                                                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                              throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseDelimitedFrom(java.io.InputStream input)
-                                                                                                                     throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseDelimitedFrom(java.io.InputStream input,
-                                                                                           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                       throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(com.google.protobuf.CodedInputStream input)
-                                                                                                                             throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Entry parseFrom(com.google.protobuf.CodedInputStream input,
-                                                                                  com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                              throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static Builder newBuilder() {
-            return Builder.create();
-        }
-
-        public Builder newBuilderForType() {
-            return newBuilder();
-        }
-
-        public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Entry prototype) {
-            return newBuilder().mergeFrom(prototype);
-        }
-
-        public Builder toBuilder() {
-            return newBuilder(this);
-        }
-
-        @java.lang.Override
-        protected Builder newBuilderForType(com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-            Builder builder = new Builder(parent);
-            return builder;
-        }
-
-        /**
-         * Protobuf type {@code com.alibaba.otter.canal.protocol.Entry}
-         *
-         * <pre>
-         ****************************************************************
-         *  message model
-         * 如果要在Enum中新增类型，确保以前的类型的下标值不变.
-         ***************************************************************
-         * </pre>
-         */
-        public static final class Builder extends com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:com.alibaba.otter.canal.protocol.Entry)
         com.alibaba.otter.canal.protocol.CanalEntry.EntryOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor;
+      }
 
-            public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor;
-            }
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Entry_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.alibaba.otter.canal.protocol.CanalEntry.Entry.class, com.alibaba.otter.canal.protocol.CanalEntry.Entry.Builder.class);
+      }
 
-            protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Entry_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.Entry.class,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Entry.Builder.class);
-            }
+      // Construct using com.alibaba.otter.canal.protocol.CanalEntry.Entry.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
 
-            // Construct using
-            // com.alibaba.otter.canal.protocol.CanalEntry.Entry.newBuilder()
-            private Builder(){
-                maybeForceBuilderInitialization();
-            }
-
-            private Builder(com.google.protobuf.GeneratedMessage.BuilderParent parent){
-                super(parent);
-                maybeForceBuilderInitialization();
-            }
-
-            private void maybeForceBuilderInitialization() {
-                if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-                    getHeaderFieldBuilder();
-                }
-            }
-
-            private static Builder create() {
-                return new Builder();
-            }
-
-            public Builder clear() {
-                super.clear();
-                if (headerBuilder_ == null) {
-                    header_ = com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance();
-                } else {
-                    headerBuilder_.clear();
-                }
-                bitField0_ = (bitField0_ & ~0x00000001);
-                entryType_ = com.alibaba.otter.canal.protocol.CanalEntry.EntryType.ROWDATA;
-                bitField0_ = (bitField0_ & ~0x00000002);
-                storeValue_ = com.google.protobuf.ByteString.EMPTY;
-                bitField0_ = (bitField0_ & ~0x00000004);
-                return this;
-            }
-
-            public Builder clone() {
-                return create().mergeFrom(buildPartial());
-            }
-
-            public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Entry getDefaultInstanceForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.Entry.getDefaultInstance();
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Entry build() {
-                com.alibaba.otter.canal.protocol.CanalEntry.Entry result = buildPartial();
-                if (!result.isInitialized()) {
-                    throw newUninitializedMessageException(result);
-                }
-                return result;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Entry buildPartial() {
-                com.alibaba.otter.canal.protocol.CanalEntry.Entry result = new com.alibaba.otter.canal.protocol.CanalEntry.Entry(this);
-                int from_bitField0_ = bitField0_;
-                int to_bitField0_ = 0;
-                if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-                    to_bitField0_ |= 0x00000001;
-                }
-                if (headerBuilder_ == null) {
-                    result.header_ = header_;
-                } else {
-                    result.header_ = headerBuilder_.build();
-                }
-                if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-                    to_bitField0_ |= 0x00000002;
-                }
-                result.entryType_ = entryType_;
-                if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-                    to_bitField0_ |= 0x00000004;
-                }
-                result.storeValue_ = storeValue_;
-                result.bitField0_ = to_bitField0_;
-                onBuilt();
-                return result;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.Message other) {
-                if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.Entry) {
-                    return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.Entry) other);
-                } else {
-                    super.mergeFrom(other);
-                    return this;
-                }
-            }
-
-            public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.Entry other) {
-                if (other == com.alibaba.otter.canal.protocol.CanalEntry.Entry.getDefaultInstance()) return this;
-                if (other.hasHeader()) {
-                    mergeHeader(other.getHeader());
-                }
-                if (other.hasEntryType()) {
-                    setEntryType(other.getEntryType());
-                }
-                if (other.hasStoreValue()) {
-                    setStoreValue(other.getStoreValue());
-                }
-                this.mergeUnknownFields(other.getUnknownFields());
-                return this;
-            }
-
-            public final boolean isInitialized() {
-                return true;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
-                                     com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                 throws java.io.IOException {
-                com.alibaba.otter.canal.protocol.CanalEntry.Entry parsedMessage = null;
-                try {
-                    parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                    parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.Entry) e.getUnfinishedMessage();
-                    throw e;
-                } finally {
-                    if (parsedMessage != null) {
-                        mergeFrom(parsedMessage);
-                    }
-                }
-                return this;
-            }
-
-            private int                                                                                                                                                                                                                 bitField0_;
-
-            private com.alibaba.otter.canal.protocol.CanalEntry.Header                                                                                                                                                                  header_ = com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance();
-            private com.google.protobuf.SingleFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Header, com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder, com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder> headerBuilder_;
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-             *
-             * <pre>
-             * *协议头部信息*
-             * </pre>
-             */
-            public boolean hasHeader() {
-                return ((bitField0_ & 0x00000001) == 0x00000001);
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-             *
-             * <pre>
-             * *协议头部信息*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Header getHeader() {
-                if (headerBuilder_ == null) {
-                    return header_;
-                } else {
-                    return headerBuilder_.getMessage();
-                }
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-             *
-             * <pre>
-             * *协议头部信息*
-             * </pre>
-             */
-            public Builder setHeader(com.alibaba.otter.canal.protocol.CanalEntry.Header value) {
-                if (headerBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    header_ = value;
-                    onChanged();
-                } else {
-                    headerBuilder_.setMessage(value);
-                }
-                bitField0_ |= 0x00000001;
-                return this;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-             *
-             * <pre>
-             * *协议头部信息*
-             * </pre>
-             */
-            public Builder setHeader(com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder builderForValue) {
-                if (headerBuilder_ == null) {
-                    header_ = builderForValue.build();
-                    onChanged();
-                } else {
-                    headerBuilder_.setMessage(builderForValue.build());
-                }
-                bitField0_ |= 0x00000001;
-                return this;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-             *
-             * <pre>
-             * *协议头部信息*
-             * </pre>
-             */
-            public Builder mergeHeader(com.alibaba.otter.canal.protocol.CanalEntry.Header value) {
-                if (headerBuilder_ == null) {
-                    if (((bitField0_ & 0x00000001) == 0x00000001)
-                        && header_ != com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance()) {
-                        header_ = com.alibaba.otter.canal.protocol.CanalEntry.Header.newBuilder(header_)
-                            .mergeFrom(value)
-                            .buildPartial();
-                    } else {
-                        header_ = value;
-                    }
-                    onChanged();
-                } else {
-                    headerBuilder_.mergeFrom(value);
-                }
-                bitField0_ |= 0x00000001;
-                return this;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-             *
-             * <pre>
-             * *协议头部信息*
-             * </pre>
-             */
-            public Builder clearHeader() {
-                if (headerBuilder_ == null) {
-                    header_ = com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance();
-                    onChanged();
-                } else {
-                    headerBuilder_.clear();
-                }
-                bitField0_ = (bitField0_ & ~0x00000001);
-                return this;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-             *
-             * <pre>
-             * *协议头部信息*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder getHeaderBuilder() {
-                bitField0_ |= 0x00000001;
-                onChanged();
-                return getHeaderFieldBuilder().getBuilder();
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-             *
-             * <pre>
-             * *协议头部信息*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder getHeaderOrBuilder() {
-                if (headerBuilder_ != null) {
-                    return headerBuilder_.getMessageOrBuilder();
-                } else {
-                    return header_;
-                }
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
-             *
-             * <pre>
-             * *协议头部信息*
-             * </pre>
-             */
-            private com.google.protobuf.SingleFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Header, com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder, com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder> getHeaderFieldBuilder() {
-                if (headerBuilder_ == null) {
-                    headerBuilder_ = new com.google.protobuf.SingleFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Header, com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder, com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder>(getHeader(),
-                        getParentForChildren(),
-                        isClean());
-                    header_ = null;
-                }
-                return headerBuilder_;
-            }
-
-            private com.alibaba.otter.canal.protocol.CanalEntry.EntryType entryType_ = com.alibaba.otter.canal.protocol.CanalEntry.EntryType.ROWDATA;
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
-             *
-             * <pre>
-             * *打散后的事件类型*
-             * </pre>
-             */
-            public boolean hasEntryType() {
-                return ((bitField0_ & 0x00000002) == 0x00000002);
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
-             *
-             * <pre>
-             * *打散后的事件类型*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.EntryType getEntryType() {
-                return entryType_;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
-             *
-             * <pre>
-             * *打散后的事件类型*
-             * </pre>
-             */
-            public Builder setEntryType(com.alibaba.otter.canal.protocol.CanalEntry.EntryType value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000002;
-                entryType_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
-             *
-             * <pre>
-             * *打散后的事件类型*
-             * </pre>
-             */
-            public Builder clearEntryType() {
-                bitField0_ = (bitField0_ & ~0x00000002);
-                entryType_ = com.alibaba.otter.canal.protocol.CanalEntry.EntryType.ROWDATA;
-                onChanged();
-                return this;
-            }
-
-            private com.google.protobuf.ByteString storeValue_ = com.google.protobuf.ByteString.EMPTY;
-
-            /**
-             * <code>optional bytes storeValue = 3;</code>
-             *
-             * <pre>
-             * *传输的二进制数组*
-             * </pre>
-             */
-            public boolean hasStoreValue() {
-                return ((bitField0_ & 0x00000004) == 0x00000004);
-            }
-
-            /**
-             * <code>optional bytes storeValue = 3;</code>
-             *
-             * <pre>
-             * *传输的二进制数组*
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getStoreValue() {
-                return storeValue_;
-            }
-
-            /**
-             * <code>optional bytes storeValue = 3;</code>
-             *
-             * <pre>
-             * *传输的二进制数组*
-             * </pre>
-             */
-            public Builder setStoreValue(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000004;
-                storeValue_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional bytes storeValue = 3;</code>
-             *
-             * <pre>
-             * *传输的二进制数组*
-             * </pre>
-             */
-            public Builder clearStoreValue() {
-                bitField0_ = (bitField0_ & ~0x00000004);
-                storeValue_ = getDefaultInstance().getStoreValue();
-                onChanged();
-                return this;
-            }
-
-            // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.Entry)
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getHeaderFieldBuilder();
         }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
 
-        static {
-            defaultInstance = new Entry(true);
-            defaultInstance.initFields();
+      public Builder clear() {
+        super.clear();
+        if (headerBuilder_ == null) {
+          header_ = com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance();
+        } else {
+          headerBuilder_.clear();
         }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        entryType_ = com.alibaba.otter.canal.protocol.CanalEntry.EntryType.ROWDATA;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        storeValue_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
 
-        // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.Entry)
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.Entry getDefaultInstanceForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.Entry.getDefaultInstance();
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.Entry build() {
+        com.alibaba.otter.canal.protocol.CanalEntry.Entry result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.Entry buildPartial() {
+        com.alibaba.otter.canal.protocol.CanalEntry.Entry result = new com.alibaba.otter.canal.protocol.CanalEntry.Entry(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        if (headerBuilder_ == null) {
+          result.header_ = header_;
+        } else {
+          result.header_ = headerBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.entryType_ = entryType_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.storeValue_ = storeValue_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.Entry) {
+          return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.Entry)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.Entry other) {
+        if (other == com.alibaba.otter.canal.protocol.CanalEntry.Entry.getDefaultInstance()) return this;
+        if (other.hasHeader()) {
+          mergeHeader(other.getHeader());
+        }
+        if (other.hasEntryType()) {
+          setEntryType(other.getEntryType());
+        }
+        if (other.hasStoreValue()) {
+          setStoreValue(other.getStoreValue());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.alibaba.otter.canal.protocol.CanalEntry.Entry parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.Entry) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private com.alibaba.otter.canal.protocol.CanalEntry.Header header_ = com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance();
+      private com.google.protobuf.SingleFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Header, com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder, com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder> headerBuilder_;
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+       *
+       * <pre>
+       **协议头部信息*
+       * </pre>
+       */
+      public boolean hasHeader() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+       *
+       * <pre>
+       **协议头部信息*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Header getHeader() {
+        if (headerBuilder_ == null) {
+          return header_;
+        } else {
+          return headerBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+       *
+       * <pre>
+       **协议头部信息*
+       * </pre>
+       */
+      public Builder setHeader(com.alibaba.otter.canal.protocol.CanalEntry.Header value) {
+        if (headerBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          header_ = value;
+          onChanged();
+        } else {
+          headerBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+       *
+       * <pre>
+       **协议头部信息*
+       * </pre>
+       */
+      public Builder setHeader(
+          com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder builderForValue) {
+        if (headerBuilder_ == null) {
+          header_ = builderForValue.build();
+          onChanged();
+        } else {
+          headerBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+       *
+       * <pre>
+       **协议头部信息*
+       * </pre>
+       */
+      public Builder mergeHeader(com.alibaba.otter.canal.protocol.CanalEntry.Header value) {
+        if (headerBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+              header_ != com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance()) {
+            header_ =
+              com.alibaba.otter.canal.protocol.CanalEntry.Header.newBuilder(header_).mergeFrom(value).buildPartial();
+          } else {
+            header_ = value;
+          }
+          onChanged();
+        } else {
+          headerBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+       *
+       * <pre>
+       **协议头部信息*
+       * </pre>
+       */
+      public Builder clearHeader() {
+        if (headerBuilder_ == null) {
+          header_ = com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance();
+          onChanged();
+        } else {
+          headerBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+       *
+       * <pre>
+       **协议头部信息*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder getHeaderBuilder() {
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return getHeaderFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+       *
+       * <pre>
+       **协议头部信息*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder getHeaderOrBuilder() {
+        if (headerBuilder_ != null) {
+          return headerBuilder_.getMessageOrBuilder();
+        } else {
+          return header_;
+        }
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Header header = 1;</code>
+       *
+       * <pre>
+       **协议头部信息*
+       * </pre>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Header, com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder, com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder> 
+          getHeaderFieldBuilder() {
+        if (headerBuilder_ == null) {
+          headerBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              com.alibaba.otter.canal.protocol.CanalEntry.Header, com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder, com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder>(
+                  getHeader(),
+                  getParentForChildren(),
+                  isClean());
+          header_ = null;
+        }
+        return headerBuilder_;
+      }
+
+      private com.alibaba.otter.canal.protocol.CanalEntry.EntryType entryType_ = com.alibaba.otter.canal.protocol.CanalEntry.EntryType.ROWDATA;
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
+       *
+       * <pre>
+       **打散后的事件类型*
+       * </pre>
+       */
+      public boolean hasEntryType() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
+       *
+       * <pre>
+       **打散后的事件类型*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.EntryType getEntryType() {
+        return entryType_;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
+       *
+       * <pre>
+       **打散后的事件类型*
+       * </pre>
+       */
+      public Builder setEntryType(com.alibaba.otter.canal.protocol.CanalEntry.EntryType value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000002;
+        entryType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EntryType entryType = 2 [default = ROWDATA];</code>
+       *
+       * <pre>
+       **打散后的事件类型*
+       * </pre>
+       */
+      public Builder clearEntryType() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        entryType_ = com.alibaba.otter.canal.protocol.CanalEntry.EntryType.ROWDATA;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.ByteString storeValue_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>optional bytes storeValue = 3;</code>
+       *
+       * <pre>
+       **传输的二进制数组*
+       * </pre>
+       */
+      public boolean hasStoreValue() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional bytes storeValue = 3;</code>
+       *
+       * <pre>
+       **传输的二进制数组*
+       * </pre>
+       */
+      public com.google.protobuf.ByteString getStoreValue() {
+        return storeValue_;
+      }
+      /**
+       * <code>optional bytes storeValue = 3;</code>
+       *
+       * <pre>
+       **传输的二进制数组*
+       * </pre>
+       */
+      public Builder setStoreValue(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        storeValue_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bytes storeValue = 3;</code>
+       *
+       * <pre>
+       **传输的二进制数组*
+       * </pre>
+       */
+      public Builder clearStoreValue() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        storeValue_ = getDefaultInstance().getStoreValue();
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.Entry)
     }
 
-    public interface HeaderOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.Header)
-    com.google.protobuf.MessageOrBuilder {
-
-        /**
-         * <code>optional int32 version = 1 [default = 1];</code>
-         *
-         * <pre>
-         * *协议的版本号*
-         * </pre>
-         */
-        boolean hasVersion();
-
-        /**
-         * <code>optional int32 version = 1 [default = 1];</code>
-         *
-         * <pre>
-         * *协议的版本号*
-         * </pre>
-         */
-        int getVersion();
-
-        /**
-         * <code>optional string logfileName = 2;</code>
-         *
-         * <pre>
-         * *binlog/redolog 文件名*
-         * </pre>
-         */
-        boolean hasLogfileName();
-
-        /**
-         * <code>optional string logfileName = 2;</code>
-         *
-         * <pre>
-         * *binlog/redolog 文件名*
-         * </pre>
-         */
-        java.lang.String getLogfileName();
-
-        /**
-         * <code>optional string logfileName = 2;</code>
-         *
-         * <pre>
-         * *binlog/redolog 文件名*
-         * </pre>
-         */
-        com.google.protobuf.ByteString getLogfileNameBytes();
-
-        /**
-         * <code>optional int64 logfileOffset = 3;</code>
-         *
-         * <pre>
-         * *binlog/redolog 文件的偏移位置*
-         * </pre>
-         */
-        boolean hasLogfileOffset();
-
-        /**
-         * <code>optional int64 logfileOffset = 3;</code>
-         *
-         * <pre>
-         * *binlog/redolog 文件的偏移位置*
-         * </pre>
-         */
-        long getLogfileOffset();
-
-        /**
-         * <code>optional int64 serverId = 4;</code>
-         *
-         * <pre>
-         * *服务端serverId*
-         * </pre>
-         */
-        boolean hasServerId();
-
-        /**
-         * <code>optional int64 serverId = 4;</code>
-         *
-         * <pre>
-         * *服务端serverId*
-         * </pre>
-         */
-        long getServerId();
-
-        /**
-         * <code>optional string serverenCode = 5;</code>
-         *
-         * <pre>
-         * * 变更数据的编码 *
-         * </pre>
-         */
-        boolean hasServerenCode();
-
-        /**
-         * <code>optional string serverenCode = 5;</code>
-         *
-         * <pre>
-         * * 变更数据的编码 *
-         * </pre>
-         */
-        java.lang.String getServerenCode();
-
-        /**
-         * <code>optional string serverenCode = 5;</code>
-         *
-         * <pre>
-         * * 变更数据的编码 *
-         * </pre>
-         */
-        com.google.protobuf.ByteString getServerenCodeBytes();
-
-        /**
-         * <code>optional int64 executeTime = 6;</code>
-         *
-         * <pre>
-         * *变更数据的执行时间 *
-         * </pre>
-         */
-        boolean hasExecuteTime();
-
-        /**
-         * <code>optional int64 executeTime = 6;</code>
-         *
-         * <pre>
-         * *变更数据的执行时间 *
-         * </pre>
-         */
-        long getExecuteTime();
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
-         *
-         * <pre>
-         * * 变更数据的来源*
-         * </pre>
-         */
-        boolean hasSourceType();
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
-         *
-         * <pre>
-         * * 变更数据的来源*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.Type getSourceType();
-
-        /**
-         * <code>optional string schemaName = 8;</code>
-         *
-         * <pre>
-         * * 变更数据的schemaname*
-         * </pre>
-         */
-        boolean hasSchemaName();
-
-        /**
-         * <code>optional string schemaName = 8;</code>
-         *
-         * <pre>
-         * * 变更数据的schemaname*
-         * </pre>
-         */
-        java.lang.String getSchemaName();
-
-        /**
-         * <code>optional string schemaName = 8;</code>
-         *
-         * <pre>
-         * * 变更数据的schemaname*
-         * </pre>
-         */
-        com.google.protobuf.ByteString getSchemaNameBytes();
-
-        /**
-         * <code>optional string tableName = 9;</code>
-         *
-         * <pre>
-         * *变更数据的tablename*
-         * </pre>
-         */
-        boolean hasTableName();
-
-        /**
-         * <code>optional string tableName = 9;</code>
-         *
-         * <pre>
-         * *变更数据的tablename*
-         * </pre>
-         */
-        java.lang.String getTableName();
-
-        /**
-         * <code>optional string tableName = 9;</code>
-         *
-         * <pre>
-         * *变更数据的tablename*
-         * </pre>
-         */
-        com.google.protobuf.ByteString getTableNameBytes();
-
-        /**
-         * <code>optional int64 eventLength = 10;</code>
-         *
-         * <pre>
-         * *每个event的长度*
-         * </pre>
-         */
-        boolean hasEventLength();
-
-        /**
-         * <code>optional int64 eventLength = 10;</code>
-         *
-         * <pre>
-         * *每个event的长度*
-         * </pre>
-         */
-        long getEventLength();
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
-         *
-         * <pre>
-         * *数据变更类型*
-         * </pre>
-         */
-        boolean hasEventType();
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
-         *
-         * <pre>
-         * *数据变更类型*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        int getPropsCount();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index);
+    static {
+      defaultInstance = new Entry(true);
+      defaultInstance.initFields();
     }
 
+    // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.Entry)
+  }
+
+  public interface HeaderOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.Header)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int32 version = 1 [default = 1];</code>
+     *
+     * <pre>
+     **协议的版本号*
+     * </pre>
+     */
+    boolean hasVersion();
+    /**
+     * <code>optional int32 version = 1 [default = 1];</code>
+     *
+     * <pre>
+     **协议的版本号*
+     * </pre>
+     */
+    int getVersion();
+
+    /**
+     * <code>optional string logfileName = 2;</code>
+     *
+     * <pre>
+     **binlog/redolog 文件名*
+     * </pre>
+     */
+    boolean hasLogfileName();
+    /**
+     * <code>optional string logfileName = 2;</code>
+     *
+     * <pre>
+     **binlog/redolog 文件名*
+     * </pre>
+     */
+    java.lang.String getLogfileName();
+    /**
+     * <code>optional string logfileName = 2;</code>
+     *
+     * <pre>
+     **binlog/redolog 文件名*
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getLogfileNameBytes();
+
+    /**
+     * <code>optional int64 logfileOffset = 3;</code>
+     *
+     * <pre>
+     **binlog/redolog 文件的偏移位置*
+     * </pre>
+     */
+    boolean hasLogfileOffset();
+    /**
+     * <code>optional int64 logfileOffset = 3;</code>
+     *
+     * <pre>
+     **binlog/redolog 文件的偏移位置*
+     * </pre>
+     */
+    long getLogfileOffset();
+
+    /**
+     * <code>optional int64 serverId = 4;</code>
+     *
+     * <pre>
+     **服务端serverId*
+     * </pre>
+     */
+    boolean hasServerId();
+    /**
+     * <code>optional int64 serverId = 4;</code>
+     *
+     * <pre>
+     **服务端serverId*
+     * </pre>
+     */
+    long getServerId();
+
+    /**
+     * <code>optional string serverenCode = 5;</code>
+     *
+     * <pre>
+     ** 变更数据的编码 *
+     * </pre>
+     */
+    boolean hasServerenCode();
+    /**
+     * <code>optional string serverenCode = 5;</code>
+     *
+     * <pre>
+     ** 变更数据的编码 *
+     * </pre>
+     */
+    java.lang.String getServerenCode();
+    /**
+     * <code>optional string serverenCode = 5;</code>
+     *
+     * <pre>
+     ** 变更数据的编码 *
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getServerenCodeBytes();
+
+    /**
+     * <code>optional int64 executeTime = 6;</code>
+     *
+     * <pre>
+     **变更数据的执行时间 *
+     * </pre>
+     */
+    boolean hasExecuteTime();
+    /**
+     * <code>optional int64 executeTime = 6;</code>
+     *
+     * <pre>
+     **变更数据的执行时间 *
+     * </pre>
+     */
+    long getExecuteTime();
+
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
+     *
+     * <pre>
+     ** 变更数据的来源*
+     * </pre>
+     */
+    boolean hasSourceType();
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
+     *
+     * <pre>
+     ** 变更数据的来源*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.Type getSourceType();
+
+    /**
+     * <code>optional string schemaName = 8;</code>
+     *
+     * <pre>
+     ** 变更数据的schemaname*
+     * </pre>
+     */
+    boolean hasSchemaName();
+    /**
+     * <code>optional string schemaName = 8;</code>
+     *
+     * <pre>
+     ** 变更数据的schemaname*
+     * </pre>
+     */
+    java.lang.String getSchemaName();
+    /**
+     * <code>optional string schemaName = 8;</code>
+     *
+     * <pre>
+     ** 变更数据的schemaname*
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getSchemaNameBytes();
+
+    /**
+     * <code>optional string tableName = 9;</code>
+     *
+     * <pre>
+     **变更数据的tablename*
+     * </pre>
+     */
+    boolean hasTableName();
+    /**
+     * <code>optional string tableName = 9;</code>
+     *
+     * <pre>
+     **变更数据的tablename*
+     * </pre>
+     */
+    java.lang.String getTableName();
+    /**
+     * <code>optional string tableName = 9;</code>
+     *
+     * <pre>
+     **变更数据的tablename*
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getTableNameBytes();
+
+    /**
+     * <code>optional int64 eventLength = 10;</code>
+     *
+     * <pre>
+     **每个event的长度*
+     * </pre>
+     */
+    boolean hasEventLength();
+    /**
+     * <code>optional int64 eventLength = 10;</code>
+     *
+     * <pre>
+     **每个event的长度*
+     * </pre>
+     */
+    long getEventLength();
+
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
+     *
+     * <pre>
+     **数据变更类型*
+     * </pre>
+     */
+    boolean hasEventType();
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
+     *
+     * <pre>
+     **数据变更类型*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType();
+
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> 
+        getPropsList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    int getPropsCount();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index);
+
+    /**
+     * <code>optional string gtid = 13;</code>
+     *
+     * <pre>
+     **当前事务的gitd*
+     * </pre>
+     */
+    boolean hasGtid();
+    /**
+     * <code>optional string gtid = 13;</code>
+     *
+     * <pre>
+     **当前事务的gitd*
+     * </pre>
+     */
+    java.lang.String getGtid();
+    /**
+     * <code>optional string gtid = 13;</code>
+     *
+     * <pre>
+     **当前事务的gitd*
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getGtidBytes();
+  }
+  /**
+   * Protobuf type {@code com.alibaba.otter.canal.protocol.Header}
+   *
+   * <pre>
+   **message Header*
+   * </pre>
+   */
+  public static final class Header extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.Header)
+      HeaderOrBuilder {
+    // Use Header.newBuilder() to construct.
+    private Header(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private Header(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final Header defaultInstance;
+    public static Header getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public Header getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private Header(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              version_ = input.readInt32();
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              logfileName_ = bs;
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              logfileOffset_ = input.readInt64();
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000008;
+              serverId_ = input.readInt64();
+              break;
+            }
+            case 42: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000010;
+              serverenCode_ = bs;
+              break;
+            }
+            case 48: {
+              bitField0_ |= 0x00000020;
+              executeTime_ = input.readInt64();
+              break;
+            }
+            case 56: {
+              int rawValue = input.readEnum();
+              com.alibaba.otter.canal.protocol.CanalEntry.Type value = com.alibaba.otter.canal.protocol.CanalEntry.Type.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(7, rawValue);
+              } else {
+                bitField0_ |= 0x00000040;
+                sourceType_ = value;
+              }
+              break;
+            }
+            case 66: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000080;
+              schemaName_ = bs;
+              break;
+            }
+            case 74: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000100;
+              tableName_ = bs;
+              break;
+            }
+            case 80: {
+              bitField0_ |= 0x00000200;
+              eventLength_ = input.readInt64();
+              break;
+            }
+            case 88: {
+              int rawValue = input.readEnum();
+              com.alibaba.otter.canal.protocol.CanalEntry.EventType value = com.alibaba.otter.canal.protocol.CanalEntry.EventType.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(11, rawValue);
+              } else {
+                bitField0_ |= 0x00000400;
+                eventType_ = value;
+              }
+              break;
+            }
+            case 98: {
+              if (!((mutable_bitField0_ & 0x00000800) == 0x00000800)) {
+                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
+                mutable_bitField0_ |= 0x00000800;
+              }
+              props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER, extensionRegistry));
+              break;
+            }
+            case 106: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000800;
+              gtid_ = bs;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000800) == 0x00000800)) {
+          props_ = java.util.Collections.unmodifiableList(props_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Header_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Header_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.alibaba.otter.canal.protocol.CanalEntry.Header.class, com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<Header> PARSER =
+        new com.google.protobuf.AbstractParser<Header>() {
+      public Header parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new Header(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<Header> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int VERSION_FIELD_NUMBER = 1;
+    private int version_;
+    /**
+     * <code>optional int32 version = 1 [default = 1];</code>
+     *
+     * <pre>
+     **协议的版本号*
+     * </pre>
+     */
+    public boolean hasVersion() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional int32 version = 1 [default = 1];</code>
+     *
+     * <pre>
+     **协议的版本号*
+     * </pre>
+     */
+    public int getVersion() {
+      return version_;
+    }
+
+    public static final int LOGFILENAME_FIELD_NUMBER = 2;
+    private java.lang.Object logfileName_;
+    /**
+     * <code>optional string logfileName = 2;</code>
+     *
+     * <pre>
+     **binlog/redolog 文件名*
+     * </pre>
+     */
+    public boolean hasLogfileName() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional string logfileName = 2;</code>
+     *
+     * <pre>
+     **binlog/redolog 文件名*
+     * </pre>
+     */
+    public java.lang.String getLogfileName() {
+      java.lang.Object ref = logfileName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          logfileName_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string logfileName = 2;</code>
+     *
+     * <pre>
+     **binlog/redolog 文件名*
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getLogfileNameBytes() {
+      java.lang.Object ref = logfileName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        logfileName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int LOGFILEOFFSET_FIELD_NUMBER = 3;
+    private long logfileOffset_;
+    /**
+     * <code>optional int64 logfileOffset = 3;</code>
+     *
+     * <pre>
+     **binlog/redolog 文件的偏移位置*
+     * </pre>
+     */
+    public boolean hasLogfileOffset() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional int64 logfileOffset = 3;</code>
+     *
+     * <pre>
+     **binlog/redolog 文件的偏移位置*
+     * </pre>
+     */
+    public long getLogfileOffset() {
+      return logfileOffset_;
+    }
+
+    public static final int SERVERID_FIELD_NUMBER = 4;
+    private long serverId_;
+    /**
+     * <code>optional int64 serverId = 4;</code>
+     *
+     * <pre>
+     **服务端serverId*
+     * </pre>
+     */
+    public boolean hasServerId() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional int64 serverId = 4;</code>
+     *
+     * <pre>
+     **服务端serverId*
+     * </pre>
+     */
+    public long getServerId() {
+      return serverId_;
+    }
+
+    public static final int SERVERENCODE_FIELD_NUMBER = 5;
+    private java.lang.Object serverenCode_;
+    /**
+     * <code>optional string serverenCode = 5;</code>
+     *
+     * <pre>
+     ** 变更数据的编码 *
+     * </pre>
+     */
+    public boolean hasServerenCode() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional string serverenCode = 5;</code>
+     *
+     * <pre>
+     ** 变更数据的编码 *
+     * </pre>
+     */
+    public java.lang.String getServerenCode() {
+      java.lang.Object ref = serverenCode_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          serverenCode_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string serverenCode = 5;</code>
+     *
+     * <pre>
+     ** 变更数据的编码 *
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getServerenCodeBytes() {
+      java.lang.Object ref = serverenCode_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        serverenCode_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int EXECUTETIME_FIELD_NUMBER = 6;
+    private long executeTime_;
+    /**
+     * <code>optional int64 executeTime = 6;</code>
+     *
+     * <pre>
+     **变更数据的执行时间 *
+     * </pre>
+     */
+    public boolean hasExecuteTime() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>optional int64 executeTime = 6;</code>
+     *
+     * <pre>
+     **变更数据的执行时间 *
+     * </pre>
+     */
+    public long getExecuteTime() {
+      return executeTime_;
+    }
+
+    public static final int SOURCETYPE_FIELD_NUMBER = 7;
+    private com.alibaba.otter.canal.protocol.CanalEntry.Type sourceType_;
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
+     *
+     * <pre>
+     ** 变更数据的来源*
+     * </pre>
+     */
+    public boolean hasSourceType() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
+     *
+     * <pre>
+     ** 变更数据的来源*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.Type getSourceType() {
+      return sourceType_;
+    }
+
+    public static final int SCHEMANAME_FIELD_NUMBER = 8;
+    private java.lang.Object schemaName_;
+    /**
+     * <code>optional string schemaName = 8;</code>
+     *
+     * <pre>
+     ** 变更数据的schemaname*
+     * </pre>
+     */
+    public boolean hasSchemaName() {
+      return ((bitField0_ & 0x00000080) == 0x00000080);
+    }
+    /**
+     * <code>optional string schemaName = 8;</code>
+     *
+     * <pre>
+     ** 变更数据的schemaname*
+     * </pre>
+     */
+    public java.lang.String getSchemaName() {
+      java.lang.Object ref = schemaName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          schemaName_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string schemaName = 8;</code>
+     *
+     * <pre>
+     ** 变更数据的schemaname*
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getSchemaNameBytes() {
+      java.lang.Object ref = schemaName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        schemaName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int TABLENAME_FIELD_NUMBER = 9;
+    private java.lang.Object tableName_;
+    /**
+     * <code>optional string tableName = 9;</code>
+     *
+     * <pre>
+     **变更数据的tablename*
+     * </pre>
+     */
+    public boolean hasTableName() {
+      return ((bitField0_ & 0x00000100) == 0x00000100);
+    }
+    /**
+     * <code>optional string tableName = 9;</code>
+     *
+     * <pre>
+     **变更数据的tablename*
+     * </pre>
+     */
+    public java.lang.String getTableName() {
+      java.lang.Object ref = tableName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          tableName_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string tableName = 9;</code>
+     *
+     * <pre>
+     **变更数据的tablename*
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getTableNameBytes() {
+      java.lang.Object ref = tableName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        tableName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int EVENTLENGTH_FIELD_NUMBER = 10;
+    private long eventLength_;
+    /**
+     * <code>optional int64 eventLength = 10;</code>
+     *
+     * <pre>
+     **每个event的长度*
+     * </pre>
+     */
+    public boolean hasEventLength() {
+      return ((bitField0_ & 0x00000200) == 0x00000200);
+    }
+    /**
+     * <code>optional int64 eventLength = 10;</code>
+     *
+     * <pre>
+     **每个event的长度*
+     * </pre>
+     */
+    public long getEventLength() {
+      return eventLength_;
+    }
+
+    public static final int EVENTTYPE_FIELD_NUMBER = 11;
+    private com.alibaba.otter.canal.protocol.CanalEntry.EventType eventType_;
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
+     *
+     * <pre>
+     **数据变更类型*
+     * </pre>
+     */
+    public boolean hasEventType() {
+      return ((bitField0_ & 0x00000400) == 0x00000400);
+    }
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
+     *
+     * <pre>
+     **数据变更类型*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType() {
+      return eventType_;
+    }
+
+    public static final int PROPS_FIELD_NUMBER = 12;
+    private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public int getPropsCount() {
+      return props_.size();
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+      return props_.get(index);
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index) {
+      return props_.get(index);
+    }
+
+    public static final int GTID_FIELD_NUMBER = 13;
+    private java.lang.Object gtid_;
+    /**
+     * <code>optional string gtid = 13;</code>
+     *
+     * <pre>
+     **当前事务的gitd*
+     * </pre>
+     */
+    public boolean hasGtid() {
+      return ((bitField0_ & 0x00000800) == 0x00000800);
+    }
+    /**
+     * <code>optional string gtid = 13;</code>
+     *
+     * <pre>
+     **当前事务的gitd*
+     * </pre>
+     */
+    public java.lang.String getGtid() {
+      java.lang.Object ref = gtid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          gtid_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string gtid = 13;</code>
+     *
+     * <pre>
+     **当前事务的gitd*
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getGtidBytes() {
+      java.lang.Object ref = gtid_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        gtid_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private void initFields() {
+      version_ = 1;
+      logfileName_ = "";
+      logfileOffset_ = 0L;
+      serverId_ = 0L;
+      serverenCode_ = "";
+      executeTime_ = 0L;
+      sourceType_ = com.alibaba.otter.canal.protocol.CanalEntry.Type.MYSQL;
+      schemaName_ = "";
+      tableName_ = "";
+      eventLength_ = 0L;
+      eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
+      props_ = java.util.Collections.emptyList();
+      gtid_ = "";
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt32(1, version_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeBytes(2, getLogfileNameBytes());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeInt64(3, logfileOffset_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeInt64(4, serverId_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeBytes(5, getServerenCodeBytes());
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeInt64(6, executeTime_);
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeEnum(7, sourceType_.getNumber());
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        output.writeBytes(8, getSchemaNameBytes());
+      }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        output.writeBytes(9, getTableNameBytes());
+      }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        output.writeInt64(10, eventLength_);
+      }
+      if (((bitField0_ & 0x00000400) == 0x00000400)) {
+        output.writeEnum(11, eventType_.getNumber());
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        output.writeMessage(12, props_.get(i));
+      }
+      if (((bitField0_ & 0x00000800) == 0x00000800)) {
+        output.writeBytes(13, getGtidBytes());
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(1, version_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(2, getLogfileNameBytes());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(3, logfileOffset_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(4, serverId_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(5, getServerenCodeBytes());
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(6, executeTime_);
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(7, sourceType_.getNumber());
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(8, getSchemaNameBytes());
+      }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(9, getTableNameBytes());
+      }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(10, eventLength_);
+      }
+      if (((bitField0_ & 0x00000400) == 0x00000400)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(11, eventType_.getNumber());
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(12, props_.get(i));
+      }
+      if (((bitField0_ & 0x00000800) == 0x00000800)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(13, getGtidBytes());
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Header prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
     /**
      * Protobuf type {@code com.alibaba.otter.canal.protocol.Header}
      *
      * <pre>
-     * *message Header*
+     **message Header*
      * </pre>
      */
-    public static final class Header extends com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.Header)
-    HeaderOrBuilder {
-
-        // Use Header.newBuilder() to construct.
-        private Header(com.google.protobuf.GeneratedMessage.Builder<?> builder){
-            super(builder);
-            this.unknownFields = builder.getUnknownFields();
-        }
-
-        private Header(boolean noInit){
-            this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance();
-        }
-
-        private static final Header defaultInstance;
-
-        public static Header getDefaultInstance() {
-            return defaultInstance;
-        }
-
-        public Header getDefaultInstanceForType() {
-            return defaultInstance;
-        }
-
-        private final com.google.protobuf.UnknownFieldSet unknownFields;
-
-        @java.lang.Override
-        public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
-            return this.unknownFields;
-        }
-
-        private Header(com.google.protobuf.CodedInputStream input,
-                       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                   throws com.google.protobuf.InvalidProtocolBufferException{
-            initFields();
-            int mutable_bitField0_ = 0;
-            com.google.protobuf.UnknownFieldSet.Builder unknownFields = com.google.protobuf.UnknownFieldSet.newBuilder();
-            try {
-                boolean done = false;
-                while (!done) {
-                    int tag = input.readTag();
-                    switch (tag) {
-                        case 0:
-                            done = true;
-                            break;
-                        default: {
-                            if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                                done = true;
-                            }
-                            break;
-                        }
-                        case 8: {
-                            bitField0_ |= 0x00000001;
-                            version_ = input.readInt32();
-                            break;
-                        }
-                        case 18: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000002;
-                            logfileName_ = bs;
-                            break;
-                        }
-                        case 24: {
-                            bitField0_ |= 0x00000004;
-                            logfileOffset_ = input.readInt64();
-                            break;
-                        }
-                        case 32: {
-                            bitField0_ |= 0x00000008;
-                            serverId_ = input.readInt64();
-                            break;
-                        }
-                        case 42: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000010;
-                            serverenCode_ = bs;
-                            break;
-                        }
-                        case 48: {
-                            bitField0_ |= 0x00000020;
-                            executeTime_ = input.readInt64();
-                            break;
-                        }
-                        case 56: {
-                            int rawValue = input.readEnum();
-                            com.alibaba.otter.canal.protocol.CanalEntry.Type value = com.alibaba.otter.canal.protocol.CanalEntry.Type.valueOf(rawValue);
-                            if (value == null) {
-                                unknownFields.mergeVarintField(7, rawValue);
-                            } else {
-                                bitField0_ |= 0x00000040;
-                                sourceType_ = value;
-                            }
-                            break;
-                        }
-                        case 66: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000080;
-                            schemaName_ = bs;
-                            break;
-                        }
-                        case 74: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000100;
-                            tableName_ = bs;
-                            break;
-                        }
-                        case 80: {
-                            bitField0_ |= 0x00000200;
-                            eventLength_ = input.readInt64();
-                            break;
-                        }
-                        case 88: {
-                            int rawValue = input.readEnum();
-                            com.alibaba.otter.canal.protocol.CanalEntry.EventType value = com.alibaba.otter.canal.protocol.CanalEntry.EventType.valueOf(rawValue);
-                            if (value == null) {
-                                unknownFields.mergeVarintField(11, rawValue);
-                            } else {
-                                bitField0_ |= 0x00000400;
-                                eventType_ = value;
-                            }
-                            break;
-                        }
-                        case 98: {
-                            if (!((mutable_bitField0_ & 0x00000800) == 0x00000800)) {
-                                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
-                                mutable_bitField0_ |= 0x00000800;
-                            }
-                            props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER,
-                                extensionRegistry));
-                            break;
-                        }
-                    }
-                }
-            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                throw e.setUnfinishedMessage(this);
-            } catch (java.io.IOException e) {
-                throw new com.google.protobuf.InvalidProtocolBufferException(e.getMessage()).setUnfinishedMessage(this);
-            } finally {
-                if (((mutable_bitField0_ & 0x00000800) == 0x00000800)) {
-                    props_ = java.util.Collections.unmodifiableList(props_);
-                }
-                this.unknownFields = unknownFields.build();
-                makeExtensionsImmutable();
-            }
-        }
-
-        public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Header_descriptor;
-        }
-
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Header_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.Header.class,
-                com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder.class);
-        }
-
-        public static com.google.protobuf.Parser<Header> PARSER = new com.google.protobuf.AbstractParser<Header>() {
-
-                                                                    public Header parsePartialFrom(com.google.protobuf.CodedInputStream input,
-                                                                                                   com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                               throws com.google.protobuf.InvalidProtocolBufferException {
-                                                                        return new Header(input, extensionRegistry);
-                                                                    }
-                                                                };
-
-        @java.lang.Override
-        public com.google.protobuf.Parser<Header> getParserForType() {
-            return PARSER;
-        }
-
-        private int             bitField0_;
-        public static final int VERSION_FIELD_NUMBER = 1;
-        private int             version_;
-
-        /**
-         * <code>optional int32 version = 1 [default = 1];</code>
-         *
-         * <pre>
-         * *协议的版本号*
-         * </pre>
-         */
-        public boolean hasVersion() {
-            return ((bitField0_ & 0x00000001) == 0x00000001);
-        }
-
-        /**
-         * <code>optional int32 version = 1 [default = 1];</code>
-         *
-         * <pre>
-         * *协议的版本号*
-         * </pre>
-         */
-        public int getVersion() {
-            return version_;
-        }
-
-        public static final int  LOGFILENAME_FIELD_NUMBER = 2;
-        private java.lang.Object logfileName_;
-
-        /**
-         * <code>optional string logfileName = 2;</code>
-         *
-         * <pre>
-         * *binlog/redolog 文件名*
-         * </pre>
-         */
-        public boolean hasLogfileName() {
-            return ((bitField0_ & 0x00000002) == 0x00000002);
-        }
-
-        /**
-         * <code>optional string logfileName = 2;</code>
-         *
-         * <pre>
-         * *binlog/redolog 文件名*
-         * </pre>
-         */
-        public java.lang.String getLogfileName() {
-            java.lang.Object ref = logfileName_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    logfileName_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string logfileName = 2;</code>
-         *
-         * <pre>
-         * *binlog/redolog 文件名*
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getLogfileNameBytes() {
-            java.lang.Object ref = logfileName_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                logfileName_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        public static final int LOGFILEOFFSET_FIELD_NUMBER = 3;
-        private long            logfileOffset_;
-
-        /**
-         * <code>optional int64 logfileOffset = 3;</code>
-         *
-         * <pre>
-         * *binlog/redolog 文件的偏移位置*
-         * </pre>
-         */
-        public boolean hasLogfileOffset() {
-            return ((bitField0_ & 0x00000004) == 0x00000004);
-        }
-
-        /**
-         * <code>optional int64 logfileOffset = 3;</code>
-         *
-         * <pre>
-         * *binlog/redolog 文件的偏移位置*
-         * </pre>
-         */
-        public long getLogfileOffset() {
-            return logfileOffset_;
-        }
-
-        public static final int SERVERID_FIELD_NUMBER = 4;
-        private long            serverId_;
-
-        /**
-         * <code>optional int64 serverId = 4;</code>
-         *
-         * <pre>
-         * *服务端serverId*
-         * </pre>
-         */
-        public boolean hasServerId() {
-            return ((bitField0_ & 0x00000008) == 0x00000008);
-        }
-
-        /**
-         * <code>optional int64 serverId = 4;</code>
-         *
-         * <pre>
-         * *服务端serverId*
-         * </pre>
-         */
-        public long getServerId() {
-            return serverId_;
-        }
-
-        public static final int  SERVERENCODE_FIELD_NUMBER = 5;
-        private java.lang.Object serverenCode_;
-
-        /**
-         * <code>optional string serverenCode = 5;</code>
-         *
-         * <pre>
-         * * 变更数据的编码 *
-         * </pre>
-         */
-        public boolean hasServerenCode() {
-            return ((bitField0_ & 0x00000010) == 0x00000010);
-        }
-
-        /**
-         * <code>optional string serverenCode = 5;</code>
-         *
-         * <pre>
-         * * 变更数据的编码 *
-         * </pre>
-         */
-        public java.lang.String getServerenCode() {
-            java.lang.Object ref = serverenCode_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    serverenCode_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string serverenCode = 5;</code>
-         *
-         * <pre>
-         * * 变更数据的编码 *
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getServerenCodeBytes() {
-            java.lang.Object ref = serverenCode_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                serverenCode_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        public static final int EXECUTETIME_FIELD_NUMBER = 6;
-        private long            executeTime_;
-
-        /**
-         * <code>optional int64 executeTime = 6;</code>
-         *
-         * <pre>
-         * *变更数据的执行时间 *
-         * </pre>
-         */
-        public boolean hasExecuteTime() {
-            return ((bitField0_ & 0x00000020) == 0x00000020);
-        }
-
-        /**
-         * <code>optional int64 executeTime = 6;</code>
-         *
-         * <pre>
-         * *变更数据的执行时间 *
-         * </pre>
-         */
-        public long getExecuteTime() {
-            return executeTime_;
-        }
-
-        public static final int                                  SOURCETYPE_FIELD_NUMBER = 7;
-        private com.alibaba.otter.canal.protocol.CanalEntry.Type sourceType_;
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
-         *
-         * <pre>
-         * * 变更数据的来源*
-         * </pre>
-         */
-        public boolean hasSourceType() {
-            return ((bitField0_ & 0x00000040) == 0x00000040);
-        }
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
-         *
-         * <pre>
-         * * 变更数据的来源*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.Type getSourceType() {
-            return sourceType_;
-        }
-
-        public static final int  SCHEMANAME_FIELD_NUMBER = 8;
-        private java.lang.Object schemaName_;
-
-        /**
-         * <code>optional string schemaName = 8;</code>
-         *
-         * <pre>
-         * * 变更数据的schemaname*
-         * </pre>
-         */
-        public boolean hasSchemaName() {
-            return ((bitField0_ & 0x00000080) == 0x00000080);
-        }
-
-        /**
-         * <code>optional string schemaName = 8;</code>
-         *
-         * <pre>
-         * * 变更数据的schemaname*
-         * </pre>
-         */
-        public java.lang.String getSchemaName() {
-            java.lang.Object ref = schemaName_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    schemaName_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string schemaName = 8;</code>
-         *
-         * <pre>
-         * * 变更数据的schemaname*
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getSchemaNameBytes() {
-            java.lang.Object ref = schemaName_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                schemaName_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        public static final int  TABLENAME_FIELD_NUMBER = 9;
-        private java.lang.Object tableName_;
-
-        /**
-         * <code>optional string tableName = 9;</code>
-         *
-         * <pre>
-         * *变更数据的tablename*
-         * </pre>
-         */
-        public boolean hasTableName() {
-            return ((bitField0_ & 0x00000100) == 0x00000100);
-        }
-
-        /**
-         * <code>optional string tableName = 9;</code>
-         *
-         * <pre>
-         * *变更数据的tablename*
-         * </pre>
-         */
-        public java.lang.String getTableName() {
-            java.lang.Object ref = tableName_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    tableName_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string tableName = 9;</code>
-         *
-         * <pre>
-         * *变更数据的tablename*
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getTableNameBytes() {
-            java.lang.Object ref = tableName_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                tableName_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        public static final int EVENTLENGTH_FIELD_NUMBER = 10;
-        private long            eventLength_;
-
-        /**
-         * <code>optional int64 eventLength = 10;</code>
-         *
-         * <pre>
-         * *每个event的长度*
-         * </pre>
-         */
-        public boolean hasEventLength() {
-            return ((bitField0_ & 0x00000200) == 0x00000200);
-        }
-
-        /**
-         * <code>optional int64 eventLength = 10;</code>
-         *
-         * <pre>
-         * *每个event的长度*
-         * </pre>
-         */
-        public long getEventLength() {
-            return eventLength_;
-        }
-
-        public static final int                                       EVENTTYPE_FIELD_NUMBER = 11;
-        private com.alibaba.otter.canal.protocol.CanalEntry.EventType eventType_;
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
-         *
-         * <pre>
-         * *数据变更类型*
-         * </pre>
-         */
-        public boolean hasEventType() {
-            return ((bitField0_ & 0x00000400) == 0x00000400);
-        }
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
-         *
-         * <pre>
-         * *数据变更类型*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType() {
-            return eventType_;
-        }
-
-        public static final int                                                  PROPS_FIELD_NUMBER = 12;
-        private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public int getPropsCount() {
-            return props_.size();
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-            return props_.get(index);
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-            return props_.get(index);
-        }
-
-        private void initFields() {
-            version_ = 1;
-            logfileName_ = "";
-            logfileOffset_ = 0L;
-            serverId_ = 0L;
-            serverenCode_ = "";
-            executeTime_ = 0L;
-            sourceType_ = com.alibaba.otter.canal.protocol.CanalEntry.Type.MYSQL;
-            schemaName_ = "";
-            tableName_ = "";
-            eventLength_ = 0L;
-            eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
-            props_ = java.util.Collections.emptyList();
-        }
-
-        private byte memoizedIsInitialized = -1;
-
-        public final boolean isInitialized() {
-            byte isInitialized = memoizedIsInitialized;
-            if (isInitialized == 1) return true;
-            if (isInitialized == 0) return false;
-
-            memoizedIsInitialized = 1;
-            return true;
-        }
-
-        public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
-            getSerializedSize();
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                output.writeInt32(1, version_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                output.writeBytes(2, getLogfileNameBytes());
-            }
-            if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                output.writeInt64(3, logfileOffset_);
-            }
-            if (((bitField0_ & 0x00000008) == 0x00000008)) {
-                output.writeInt64(4, serverId_);
-            }
-            if (((bitField0_ & 0x00000010) == 0x00000010)) {
-                output.writeBytes(5, getServerenCodeBytes());
-            }
-            if (((bitField0_ & 0x00000020) == 0x00000020)) {
-                output.writeInt64(6, executeTime_);
-            }
-            if (((bitField0_ & 0x00000040) == 0x00000040)) {
-                output.writeEnum(7, sourceType_.getNumber());
-            }
-            if (((bitField0_ & 0x00000080) == 0x00000080)) {
-                output.writeBytes(8, getSchemaNameBytes());
-            }
-            if (((bitField0_ & 0x00000100) == 0x00000100)) {
-                output.writeBytes(9, getTableNameBytes());
-            }
-            if (((bitField0_ & 0x00000200) == 0x00000200)) {
-                output.writeInt64(10, eventLength_);
-            }
-            if (((bitField0_ & 0x00000400) == 0x00000400)) {
-                output.writeEnum(11, eventType_.getNumber());
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                output.writeMessage(12, props_.get(i));
-            }
-            getUnknownFields().writeTo(output);
-        }
-
-        private int memoizedSerializedSize = -1;
-
-        public int getSerializedSize() {
-            int size = memoizedSerializedSize;
-            if (size != -1) return size;
-
-            size = 0;
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt32Size(1, version_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(2, getLogfileNameBytes());
-            }
-            if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt64Size(3, logfileOffset_);
-            }
-            if (((bitField0_ & 0x00000008) == 0x00000008)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt64Size(4, serverId_);
-            }
-            if (((bitField0_ & 0x00000010) == 0x00000010)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(5, getServerenCodeBytes());
-            }
-            if (((bitField0_ & 0x00000020) == 0x00000020)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt64Size(6, executeTime_);
-            }
-            if (((bitField0_ & 0x00000040) == 0x00000040)) {
-                size += com.google.protobuf.CodedOutputStream.computeEnumSize(7, sourceType_.getNumber());
-            }
-            if (((bitField0_ & 0x00000080) == 0x00000080)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(8, getSchemaNameBytes());
-            }
-            if (((bitField0_ & 0x00000100) == 0x00000100)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(9, getTableNameBytes());
-            }
-            if (((bitField0_ & 0x00000200) == 0x00000200)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt64Size(10, eventLength_);
-            }
-            if (((bitField0_ & 0x00000400) == 0x00000400)) {
-                size += com.google.protobuf.CodedOutputStream.computeEnumSize(11, eventType_.getNumber());
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                size += com.google.protobuf.CodedOutputStream.computeMessageSize(12, props_.get(i));
-            }
-            size += getUnknownFields().getSerializedSize();
-            memoizedSerializedSize = size;
-            return size;
-        }
-
-        private static final long serialVersionUID = 0L;
-
-        @java.lang.Override
-        protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-            return super.writeReplace();
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(com.google.protobuf.ByteString data)
-                                                                                                                       throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(com.google.protobuf.ByteString data,
-                                                                                   com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                               throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(byte[] data)
-                                                                                               throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(byte[] data,
-                                                                                   com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                               throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(java.io.InputStream input)
-                                                                                                             throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(java.io.InputStream input,
-                                                                                   com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                               throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseDelimitedFrom(java.io.InputStream input)
-                                                                                                                      throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseDelimitedFrom(java.io.InputStream input,
-                                                                                            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                        throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(com.google.protobuf.CodedInputStream input)
-                                                                                                                              throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Header parseFrom(com.google.protobuf.CodedInputStream input,
-                                                                                   com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                               throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static Builder newBuilder() {
-            return Builder.create();
-        }
-
-        public Builder newBuilderForType() {
-            return newBuilder();
-        }
-
-        public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Header prototype) {
-            return newBuilder().mergeFrom(prototype);
-        }
-
-        public Builder toBuilder() {
-            return newBuilder(this);
-        }
-
-        @java.lang.Override
-        protected Builder newBuilderForType(com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-            Builder builder = new Builder(parent);
-            return builder;
-        }
-
-        /**
-         * Protobuf type {@code com.alibaba.otter.canal.protocol.Header}
-         *
-         * <pre>
-         * *message Header*
-         * </pre>
-         */
-        public static final class Builder extends com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:com.alibaba.otter.canal.protocol.Header)
         com.alibaba.otter.canal.protocol.CanalEntry.HeaderOrBuilder {
-
-            public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Header_descriptor;
-            }
-
-            protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Header_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.Header.class,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder.class);
-            }
-
-            // Construct using
-            // com.alibaba.otter.canal.protocol.CanalEntry.Header.newBuilder()
-            private Builder(){
-                maybeForceBuilderInitialization();
-            }
-
-            private Builder(com.google.protobuf.GeneratedMessage.BuilderParent parent){
-                super(parent);
-                maybeForceBuilderInitialization();
-            }
-
-            private void maybeForceBuilderInitialization() {
-                if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-                    getPropsFieldBuilder();
-                }
-            }
-
-            private static Builder create() {
-                return new Builder();
-            }
-
-            public Builder clear() {
-                super.clear();
-                version_ = 1;
-                bitField0_ = (bitField0_ & ~0x00000001);
-                logfileName_ = "";
-                bitField0_ = (bitField0_ & ~0x00000002);
-                logfileOffset_ = 0L;
-                bitField0_ = (bitField0_ & ~0x00000004);
-                serverId_ = 0L;
-                bitField0_ = (bitField0_ & ~0x00000008);
-                serverenCode_ = "";
-                bitField0_ = (bitField0_ & ~0x00000010);
-                executeTime_ = 0L;
-                bitField0_ = (bitField0_ & ~0x00000020);
-                sourceType_ = com.alibaba.otter.canal.protocol.CanalEntry.Type.MYSQL;
-                bitField0_ = (bitField0_ & ~0x00000040);
-                schemaName_ = "";
-                bitField0_ = (bitField0_ & ~0x00000080);
-                tableName_ = "";
-                bitField0_ = (bitField0_ & ~0x00000100);
-                eventLength_ = 0L;
-                bitField0_ = (bitField0_ & ~0x00000200);
-                eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
-                bitField0_ = (bitField0_ & ~0x00000400);
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000800);
-                } else {
-                    propsBuilder_.clear();
-                }
-                return this;
-            }
-
-            public Builder clone() {
-                return create().mergeFrom(buildPartial());
-            }
-
-            public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Header_descriptor;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Header getDefaultInstanceForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance();
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Header build() {
-                com.alibaba.otter.canal.protocol.CanalEntry.Header result = buildPartial();
-                if (!result.isInitialized()) {
-                    throw newUninitializedMessageException(result);
-                }
-                return result;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Header buildPartial() {
-                com.alibaba.otter.canal.protocol.CanalEntry.Header result = new com.alibaba.otter.canal.protocol.CanalEntry.Header(this);
-                int from_bitField0_ = bitField0_;
-                int to_bitField0_ = 0;
-                if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-                    to_bitField0_ |= 0x00000001;
-                }
-                result.version_ = version_;
-                if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-                    to_bitField0_ |= 0x00000002;
-                }
-                result.logfileName_ = logfileName_;
-                if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-                    to_bitField0_ |= 0x00000004;
-                }
-                result.logfileOffset_ = logfileOffset_;
-                if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-                    to_bitField0_ |= 0x00000008;
-                }
-                result.serverId_ = serverId_;
-                if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-                    to_bitField0_ |= 0x00000010;
-                }
-                result.serverenCode_ = serverenCode_;
-                if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
-                    to_bitField0_ |= 0x00000020;
-                }
-                result.executeTime_ = executeTime_;
-                if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-                    to_bitField0_ |= 0x00000040;
-                }
-                result.sourceType_ = sourceType_;
-                if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
-                    to_bitField0_ |= 0x00000080;
-                }
-                result.schemaName_ = schemaName_;
-                if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
-                    to_bitField0_ |= 0x00000100;
-                }
-                result.tableName_ = tableName_;
-                if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
-                    to_bitField0_ |= 0x00000200;
-                }
-                result.eventLength_ = eventLength_;
-                if (((from_bitField0_ & 0x00000400) == 0x00000400)) {
-                    to_bitField0_ |= 0x00000400;
-                }
-                result.eventType_ = eventType_;
-                if (propsBuilder_ == null) {
-                    if (((bitField0_ & 0x00000800) == 0x00000800)) {
-                        props_ = java.util.Collections.unmodifiableList(props_);
-                        bitField0_ = (bitField0_ & ~0x00000800);
-                    }
-                    result.props_ = props_;
-                } else {
-                    result.props_ = propsBuilder_.build();
-                }
-                result.bitField0_ = to_bitField0_;
-                onBuilt();
-                return result;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.Message other) {
-                if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.Header) {
-                    return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.Header) other);
-                } else {
-                    super.mergeFrom(other);
-                    return this;
-                }
-            }
-
-            public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.Header other) {
-                if (other == com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance()) return this;
-                if (other.hasVersion()) {
-                    setVersion(other.getVersion());
-                }
-                if (other.hasLogfileName()) {
-                    bitField0_ |= 0x00000002;
-                    logfileName_ = other.logfileName_;
-                    onChanged();
-                }
-                if (other.hasLogfileOffset()) {
-                    setLogfileOffset(other.getLogfileOffset());
-                }
-                if (other.hasServerId()) {
-                    setServerId(other.getServerId());
-                }
-                if (other.hasServerenCode()) {
-                    bitField0_ |= 0x00000010;
-                    serverenCode_ = other.serverenCode_;
-                    onChanged();
-                }
-                if (other.hasExecuteTime()) {
-                    setExecuteTime(other.getExecuteTime());
-                }
-                if (other.hasSourceType()) {
-                    setSourceType(other.getSourceType());
-                }
-                if (other.hasSchemaName()) {
-                    bitField0_ |= 0x00000080;
-                    schemaName_ = other.schemaName_;
-                    onChanged();
-                }
-                if (other.hasTableName()) {
-                    bitField0_ |= 0x00000100;
-                    tableName_ = other.tableName_;
-                    onChanged();
-                }
-                if (other.hasEventLength()) {
-                    setEventLength(other.getEventLength());
-                }
-                if (other.hasEventType()) {
-                    setEventType(other.getEventType());
-                }
-                if (propsBuilder_ == null) {
-                    if (!other.props_.isEmpty()) {
-                        if (props_.isEmpty()) {
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000800);
-                        } else {
-                            ensurePropsIsMutable();
-                            props_.addAll(other.props_);
-                        }
-                        onChanged();
-                    }
-                } else {
-                    if (!other.props_.isEmpty()) {
-                        if (propsBuilder_.isEmpty()) {
-                            propsBuilder_.dispose();
-                            propsBuilder_ = null;
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000800);
-                            propsBuilder_ = com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ? getPropsFieldBuilder() : null;
-                        } else {
-                            propsBuilder_.addAllMessages(other.props_);
-                        }
-                    }
-                }
-                this.mergeUnknownFields(other.getUnknownFields());
-                return this;
-            }
-
-            public final boolean isInitialized() {
-                return true;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
-                                     com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                 throws java.io.IOException {
-                com.alibaba.otter.canal.protocol.CanalEntry.Header parsedMessage = null;
-                try {
-                    parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                    parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.Header) e.getUnfinishedMessage();
-                    throw e;
-                } finally {
-                    if (parsedMessage != null) {
-                        mergeFrom(parsedMessage);
-                    }
-                }
-                return this;
-            }
-
-            private int bitField0_;
-
-            private int version_ = 1;
-
-            /**
-             * <code>optional int32 version = 1 [default = 1];</code>
-             *
-             * <pre>
-             * *协议的版本号*
-             * </pre>
-             */
-            public boolean hasVersion() {
-                return ((bitField0_ & 0x00000001) == 0x00000001);
-            }
-
-            /**
-             * <code>optional int32 version = 1 [default = 1];</code>
-             *
-             * <pre>
-             * *协议的版本号*
-             * </pre>
-             */
-            public int getVersion() {
-                return version_;
-            }
-
-            /**
-             * <code>optional int32 version = 1 [default = 1];</code>
-             *
-             * <pre>
-             * *协议的版本号*
-             * </pre>
-             */
-            public Builder setVersion(int value) {
-                bitField0_ |= 0x00000001;
-                version_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int32 version = 1 [default = 1];</code>
-             *
-             * <pre>
-             * *协议的版本号*
-             * </pre>
-             */
-            public Builder clearVersion() {
-                bitField0_ = (bitField0_ & ~0x00000001);
-                version_ = 1;
-                onChanged();
-                return this;
-            }
-
-            private java.lang.Object logfileName_ = "";
-
-            /**
-             * <code>optional string logfileName = 2;</code>
-             *
-             * <pre>
-             * *binlog/redolog 文件名*
-             * </pre>
-             */
-            public boolean hasLogfileName() {
-                return ((bitField0_ & 0x00000002) == 0x00000002);
-            }
-
-            /**
-             * <code>optional string logfileName = 2;</code>
-             *
-             * <pre>
-             * *binlog/redolog 文件名*
-             * </pre>
-             */
-            public java.lang.String getLogfileName() {
-                java.lang.Object ref = logfileName_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        logfileName_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string logfileName = 2;</code>
-             *
-             * <pre>
-             * *binlog/redolog 文件名*
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getLogfileNameBytes() {
-                java.lang.Object ref = logfileName_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    logfileName_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string logfileName = 2;</code>
-             *
-             * <pre>
-             * *binlog/redolog 文件名*
-             * </pre>
-             */
-            public Builder setLogfileName(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000002;
-                logfileName_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string logfileName = 2;</code>
-             *
-             * <pre>
-             * *binlog/redolog 文件名*
-             * </pre>
-             */
-            public Builder clearLogfileName() {
-                bitField0_ = (bitField0_ & ~0x00000002);
-                logfileName_ = getDefaultInstance().getLogfileName();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string logfileName = 2;</code>
-             *
-             * <pre>
-             * *binlog/redolog 文件名*
-             * </pre>
-             */
-            public Builder setLogfileNameBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000002;
-                logfileName_ = value;
-                onChanged();
-                return this;
-            }
-
-            private long logfileOffset_;
-
-            /**
-             * <code>optional int64 logfileOffset = 3;</code>
-             *
-             * <pre>
-             * *binlog/redolog 文件的偏移位置*
-             * </pre>
-             */
-            public boolean hasLogfileOffset() {
-                return ((bitField0_ & 0x00000004) == 0x00000004);
-            }
-
-            /**
-             * <code>optional int64 logfileOffset = 3;</code>
-             *
-             * <pre>
-             * *binlog/redolog 文件的偏移位置*
-             * </pre>
-             */
-            public long getLogfileOffset() {
-                return logfileOffset_;
-            }
-
-            /**
-             * <code>optional int64 logfileOffset = 3;</code>
-             *
-             * <pre>
-             * *binlog/redolog 文件的偏移位置*
-             * </pre>
-             */
-            public Builder setLogfileOffset(long value) {
-                bitField0_ |= 0x00000004;
-                logfileOffset_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int64 logfileOffset = 3;</code>
-             *
-             * <pre>
-             * *binlog/redolog 文件的偏移位置*
-             * </pre>
-             */
-            public Builder clearLogfileOffset() {
-                bitField0_ = (bitField0_ & ~0x00000004);
-                logfileOffset_ = 0L;
-                onChanged();
-                return this;
-            }
-
-            private long serverId_;
-
-            /**
-             * <code>optional int64 serverId = 4;</code>
-             *
-             * <pre>
-             * *服务端serverId*
-             * </pre>
-             */
-            public boolean hasServerId() {
-                return ((bitField0_ & 0x00000008) == 0x00000008);
-            }
-
-            /**
-             * <code>optional int64 serverId = 4;</code>
-             *
-             * <pre>
-             * *服务端serverId*
-             * </pre>
-             */
-            public long getServerId() {
-                return serverId_;
-            }
-
-            /**
-             * <code>optional int64 serverId = 4;</code>
-             *
-             * <pre>
-             * *服务端serverId*
-             * </pre>
-             */
-            public Builder setServerId(long value) {
-                bitField0_ |= 0x00000008;
-                serverId_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int64 serverId = 4;</code>
-             *
-             * <pre>
-             * *服务端serverId*
-             * </pre>
-             */
-            public Builder clearServerId() {
-                bitField0_ = (bitField0_ & ~0x00000008);
-                serverId_ = 0L;
-                onChanged();
-                return this;
-            }
-
-            private java.lang.Object serverenCode_ = "";
-
-            /**
-             * <code>optional string serverenCode = 5;</code>
-             *
-             * <pre>
-             * * 变更数据的编码 *
-             * </pre>
-             */
-            public boolean hasServerenCode() {
-                return ((bitField0_ & 0x00000010) == 0x00000010);
-            }
-
-            /**
-             * <code>optional string serverenCode = 5;</code>
-             *
-             * <pre>
-             * * 变更数据的编码 *
-             * </pre>
-             */
-            public java.lang.String getServerenCode() {
-                java.lang.Object ref = serverenCode_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        serverenCode_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string serverenCode = 5;</code>
-             *
-             * <pre>
-             * * 变更数据的编码 *
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getServerenCodeBytes() {
-                java.lang.Object ref = serverenCode_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    serverenCode_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string serverenCode = 5;</code>
-             *
-             * <pre>
-             * * 变更数据的编码 *
-             * </pre>
-             */
-            public Builder setServerenCode(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000010;
-                serverenCode_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string serverenCode = 5;</code>
-             *
-             * <pre>
-             * * 变更数据的编码 *
-             * </pre>
-             */
-            public Builder clearServerenCode() {
-                bitField0_ = (bitField0_ & ~0x00000010);
-                serverenCode_ = getDefaultInstance().getServerenCode();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string serverenCode = 5;</code>
-             *
-             * <pre>
-             * * 变更数据的编码 *
-             * </pre>
-             */
-            public Builder setServerenCodeBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000010;
-                serverenCode_ = value;
-                onChanged();
-                return this;
-            }
-
-            private long executeTime_;
-
-            /**
-             * <code>optional int64 executeTime = 6;</code>
-             *
-             * <pre>
-             * *变更数据的执行时间 *
-             * </pre>
-             */
-            public boolean hasExecuteTime() {
-                return ((bitField0_ & 0x00000020) == 0x00000020);
-            }
-
-            /**
-             * <code>optional int64 executeTime = 6;</code>
-             *
-             * <pre>
-             * *变更数据的执行时间 *
-             * </pre>
-             */
-            public long getExecuteTime() {
-                return executeTime_;
-            }
-
-            /**
-             * <code>optional int64 executeTime = 6;</code>
-             *
-             * <pre>
-             * *变更数据的执行时间 *
-             * </pre>
-             */
-            public Builder setExecuteTime(long value) {
-                bitField0_ |= 0x00000020;
-                executeTime_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int64 executeTime = 6;</code>
-             *
-             * <pre>
-             * *变更数据的执行时间 *
-             * </pre>
-             */
-            public Builder clearExecuteTime() {
-                bitField0_ = (bitField0_ & ~0x00000020);
-                executeTime_ = 0L;
-                onChanged();
-                return this;
-            }
-
-            private com.alibaba.otter.canal.protocol.CanalEntry.Type sourceType_ = com.alibaba.otter.canal.protocol.CanalEntry.Type.MYSQL;
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
-             *
-             * <pre>
-             * * 变更数据的来源*
-             * </pre>
-             */
-            public boolean hasSourceType() {
-                return ((bitField0_ & 0x00000040) == 0x00000040);
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
-             *
-             * <pre>
-             * * 变更数据的来源*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Type getSourceType() {
-                return sourceType_;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
-             *
-             * <pre>
-             * * 变更数据的来源*
-             * </pre>
-             */
-            public Builder setSourceType(com.alibaba.otter.canal.protocol.CanalEntry.Type value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000040;
-                sourceType_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
-             *
-             * <pre>
-             * * 变更数据的来源*
-             * </pre>
-             */
-            public Builder clearSourceType() {
-                bitField0_ = (bitField0_ & ~0x00000040);
-                sourceType_ = com.alibaba.otter.canal.protocol.CanalEntry.Type.MYSQL;
-                onChanged();
-                return this;
-            }
-
-            private java.lang.Object schemaName_ = "";
-
-            /**
-             * <code>optional string schemaName = 8;</code>
-             *
-             * <pre>
-             * * 变更数据的schemaname*
-             * </pre>
-             */
-            public boolean hasSchemaName() {
-                return ((bitField0_ & 0x00000080) == 0x00000080);
-            }
-
-            /**
-             * <code>optional string schemaName = 8;</code>
-             *
-             * <pre>
-             * * 变更数据的schemaname*
-             * </pre>
-             */
-            public java.lang.String getSchemaName() {
-                java.lang.Object ref = schemaName_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        schemaName_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string schemaName = 8;</code>
-             *
-             * <pre>
-             * * 变更数据的schemaname*
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getSchemaNameBytes() {
-                java.lang.Object ref = schemaName_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    schemaName_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string schemaName = 8;</code>
-             *
-             * <pre>
-             * * 变更数据的schemaname*
-             * </pre>
-             */
-            public Builder setSchemaName(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000080;
-                schemaName_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string schemaName = 8;</code>
-             *
-             * <pre>
-             * * 变更数据的schemaname*
-             * </pre>
-             */
-            public Builder clearSchemaName() {
-                bitField0_ = (bitField0_ & ~0x00000080);
-                schemaName_ = getDefaultInstance().getSchemaName();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string schemaName = 8;</code>
-             *
-             * <pre>
-             * * 变更数据的schemaname*
-             * </pre>
-             */
-            public Builder setSchemaNameBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000080;
-                schemaName_ = value;
-                onChanged();
-                return this;
-            }
-
-            private java.lang.Object tableName_ = "";
-
-            /**
-             * <code>optional string tableName = 9;</code>
-             *
-             * <pre>
-             * *变更数据的tablename*
-             * </pre>
-             */
-            public boolean hasTableName() {
-                return ((bitField0_ & 0x00000100) == 0x00000100);
-            }
-
-            /**
-             * <code>optional string tableName = 9;</code>
-             *
-             * <pre>
-             * *变更数据的tablename*
-             * </pre>
-             */
-            public java.lang.String getTableName() {
-                java.lang.Object ref = tableName_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        tableName_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string tableName = 9;</code>
-             *
-             * <pre>
-             * *变更数据的tablename*
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getTableNameBytes() {
-                java.lang.Object ref = tableName_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    tableName_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string tableName = 9;</code>
-             *
-             * <pre>
-             * *变更数据的tablename*
-             * </pre>
-             */
-            public Builder setTableName(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000100;
-                tableName_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string tableName = 9;</code>
-             *
-             * <pre>
-             * *变更数据的tablename*
-             * </pre>
-             */
-            public Builder clearTableName() {
-                bitField0_ = (bitField0_ & ~0x00000100);
-                tableName_ = getDefaultInstance().getTableName();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string tableName = 9;</code>
-             *
-             * <pre>
-             * *变更数据的tablename*
-             * </pre>
-             */
-            public Builder setTableNameBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000100;
-                tableName_ = value;
-                onChanged();
-                return this;
-            }
-
-            private long eventLength_;
-
-            /**
-             * <code>optional int64 eventLength = 10;</code>
-             *
-             * <pre>
-             * *每个event的长度*
-             * </pre>
-             */
-            public boolean hasEventLength() {
-                return ((bitField0_ & 0x00000200) == 0x00000200);
-            }
-
-            /**
-             * <code>optional int64 eventLength = 10;</code>
-             *
-             * <pre>
-             * *每个event的长度*
-             * </pre>
-             */
-            public long getEventLength() {
-                return eventLength_;
-            }
-
-            /**
-             * <code>optional int64 eventLength = 10;</code>
-             *
-             * <pre>
-             * *每个event的长度*
-             * </pre>
-             */
-            public Builder setEventLength(long value) {
-                bitField0_ |= 0x00000200;
-                eventLength_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int64 eventLength = 10;</code>
-             *
-             * <pre>
-             * *每个event的长度*
-             * </pre>
-             */
-            public Builder clearEventLength() {
-                bitField0_ = (bitField0_ & ~0x00000200);
-                eventLength_ = 0L;
-                onChanged();
-                return this;
-            }
-
-            private com.alibaba.otter.canal.protocol.CanalEntry.EventType eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
-             *
-             * <pre>
-             * *数据变更类型*
-             * </pre>
-             */
-            public boolean hasEventType() {
-                return ((bitField0_ & 0x00000400) == 0x00000400);
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
-             *
-             * <pre>
-             * *数据变更类型*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType() {
-                return eventType_;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
-             *
-             * <pre>
-             * *数据变更类型*
-             * </pre>
-             */
-            public Builder setEventType(com.alibaba.otter.canal.protocol.CanalEntry.EventType value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000400;
-                eventType_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
-             *
-             * <pre>
-             * *数据变更类型*
-             * </pre>
-             */
-            public Builder clearEventType() {
-                bitField0_ = (bitField0_ & ~0x00000400);
-                eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
-                onChanged();
-                return this;
-            }
-
-            private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ = java.util.Collections.emptyList();
-
-            private void ensurePropsIsMutable() {
-                if (!((bitField0_ & 0x00000800) == 0x00000800)) {
-                    props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
-                    bitField0_ |= 0x00000800;
-                }
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-                if (propsBuilder_ == null) {
-                    return java.util.Collections.unmodifiableList(props_);
-                } else {
-                    return propsBuilder_.getMessageList();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public int getPropsCount() {
-                if (propsBuilder_ == null) {
-                    return props_.size();
-                } else {
-                    return propsBuilder_.getCount();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessage(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.set(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.set(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addAllProps(java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    com.google.protobuf.AbstractMessageLite.Builder.addAll(values, props_);
-                    onChanged();
-                } else {
-                    propsBuilder_.addAllMessages(values);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder clearProps() {
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000800);
-                    onChanged();
-                } else {
-                    propsBuilder_.clear();
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder removeProps(int index) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.remove(index);
-                    onChanged();
-                } else {
-                    propsBuilder_.remove(index);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(int index) {
-                return getPropsFieldBuilder().getBuilder(index);
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessageOrBuilder(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-                if (propsBuilder_ != null) {
-                    return propsBuilder_.getMessageOrBuilderList();
-                } else {
-                    return java.util.Collections.unmodifiableList(props_);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
-                return getPropsFieldBuilder().addBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(int index) {
-                return getPropsFieldBuilder().addBuilder(index,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> getPropsBuilderList() {
-                return getPropsFieldBuilder().getBuilderList();
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsFieldBuilder() {
-                if (propsBuilder_ == null) {
-                    propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(props_,
-                        ((bitField0_ & 0x00000800) == 0x00000800),
-                        getParentForChildren(),
-                        isClean());
-                    props_ = null;
-                }
-                return propsBuilder_;
-            }
-
-            // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.Header)
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Header_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Header_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.alibaba.otter.canal.protocol.CanalEntry.Header.class, com.alibaba.otter.canal.protocol.CanalEntry.Header.Builder.class);
+      }
+
+      // Construct using com.alibaba.otter.canal.protocol.CanalEntry.Header.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getPropsFieldBuilder();
         }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
 
-        static {
-            defaultInstance = new Header(true);
-            defaultInstance.initFields();
+      public Builder clear() {
+        super.clear();
+        version_ = 1;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        logfileName_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        logfileOffset_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        serverId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        serverenCode_ = "";
+        bitField0_ = (bitField0_ & ~0x00000010);
+        executeTime_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000020);
+        sourceType_ = com.alibaba.otter.canal.protocol.CanalEntry.Type.MYSQL;
+        bitField0_ = (bitField0_ & ~0x00000040);
+        schemaName_ = "";
+        bitField0_ = (bitField0_ & ~0x00000080);
+        tableName_ = "";
+        bitField0_ = (bitField0_ & ~0x00000100);
+        eventLength_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000200);
+        eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
+        bitField0_ = (bitField0_ & ~0x00000400);
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000800);
+        } else {
+          propsBuilder_.clear();
         }
+        gtid_ = "";
+        bitField0_ = (bitField0_ & ~0x00001000);
+        return this;
+      }
 
-        // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.Header)
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Header_descriptor;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.Header getDefaultInstanceForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance();
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.Header build() {
+        com.alibaba.otter.canal.protocol.CanalEntry.Header result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.Header buildPartial() {
+        com.alibaba.otter.canal.protocol.CanalEntry.Header result = new com.alibaba.otter.canal.protocol.CanalEntry.Header(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.version_ = version_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.logfileName_ = logfileName_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.logfileOffset_ = logfileOffset_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.serverId_ = serverId_;
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.serverenCode_ = serverenCode_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        result.executeTime_ = executeTime_;
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        result.sourceType_ = sourceType_;
+        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+          to_bitField0_ |= 0x00000080;
+        }
+        result.schemaName_ = schemaName_;
+        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
+          to_bitField0_ |= 0x00000100;
+        }
+        result.tableName_ = tableName_;
+        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+          to_bitField0_ |= 0x00000200;
+        }
+        result.eventLength_ = eventLength_;
+        if (((from_bitField0_ & 0x00000400) == 0x00000400)) {
+          to_bitField0_ |= 0x00000400;
+        }
+        result.eventType_ = eventType_;
+        if (propsBuilder_ == null) {
+          if (((bitField0_ & 0x00000800) == 0x00000800)) {
+            props_ = java.util.Collections.unmodifiableList(props_);
+            bitField0_ = (bitField0_ & ~0x00000800);
+          }
+          result.props_ = props_;
+        } else {
+          result.props_ = propsBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
+          to_bitField0_ |= 0x00000800;
+        }
+        result.gtid_ = gtid_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.Header) {
+          return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.Header)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.Header other) {
+        if (other == com.alibaba.otter.canal.protocol.CanalEntry.Header.getDefaultInstance()) return this;
+        if (other.hasVersion()) {
+          setVersion(other.getVersion());
+        }
+        if (other.hasLogfileName()) {
+          bitField0_ |= 0x00000002;
+          logfileName_ = other.logfileName_;
+          onChanged();
+        }
+        if (other.hasLogfileOffset()) {
+          setLogfileOffset(other.getLogfileOffset());
+        }
+        if (other.hasServerId()) {
+          setServerId(other.getServerId());
+        }
+        if (other.hasServerenCode()) {
+          bitField0_ |= 0x00000010;
+          serverenCode_ = other.serverenCode_;
+          onChanged();
+        }
+        if (other.hasExecuteTime()) {
+          setExecuteTime(other.getExecuteTime());
+        }
+        if (other.hasSourceType()) {
+          setSourceType(other.getSourceType());
+        }
+        if (other.hasSchemaName()) {
+          bitField0_ |= 0x00000080;
+          schemaName_ = other.schemaName_;
+          onChanged();
+        }
+        if (other.hasTableName()) {
+          bitField0_ |= 0x00000100;
+          tableName_ = other.tableName_;
+          onChanged();
+        }
+        if (other.hasEventLength()) {
+          setEventLength(other.getEventLength());
+        }
+        if (other.hasEventType()) {
+          setEventType(other.getEventType());
+        }
+        if (propsBuilder_ == null) {
+          if (!other.props_.isEmpty()) {
+            if (props_.isEmpty()) {
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000800);
+            } else {
+              ensurePropsIsMutable();
+              props_.addAll(other.props_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.props_.isEmpty()) {
+            if (propsBuilder_.isEmpty()) {
+              propsBuilder_.dispose();
+              propsBuilder_ = null;
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000800);
+              propsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getPropsFieldBuilder() : null;
+            } else {
+              propsBuilder_.addAllMessages(other.props_);
+            }
+          }
+        }
+        if (other.hasGtid()) {
+          bitField0_ |= 0x00001000;
+          gtid_ = other.gtid_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.alibaba.otter.canal.protocol.CanalEntry.Header parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.Header) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private int version_ = 1;
+      /**
+       * <code>optional int32 version = 1 [default = 1];</code>
+       *
+       * <pre>
+       **协议的版本号*
+       * </pre>
+       */
+      public boolean hasVersion() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional int32 version = 1 [default = 1];</code>
+       *
+       * <pre>
+       **协议的版本号*
+       * </pre>
+       */
+      public int getVersion() {
+        return version_;
+      }
+      /**
+       * <code>optional int32 version = 1 [default = 1];</code>
+       *
+       * <pre>
+       **协议的版本号*
+       * </pre>
+       */
+      public Builder setVersion(int value) {
+        bitField0_ |= 0x00000001;
+        version_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 version = 1 [default = 1];</code>
+       *
+       * <pre>
+       **协议的版本号*
+       * </pre>
+       */
+      public Builder clearVersion() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        version_ = 1;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object logfileName_ = "";
+      /**
+       * <code>optional string logfileName = 2;</code>
+       *
+       * <pre>
+       **binlog/redolog 文件名*
+       * </pre>
+       */
+      public boolean hasLogfileName() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional string logfileName = 2;</code>
+       *
+       * <pre>
+       **binlog/redolog 文件名*
+       * </pre>
+       */
+      public java.lang.String getLogfileName() {
+        java.lang.Object ref = logfileName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            logfileName_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string logfileName = 2;</code>
+       *
+       * <pre>
+       **binlog/redolog 文件名*
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getLogfileNameBytes() {
+        java.lang.Object ref = logfileName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          logfileName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string logfileName = 2;</code>
+       *
+       * <pre>
+       **binlog/redolog 文件名*
+       * </pre>
+       */
+      public Builder setLogfileName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        logfileName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string logfileName = 2;</code>
+       *
+       * <pre>
+       **binlog/redolog 文件名*
+       * </pre>
+       */
+      public Builder clearLogfileName() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        logfileName_ = getDefaultInstance().getLogfileName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string logfileName = 2;</code>
+       *
+       * <pre>
+       **binlog/redolog 文件名*
+       * </pre>
+       */
+      public Builder setLogfileNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        logfileName_ = value;
+        onChanged();
+        return this;
+      }
+
+      private long logfileOffset_ ;
+      /**
+       * <code>optional int64 logfileOffset = 3;</code>
+       *
+       * <pre>
+       **binlog/redolog 文件的偏移位置*
+       * </pre>
+       */
+      public boolean hasLogfileOffset() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional int64 logfileOffset = 3;</code>
+       *
+       * <pre>
+       **binlog/redolog 文件的偏移位置*
+       * </pre>
+       */
+      public long getLogfileOffset() {
+        return logfileOffset_;
+      }
+      /**
+       * <code>optional int64 logfileOffset = 3;</code>
+       *
+       * <pre>
+       **binlog/redolog 文件的偏移位置*
+       * </pre>
+       */
+      public Builder setLogfileOffset(long value) {
+        bitField0_ |= 0x00000004;
+        logfileOffset_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 logfileOffset = 3;</code>
+       *
+       * <pre>
+       **binlog/redolog 文件的偏移位置*
+       * </pre>
+       */
+      public Builder clearLogfileOffset() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        logfileOffset_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long serverId_ ;
+      /**
+       * <code>optional int64 serverId = 4;</code>
+       *
+       * <pre>
+       **服务端serverId*
+       * </pre>
+       */
+      public boolean hasServerId() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional int64 serverId = 4;</code>
+       *
+       * <pre>
+       **服务端serverId*
+       * </pre>
+       */
+      public long getServerId() {
+        return serverId_;
+      }
+      /**
+       * <code>optional int64 serverId = 4;</code>
+       *
+       * <pre>
+       **服务端serverId*
+       * </pre>
+       */
+      public Builder setServerId(long value) {
+        bitField0_ |= 0x00000008;
+        serverId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 serverId = 4;</code>
+       *
+       * <pre>
+       **服务端serverId*
+       * </pre>
+       */
+      public Builder clearServerId() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        serverId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object serverenCode_ = "";
+      /**
+       * <code>optional string serverenCode = 5;</code>
+       *
+       * <pre>
+       ** 变更数据的编码 *
+       * </pre>
+       */
+      public boolean hasServerenCode() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <code>optional string serverenCode = 5;</code>
+       *
+       * <pre>
+       ** 变更数据的编码 *
+       * </pre>
+       */
+      public java.lang.String getServerenCode() {
+        java.lang.Object ref = serverenCode_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            serverenCode_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string serverenCode = 5;</code>
+       *
+       * <pre>
+       ** 变更数据的编码 *
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getServerenCodeBytes() {
+        java.lang.Object ref = serverenCode_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          serverenCode_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string serverenCode = 5;</code>
+       *
+       * <pre>
+       ** 变更数据的编码 *
+       * </pre>
+       */
+      public Builder setServerenCode(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+        serverenCode_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string serverenCode = 5;</code>
+       *
+       * <pre>
+       ** 变更数据的编码 *
+       * </pre>
+       */
+      public Builder clearServerenCode() {
+        bitField0_ = (bitField0_ & ~0x00000010);
+        serverenCode_ = getDefaultInstance().getServerenCode();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string serverenCode = 5;</code>
+       *
+       * <pre>
+       ** 变更数据的编码 *
+       * </pre>
+       */
+      public Builder setServerenCodeBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+        serverenCode_ = value;
+        onChanged();
+        return this;
+      }
+
+      private long executeTime_ ;
+      /**
+       * <code>optional int64 executeTime = 6;</code>
+       *
+       * <pre>
+       **变更数据的执行时间 *
+       * </pre>
+       */
+      public boolean hasExecuteTime() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>optional int64 executeTime = 6;</code>
+       *
+       * <pre>
+       **变更数据的执行时间 *
+       * </pre>
+       */
+      public long getExecuteTime() {
+        return executeTime_;
+      }
+      /**
+       * <code>optional int64 executeTime = 6;</code>
+       *
+       * <pre>
+       **变更数据的执行时间 *
+       * </pre>
+       */
+      public Builder setExecuteTime(long value) {
+        bitField0_ |= 0x00000020;
+        executeTime_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 executeTime = 6;</code>
+       *
+       * <pre>
+       **变更数据的执行时间 *
+       * </pre>
+       */
+      public Builder clearExecuteTime() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        executeTime_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private com.alibaba.otter.canal.protocol.CanalEntry.Type sourceType_ = com.alibaba.otter.canal.protocol.CanalEntry.Type.MYSQL;
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
+       *
+       * <pre>
+       ** 变更数据的来源*
+       * </pre>
+       */
+      public boolean hasSourceType() {
+        return ((bitField0_ & 0x00000040) == 0x00000040);
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
+       *
+       * <pre>
+       ** 变更数据的来源*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Type getSourceType() {
+        return sourceType_;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
+       *
+       * <pre>
+       ** 变更数据的来源*
+       * </pre>
+       */
+      public Builder setSourceType(com.alibaba.otter.canal.protocol.CanalEntry.Type value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000040;
+        sourceType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.Type sourceType = 7 [default = MYSQL];</code>
+       *
+       * <pre>
+       ** 变更数据的来源*
+       * </pre>
+       */
+      public Builder clearSourceType() {
+        bitField0_ = (bitField0_ & ~0x00000040);
+        sourceType_ = com.alibaba.otter.canal.protocol.CanalEntry.Type.MYSQL;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object schemaName_ = "";
+      /**
+       * <code>optional string schemaName = 8;</code>
+       *
+       * <pre>
+       ** 变更数据的schemaname*
+       * </pre>
+       */
+      public boolean hasSchemaName() {
+        return ((bitField0_ & 0x00000080) == 0x00000080);
+      }
+      /**
+       * <code>optional string schemaName = 8;</code>
+       *
+       * <pre>
+       ** 变更数据的schemaname*
+       * </pre>
+       */
+      public java.lang.String getSchemaName() {
+        java.lang.Object ref = schemaName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            schemaName_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string schemaName = 8;</code>
+       *
+       * <pre>
+       ** 变更数据的schemaname*
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getSchemaNameBytes() {
+        java.lang.Object ref = schemaName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          schemaName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string schemaName = 8;</code>
+       *
+       * <pre>
+       ** 变更数据的schemaname*
+       * </pre>
+       */
+      public Builder setSchemaName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000080;
+        schemaName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string schemaName = 8;</code>
+       *
+       * <pre>
+       ** 变更数据的schemaname*
+       * </pre>
+       */
+      public Builder clearSchemaName() {
+        bitField0_ = (bitField0_ & ~0x00000080);
+        schemaName_ = getDefaultInstance().getSchemaName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string schemaName = 8;</code>
+       *
+       * <pre>
+       ** 变更数据的schemaname*
+       * </pre>
+       */
+      public Builder setSchemaNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000080;
+        schemaName_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object tableName_ = "";
+      /**
+       * <code>optional string tableName = 9;</code>
+       *
+       * <pre>
+       **变更数据的tablename*
+       * </pre>
+       */
+      public boolean hasTableName() {
+        return ((bitField0_ & 0x00000100) == 0x00000100);
+      }
+      /**
+       * <code>optional string tableName = 9;</code>
+       *
+       * <pre>
+       **变更数据的tablename*
+       * </pre>
+       */
+      public java.lang.String getTableName() {
+        java.lang.Object ref = tableName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            tableName_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string tableName = 9;</code>
+       *
+       * <pre>
+       **变更数据的tablename*
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getTableNameBytes() {
+        java.lang.Object ref = tableName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          tableName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string tableName = 9;</code>
+       *
+       * <pre>
+       **变更数据的tablename*
+       * </pre>
+       */
+      public Builder setTableName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000100;
+        tableName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string tableName = 9;</code>
+       *
+       * <pre>
+       **变更数据的tablename*
+       * </pre>
+       */
+      public Builder clearTableName() {
+        bitField0_ = (bitField0_ & ~0x00000100);
+        tableName_ = getDefaultInstance().getTableName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string tableName = 9;</code>
+       *
+       * <pre>
+       **变更数据的tablename*
+       * </pre>
+       */
+      public Builder setTableNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000100;
+        tableName_ = value;
+        onChanged();
+        return this;
+      }
+
+      private long eventLength_ ;
+      /**
+       * <code>optional int64 eventLength = 10;</code>
+       *
+       * <pre>
+       **每个event的长度*
+       * </pre>
+       */
+      public boolean hasEventLength() {
+        return ((bitField0_ & 0x00000200) == 0x00000200);
+      }
+      /**
+       * <code>optional int64 eventLength = 10;</code>
+       *
+       * <pre>
+       **每个event的长度*
+       * </pre>
+       */
+      public long getEventLength() {
+        return eventLength_;
+      }
+      /**
+       * <code>optional int64 eventLength = 10;</code>
+       *
+       * <pre>
+       **每个event的长度*
+       * </pre>
+       */
+      public Builder setEventLength(long value) {
+        bitField0_ |= 0x00000200;
+        eventLength_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 eventLength = 10;</code>
+       *
+       * <pre>
+       **每个event的长度*
+       * </pre>
+       */
+      public Builder clearEventLength() {
+        bitField0_ = (bitField0_ & ~0x00000200);
+        eventLength_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private com.alibaba.otter.canal.protocol.CanalEntry.EventType eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
+       *
+       * <pre>
+       **数据变更类型*
+       * </pre>
+       */
+      public boolean hasEventType() {
+        return ((bitField0_ & 0x00000400) == 0x00000400);
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
+       *
+       * <pre>
+       **数据变更类型*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType() {
+        return eventType_;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
+       *
+       * <pre>
+       **数据变更类型*
+       * </pre>
+       */
+      public Builder setEventType(com.alibaba.otter.canal.protocol.CanalEntry.EventType value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000400;
+        eventType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 11 [default = UPDATE];</code>
+       *
+       * <pre>
+       **数据变更类型*
+       * </pre>
+       */
+      public Builder clearEventType() {
+        bitField0_ = (bitField0_ & ~0x00000400);
+        eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ =
+        java.util.Collections.emptyList();
+      private void ensurePropsIsMutable() {
+        if (!((bitField0_ & 0x00000800) == 0x00000800)) {
+          props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
+          bitField0_ |= 0x00000800;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
+
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+        if (propsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(props_);
+        } else {
+          return propsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public int getPropsCount() {
+        if (propsBuilder_ == null) {
+          return props_.size();
+        } else {
+          return propsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);
+        } else {
+          return propsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.set(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addAllProps(
+          java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, props_);
+          onChanged();
+        } else {
+          propsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder clearProps() {
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000800);
+          onChanged();
+        } else {
+          propsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder removeProps(int index) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.remove(index);
+          onChanged();
+        } else {
+          propsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+          int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);  } else {
+          return propsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+           getPropsOrBuilderList() {
+        if (propsBuilder_ != null) {
+          return propsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(props_);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
+        return getPropsFieldBuilder().addBuilder(
+            com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().addBuilder(
+            index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 12;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> 
+           getPropsBuilderList() {
+        return getPropsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+          getPropsFieldBuilder() {
+        if (propsBuilder_ == null) {
+          propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(
+                  props_,
+                  ((bitField0_ & 0x00000800) == 0x00000800),
+                  getParentForChildren(),
+                  isClean());
+          props_ = null;
+        }
+        return propsBuilder_;
+      }
+
+      private java.lang.Object gtid_ = "";
+      /**
+       * <code>optional string gtid = 13;</code>
+       *
+       * <pre>
+       **当前事务的gitd*
+       * </pre>
+       */
+      public boolean hasGtid() {
+        return ((bitField0_ & 0x00001000) == 0x00001000);
+      }
+      /**
+       * <code>optional string gtid = 13;</code>
+       *
+       * <pre>
+       **当前事务的gitd*
+       * </pre>
+       */
+      public java.lang.String getGtid() {
+        java.lang.Object ref = gtid_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            gtid_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string gtid = 13;</code>
+       *
+       * <pre>
+       **当前事务的gitd*
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getGtidBytes() {
+        java.lang.Object ref = gtid_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          gtid_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string gtid = 13;</code>
+       *
+       * <pre>
+       **当前事务的gitd*
+       * </pre>
+       */
+      public Builder setGtid(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00001000;
+        gtid_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string gtid = 13;</code>
+       *
+       * <pre>
+       **当前事务的gitd*
+       * </pre>
+       */
+      public Builder clearGtid() {
+        bitField0_ = (bitField0_ & ~0x00001000);
+        gtid_ = getDefaultInstance().getGtid();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string gtid = 13;</code>
+       *
+       * <pre>
+       **当前事务的gitd*
+       * </pre>
+       */
+      public Builder setGtidBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00001000;
+        gtid_ = value;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.Header)
     }
 
-    public interface ColumnOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.Column)
-    com.google.protobuf.MessageOrBuilder {
-
-        /**
-         * <code>optional int32 index = 1;</code>
-         *
-         * <pre>
-         * *字段下标*
-         * </pre>
-         */
-        boolean hasIndex();
-
-        /**
-         * <code>optional int32 index = 1;</code>
-         *
-         * <pre>
-         * *字段下标*
-         * </pre>
-         */
-        int getIndex();
-
-        /**
-         * <code>optional int32 sqlType = 2;</code>
-         *
-         * <pre>
-         * *字段java中类型*
-         * </pre>
-         */
-        boolean hasSqlType();
-
-        /**
-         * <code>optional int32 sqlType = 2;</code>
-         *
-         * <pre>
-         * *字段java中类型*
-         * </pre>
-         */
-        int getSqlType();
-
-        /**
-         * <code>optional string name = 3;</code>
-         *
-         * <pre>
-         * *字段名称(忽略大小写)，在mysql中是没有的*
-         * </pre>
-         */
-        boolean hasName();
-
-        /**
-         * <code>optional string name = 3;</code>
-         *
-         * <pre>
-         * *字段名称(忽略大小写)，在mysql中是没有的*
-         * </pre>
-         */
-        java.lang.String getName();
-
-        /**
-         * <code>optional string name = 3;</code>
-         *
-         * <pre>
-         * *字段名称(忽略大小写)，在mysql中是没有的*
-         * </pre>
-         */
-        com.google.protobuf.ByteString getNameBytes();
-
-        /**
-         * <code>optional bool isKey = 4;</code>
-         *
-         * <pre>
-         * *是否是主键*
-         * </pre>
-         */
-        boolean hasIsKey();
-
-        /**
-         * <code>optional bool isKey = 4;</code>
-         *
-         * <pre>
-         * *是否是主键*
-         * </pre>
-         */
-        boolean getIsKey();
-
-        /**
-         * <code>optional bool updated = 5;</code>
-         *
-         * <pre>
-         * *如果EventType=UPDATE,用于标识这个字段值是否有修改*
-         * </pre>
-         */
-        boolean hasUpdated();
-
-        /**
-         * <code>optional bool updated = 5;</code>
-         *
-         * <pre>
-         * *如果EventType=UPDATE,用于标识这个字段值是否有修改*
-         * </pre>
-         */
-        boolean getUpdated();
-
-        /**
-         * <code>optional bool isNull = 6 [default = false];</code>
-         *
-         * <pre>
-         * * 标识是否为空  *
-         * </pre>
-         */
-        boolean hasIsNull();
-
-        /**
-         * <code>optional bool isNull = 6 [default = false];</code>
-         *
-         * <pre>
-         * * 标识是否为空  *
-         * </pre>
-         */
-        boolean getIsNull();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        int getPropsCount();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index);
-
-        /**
-         * <code>optional string value = 8;</code>
-         *
-         * <pre>
-         * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-         * </pre>
-         */
-        boolean hasValue();
-
-        /**
-         * <code>optional string value = 8;</code>
-         *
-         * <pre>
-         * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-         * </pre>
-         */
-        java.lang.String getValue();
-
-        /**
-         * <code>optional string value = 8;</code>
-         *
-         * <pre>
-         * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-         * </pre>
-         */
-        com.google.protobuf.ByteString getValueBytes();
-
-        /**
-         * <code>optional int32 length = 9;</code>
-         *
-         * <pre>
-         * * 对应数据对象原始长度 *
-         * </pre>
-         */
-        boolean hasLength();
-
-        /**
-         * <code>optional int32 length = 9;</code>
-         *
-         * <pre>
-         * * 对应数据对象原始长度 *
-         * </pre>
-         */
-        int getLength();
-
-        /**
-         * <code>optional string mysqlType = 10;</code>
-         *
-         * <pre>
-         * *字段mysql类型*
-         * </pre>
-         */
-        boolean hasMysqlType();
-
-        /**
-         * <code>optional string mysqlType = 10;</code>
-         *
-         * <pre>
-         * *字段mysql类型*
-         * </pre>
-         */
-        java.lang.String getMysqlType();
-
-        /**
-         * <code>optional string mysqlType = 10;</code>
-         *
-         * <pre>
-         * *字段mysql类型*
-         * </pre>
-         */
-        com.google.protobuf.ByteString getMysqlTypeBytes();
+    static {
+      defaultInstance = new Header(true);
+      defaultInstance.initFields();
     }
 
+    // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.Header)
+  }
+
+  public interface ColumnOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.Column)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int32 index = 1;</code>
+     *
+     * <pre>
+     **字段下标*
+     * </pre>
+     */
+    boolean hasIndex();
+    /**
+     * <code>optional int32 index = 1;</code>
+     *
+     * <pre>
+     **字段下标*
+     * </pre>
+     */
+    int getIndex();
+
+    /**
+     * <code>optional int32 sqlType = 2;</code>
+     *
+     * <pre>
+     **字段java中类型*
+     * </pre>
+     */
+    boolean hasSqlType();
+    /**
+     * <code>optional int32 sqlType = 2;</code>
+     *
+     * <pre>
+     **字段java中类型*
+     * </pre>
+     */
+    int getSqlType();
+
+    /**
+     * <code>optional string name = 3;</code>
+     *
+     * <pre>
+     **字段名称(忽略大小写)，在mysql中是没有的*
+     * </pre>
+     */
+    boolean hasName();
+    /**
+     * <code>optional string name = 3;</code>
+     *
+     * <pre>
+     **字段名称(忽略大小写)，在mysql中是没有的*
+     * </pre>
+     */
+    java.lang.String getName();
+    /**
+     * <code>optional string name = 3;</code>
+     *
+     * <pre>
+     **字段名称(忽略大小写)，在mysql中是没有的*
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getNameBytes();
+
+    /**
+     * <code>optional bool isKey = 4;</code>
+     *
+     * <pre>
+     **是否是主键*
+     * </pre>
+     */
+    boolean hasIsKey();
+    /**
+     * <code>optional bool isKey = 4;</code>
+     *
+     * <pre>
+     **是否是主键*
+     * </pre>
+     */
+    boolean getIsKey();
+
+    /**
+     * <code>optional bool updated = 5;</code>
+     *
+     * <pre>
+     **如果EventType=UPDATE,用于标识这个字段值是否有修改*
+     * </pre>
+     */
+    boolean hasUpdated();
+    /**
+     * <code>optional bool updated = 5;</code>
+     *
+     * <pre>
+     **如果EventType=UPDATE,用于标识这个字段值是否有修改*
+     * </pre>
+     */
+    boolean getUpdated();
+
+    /**
+     * <code>optional bool isNull = 6 [default = false];</code>
+     *
+     * <pre>
+     ** 标识是否为空  *
+     * </pre>
+     */
+    boolean hasIsNull();
+    /**
+     * <code>optional bool isNull = 6 [default = false];</code>
+     *
+     * <pre>
+     ** 标识是否为空  *
+     * </pre>
+     */
+    boolean getIsNull();
+
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> 
+        getPropsList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    int getPropsCount();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index);
+
+    /**
+     * <code>optional string value = 8;</code>
+     *
+     * <pre>
+     ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+     * </pre>
+     */
+    boolean hasValue();
+    /**
+     * <code>optional string value = 8;</code>
+     *
+     * <pre>
+     ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+     * </pre>
+     */
+    java.lang.String getValue();
+    /**
+     * <code>optional string value = 8;</code>
+     *
+     * <pre>
+     ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getValueBytes();
+
+    /**
+     * <code>optional int32 length = 9;</code>
+     *
+     * <pre>
+     ** 对应数据对象原始长度 *
+     * </pre>
+     */
+    boolean hasLength();
+    /**
+     * <code>optional int32 length = 9;</code>
+     *
+     * <pre>
+     ** 对应数据对象原始长度 *
+     * </pre>
+     */
+    int getLength();
+
+    /**
+     * <code>optional string mysqlType = 10;</code>
+     *
+     * <pre>
+     **字段mysql类型*
+     * </pre>
+     */
+    boolean hasMysqlType();
+    /**
+     * <code>optional string mysqlType = 10;</code>
+     *
+     * <pre>
+     **字段mysql类型*
+     * </pre>
+     */
+    java.lang.String getMysqlType();
+    /**
+     * <code>optional string mysqlType = 10;</code>
+     *
+     * <pre>
+     **字段mysql类型*
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getMysqlTypeBytes();
+  }
+  /**
+   * Protobuf type {@code com.alibaba.otter.canal.protocol.Column}
+   *
+   * <pre>
+   **每个字段的数据结构*
+   * </pre>
+   */
+  public static final class Column extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.Column)
+      ColumnOrBuilder {
+    // Use Column.newBuilder() to construct.
+    private Column(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private Column(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final Column defaultInstance;
+    public static Column getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public Column getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private Column(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              index_ = input.readInt32();
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              sqlType_ = input.readInt32();
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000004;
+              name_ = bs;
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000008;
+              isKey_ = input.readBool();
+              break;
+            }
+            case 40: {
+              bitField0_ |= 0x00000010;
+              updated_ = input.readBool();
+              break;
+            }
+            case 48: {
+              bitField0_ |= 0x00000020;
+              isNull_ = input.readBool();
+              break;
+            }
+            case 58: {
+              if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
+                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
+                mutable_bitField0_ |= 0x00000040;
+              }
+              props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER, extensionRegistry));
+              break;
+            }
+            case 66: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000040;
+              value_ = bs;
+              break;
+            }
+            case 72: {
+              bitField0_ |= 0x00000080;
+              length_ = input.readInt32();
+              break;
+            }
+            case 82: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000100;
+              mysqlType_ = bs;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
+          props_ = java.util.Collections.unmodifiableList(props_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Column_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Column_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.alibaba.otter.canal.protocol.CanalEntry.Column.class, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<Column> PARSER =
+        new com.google.protobuf.AbstractParser<Column>() {
+      public Column parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new Column(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<Column> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int INDEX_FIELD_NUMBER = 1;
+    private int index_;
+    /**
+     * <code>optional int32 index = 1;</code>
+     *
+     * <pre>
+     **字段下标*
+     * </pre>
+     */
+    public boolean hasIndex() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional int32 index = 1;</code>
+     *
+     * <pre>
+     **字段下标*
+     * </pre>
+     */
+    public int getIndex() {
+      return index_;
+    }
+
+    public static final int SQLTYPE_FIELD_NUMBER = 2;
+    private int sqlType_;
+    /**
+     * <code>optional int32 sqlType = 2;</code>
+     *
+     * <pre>
+     **字段java中类型*
+     * </pre>
+     */
+    public boolean hasSqlType() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional int32 sqlType = 2;</code>
+     *
+     * <pre>
+     **字段java中类型*
+     * </pre>
+     */
+    public int getSqlType() {
+      return sqlType_;
+    }
+
+    public static final int NAME_FIELD_NUMBER = 3;
+    private java.lang.Object name_;
+    /**
+     * <code>optional string name = 3;</code>
+     *
+     * <pre>
+     **字段名称(忽略大小写)，在mysql中是没有的*
+     * </pre>
+     */
+    public boolean hasName() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional string name = 3;</code>
+     *
+     * <pre>
+     **字段名称(忽略大小写)，在mysql中是没有的*
+     * </pre>
+     */
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          name_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string name = 3;</code>
+     *
+     * <pre>
+     **字段名称(忽略大小写)，在mysql中是没有的*
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getNameBytes() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        name_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ISKEY_FIELD_NUMBER = 4;
+    private boolean isKey_;
+    /**
+     * <code>optional bool isKey = 4;</code>
+     *
+     * <pre>
+     **是否是主键*
+     * </pre>
+     */
+    public boolean hasIsKey() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional bool isKey = 4;</code>
+     *
+     * <pre>
+     **是否是主键*
+     * </pre>
+     */
+    public boolean getIsKey() {
+      return isKey_;
+    }
+
+    public static final int UPDATED_FIELD_NUMBER = 5;
+    private boolean updated_;
+    /**
+     * <code>optional bool updated = 5;</code>
+     *
+     * <pre>
+     **如果EventType=UPDATE,用于标识这个字段值是否有修改*
+     * </pre>
+     */
+    public boolean hasUpdated() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional bool updated = 5;</code>
+     *
+     * <pre>
+     **如果EventType=UPDATE,用于标识这个字段值是否有修改*
+     * </pre>
+     */
+    public boolean getUpdated() {
+      return updated_;
+    }
+
+    public static final int ISNULL_FIELD_NUMBER = 6;
+    private boolean isNull_;
+    /**
+     * <code>optional bool isNull = 6 [default = false];</code>
+     *
+     * <pre>
+     ** 标识是否为空  *
+     * </pre>
+     */
+    public boolean hasIsNull() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>optional bool isNull = 6 [default = false];</code>
+     *
+     * <pre>
+     ** 标识是否为空  *
+     * </pre>
+     */
+    public boolean getIsNull() {
+      return isNull_;
+    }
+
+    public static final int PROPS_FIELD_NUMBER = 7;
+    private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public int getPropsCount() {
+      return props_.size();
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+      return props_.get(index);
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index) {
+      return props_.get(index);
+    }
+
+    public static final int VALUE_FIELD_NUMBER = 8;
+    private java.lang.Object value_;
+    /**
+     * <code>optional string value = 8;</code>
+     *
+     * <pre>
+     ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+     * </pre>
+     */
+    public boolean hasValue() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional string value = 8;</code>
+     *
+     * <pre>
+     ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+     * </pre>
+     */
+    public java.lang.String getValue() {
+      java.lang.Object ref = value_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          value_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string value = 8;</code>
+     *
+     * <pre>
+     ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getValueBytes() {
+      java.lang.Object ref = value_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        value_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int LENGTH_FIELD_NUMBER = 9;
+    private int length_;
+    /**
+     * <code>optional int32 length = 9;</code>
+     *
+     * <pre>
+     ** 对应数据对象原始长度 *
+     * </pre>
+     */
+    public boolean hasLength() {
+      return ((bitField0_ & 0x00000080) == 0x00000080);
+    }
+    /**
+     * <code>optional int32 length = 9;</code>
+     *
+     * <pre>
+     ** 对应数据对象原始长度 *
+     * </pre>
+     */
+    public int getLength() {
+      return length_;
+    }
+
+    public static final int MYSQLTYPE_FIELD_NUMBER = 10;
+    private java.lang.Object mysqlType_;
+    /**
+     * <code>optional string mysqlType = 10;</code>
+     *
+     * <pre>
+     **字段mysql类型*
+     * </pre>
+     */
+    public boolean hasMysqlType() {
+      return ((bitField0_ & 0x00000100) == 0x00000100);
+    }
+    /**
+     * <code>optional string mysqlType = 10;</code>
+     *
+     * <pre>
+     **字段mysql类型*
+     * </pre>
+     */
+    public java.lang.String getMysqlType() {
+      java.lang.Object ref = mysqlType_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          mysqlType_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string mysqlType = 10;</code>
+     *
+     * <pre>
+     **字段mysql类型*
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getMysqlTypeBytes() {
+      java.lang.Object ref = mysqlType_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        mysqlType_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private void initFields() {
+      index_ = 0;
+      sqlType_ = 0;
+      name_ = "";
+      isKey_ = false;
+      updated_ = false;
+      isNull_ = false;
+      props_ = java.util.Collections.emptyList();
+      value_ = "";
+      length_ = 0;
+      mysqlType_ = "";
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt32(1, index_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt32(2, sqlType_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeBytes(3, getNameBytes());
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeBool(4, isKey_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeBool(5, updated_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeBool(6, isNull_);
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        output.writeMessage(7, props_.get(i));
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeBytes(8, getValueBytes());
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        output.writeInt32(9, length_);
+      }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        output.writeBytes(10, getMysqlTypeBytes());
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(1, index_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(2, sqlType_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(3, getNameBytes());
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(4, isKey_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(5, updated_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(6, isNull_);
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(7, props_.get(i));
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(8, getValueBytes());
+      }
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(9, length_);
+      }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(10, getMysqlTypeBytes());
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Column prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
     /**
      * Protobuf type {@code com.alibaba.otter.canal.protocol.Column}
      *
      * <pre>
-     * *每个字段的数据结构*
+     **每个字段的数据结构*
      * </pre>
      */
-    public static final class Column extends com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.Column)
-    ColumnOrBuilder {
-
-        // Use Column.newBuilder() to construct.
-        private Column(com.google.protobuf.GeneratedMessage.Builder<?> builder){
-            super(builder);
-            this.unknownFields = builder.getUnknownFields();
-        }
-
-        private Column(boolean noInit){
-            this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance();
-        }
-
-        private static final Column defaultInstance;
-
-        public static Column getDefaultInstance() {
-            return defaultInstance;
-        }
-
-        public Column getDefaultInstanceForType() {
-            return defaultInstance;
-        }
-
-        private final com.google.protobuf.UnknownFieldSet unknownFields;
-
-        @java.lang.Override
-        public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
-            return this.unknownFields;
-        }
-
-        private Column(com.google.protobuf.CodedInputStream input,
-                       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                   throws com.google.protobuf.InvalidProtocolBufferException{
-            initFields();
-            int mutable_bitField0_ = 0;
-            com.google.protobuf.UnknownFieldSet.Builder unknownFields = com.google.protobuf.UnknownFieldSet.newBuilder();
-            try {
-                boolean done = false;
-                while (!done) {
-                    int tag = input.readTag();
-                    switch (tag) {
-                        case 0:
-                            done = true;
-                            break;
-                        default: {
-                            if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                                done = true;
-                            }
-                            break;
-                        }
-                        case 8: {
-                            bitField0_ |= 0x00000001;
-                            index_ = input.readInt32();
-                            break;
-                        }
-                        case 16: {
-                            bitField0_ |= 0x00000002;
-                            sqlType_ = input.readInt32();
-                            break;
-                        }
-                        case 26: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000004;
-                            name_ = bs;
-                            break;
-                        }
-                        case 32: {
-                            bitField0_ |= 0x00000008;
-                            isKey_ = input.readBool();
-                            break;
-                        }
-                        case 40: {
-                            bitField0_ |= 0x00000010;
-                            updated_ = input.readBool();
-                            break;
-                        }
-                        case 48: {
-                            bitField0_ |= 0x00000020;
-                            isNull_ = input.readBool();
-                            break;
-                        }
-                        case 58: {
-                            if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
-                                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
-                                mutable_bitField0_ |= 0x00000040;
-                            }
-                            props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER,
-                                extensionRegistry));
-                            break;
-                        }
-                        case 66: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000040;
-                            value_ = bs;
-                            break;
-                        }
-                        case 72: {
-                            bitField0_ |= 0x00000080;
-                            length_ = input.readInt32();
-                            break;
-                        }
-                        case 82: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000100;
-                            mysqlType_ = bs;
-                            break;
-                        }
-                    }
-                }
-            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                throw e.setUnfinishedMessage(this);
-            } catch (java.io.IOException e) {
-                throw new com.google.protobuf.InvalidProtocolBufferException(e.getMessage()).setUnfinishedMessage(this);
-            } finally {
-                if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
-                    props_ = java.util.Collections.unmodifiableList(props_);
-                }
-                this.unknownFields = unknownFields.build();
-                makeExtensionsImmutable();
-            }
-        }
-
-        public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Column_descriptor;
-        }
-
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Column_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.Column.class,
-                com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder.class);
-        }
-
-        public static com.google.protobuf.Parser<Column> PARSER = new com.google.protobuf.AbstractParser<Column>() {
-
-                                                                    public Column parsePartialFrom(com.google.protobuf.CodedInputStream input,
-                                                                                                   com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                               throws com.google.protobuf.InvalidProtocolBufferException {
-                                                                        return new Column(input, extensionRegistry);
-                                                                    }
-                                                                };
-
-        @java.lang.Override
-        public com.google.protobuf.Parser<Column> getParserForType() {
-            return PARSER;
-        }
-
-        private int             bitField0_;
-        public static final int INDEX_FIELD_NUMBER = 1;
-        private int             index_;
-
-        /**
-         * <code>optional int32 index = 1;</code>
-         *
-         * <pre>
-         * *字段下标*
-         * </pre>
-         */
-        public boolean hasIndex() {
-            return ((bitField0_ & 0x00000001) == 0x00000001);
-        }
-
-        /**
-         * <code>optional int32 index = 1;</code>
-         *
-         * <pre>
-         * *字段下标*
-         * </pre>
-         */
-        public int getIndex() {
-            return index_;
-        }
-
-        public static final int SQLTYPE_FIELD_NUMBER = 2;
-        private int             sqlType_;
-
-        /**
-         * <code>optional int32 sqlType = 2;</code>
-         *
-         * <pre>
-         * *字段java中类型*
-         * </pre>
-         */
-        public boolean hasSqlType() {
-            return ((bitField0_ & 0x00000002) == 0x00000002);
-        }
-
-        /**
-         * <code>optional int32 sqlType = 2;</code>
-         *
-         * <pre>
-         * *字段java中类型*
-         * </pre>
-         */
-        public int getSqlType() {
-            return sqlType_;
-        }
-
-        public static final int  NAME_FIELD_NUMBER = 3;
-        private java.lang.Object name_;
-
-        /**
-         * <code>optional string name = 3;</code>
-         *
-         * <pre>
-         * *字段名称(忽略大小写)，在mysql中是没有的*
-         * </pre>
-         */
-        public boolean hasName() {
-            return ((bitField0_ & 0x00000004) == 0x00000004);
-        }
-
-        /**
-         * <code>optional string name = 3;</code>
-         *
-         * <pre>
-         * *字段名称(忽略大小写)，在mysql中是没有的*
-         * </pre>
-         */
-        public java.lang.String getName() {
-            java.lang.Object ref = name_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    name_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string name = 3;</code>
-         *
-         * <pre>
-         * *字段名称(忽略大小写)，在mysql中是没有的*
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getNameBytes() {
-            java.lang.Object ref = name_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                name_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        public static final int ISKEY_FIELD_NUMBER = 4;
-        private boolean         isKey_;
-
-        /**
-         * <code>optional bool isKey = 4;</code>
-         *
-         * <pre>
-         * *是否是主键*
-         * </pre>
-         */
-        public boolean hasIsKey() {
-            return ((bitField0_ & 0x00000008) == 0x00000008);
-        }
-
-        /**
-         * <code>optional bool isKey = 4;</code>
-         *
-         * <pre>
-         * *是否是主键*
-         * </pre>
-         */
-        public boolean getIsKey() {
-            return isKey_;
-        }
-
-        public static final int UPDATED_FIELD_NUMBER = 5;
-        private boolean         updated_;
-
-        /**
-         * <code>optional bool updated = 5;</code>
-         *
-         * <pre>
-         * *如果EventType=UPDATE,用于标识这个字段值是否有修改*
-         * </pre>
-         */
-        public boolean hasUpdated() {
-            return ((bitField0_ & 0x00000010) == 0x00000010);
-        }
-
-        /**
-         * <code>optional bool updated = 5;</code>
-         *
-         * <pre>
-         * *如果EventType=UPDATE,用于标识这个字段值是否有修改*
-         * </pre>
-         */
-        public boolean getUpdated() {
-            return updated_;
-        }
-
-        public static final int ISNULL_FIELD_NUMBER = 6;
-        private boolean         isNull_;
-
-        /**
-         * <code>optional bool isNull = 6 [default = false];</code>
-         *
-         * <pre>
-         * * 标识是否为空  *
-         * </pre>
-         */
-        public boolean hasIsNull() {
-            return ((bitField0_ & 0x00000020) == 0x00000020);
-        }
-
-        /**
-         * <code>optional bool isNull = 6 [default = false];</code>
-         *
-         * <pre>
-         * * 标识是否为空  *
-         * </pre>
-         */
-        public boolean getIsNull() {
-            return isNull_;
-        }
-
-        public static final int                                                  PROPS_FIELD_NUMBER = 7;
-        private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public int getPropsCount() {
-            return props_.size();
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-            return props_.get(index);
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-            return props_.get(index);
-        }
-
-        public static final int  VALUE_FIELD_NUMBER = 8;
-        private java.lang.Object value_;
-
-        /**
-         * <code>optional string value = 8;</code>
-         *
-         * <pre>
-         * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-         * </pre>
-         */
-        public boolean hasValue() {
-            return ((bitField0_ & 0x00000040) == 0x00000040);
-        }
-
-        /**
-         * <code>optional string value = 8;</code>
-         *
-         * <pre>
-         * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-         * </pre>
-         */
-        public java.lang.String getValue() {
-            java.lang.Object ref = value_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    value_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string value = 8;</code>
-         *
-         * <pre>
-         * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getValueBytes() {
-            java.lang.Object ref = value_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                value_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        public static final int LENGTH_FIELD_NUMBER = 9;
-        private int             length_;
-
-        /**
-         * <code>optional int32 length = 9;</code>
-         *
-         * <pre>
-         * * 对应数据对象原始长度 *
-         * </pre>
-         */
-        public boolean hasLength() {
-            return ((bitField0_ & 0x00000080) == 0x00000080);
-        }
-
-        /**
-         * <code>optional int32 length = 9;</code>
-         *
-         * <pre>
-         * * 对应数据对象原始长度 *
-         * </pre>
-         */
-        public int getLength() {
-            return length_;
-        }
-
-        public static final int  MYSQLTYPE_FIELD_NUMBER = 10;
-        private java.lang.Object mysqlType_;
-
-        /**
-         * <code>optional string mysqlType = 10;</code>
-         *
-         * <pre>
-         * *字段mysql类型*
-         * </pre>
-         */
-        public boolean hasMysqlType() {
-            return ((bitField0_ & 0x00000100) == 0x00000100);
-        }
-
-        /**
-         * <code>optional string mysqlType = 10;</code>
-         *
-         * <pre>
-         * *字段mysql类型*
-         * </pre>
-         */
-        public java.lang.String getMysqlType() {
-            java.lang.Object ref = mysqlType_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    mysqlType_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string mysqlType = 10;</code>
-         *
-         * <pre>
-         * *字段mysql类型*
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getMysqlTypeBytes() {
-            java.lang.Object ref = mysqlType_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                mysqlType_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        private void initFields() {
-            index_ = 0;
-            sqlType_ = 0;
-            name_ = "";
-            isKey_ = false;
-            updated_ = false;
-            isNull_ = false;
-            props_ = java.util.Collections.emptyList();
-            value_ = "";
-            length_ = 0;
-            mysqlType_ = "";
-        }
-
-        private byte memoizedIsInitialized = -1;
-
-        public final boolean isInitialized() {
-            byte isInitialized = memoizedIsInitialized;
-            if (isInitialized == 1) return true;
-            if (isInitialized == 0) return false;
-
-            memoizedIsInitialized = 1;
-            return true;
-        }
-
-        public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
-            getSerializedSize();
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                output.writeInt32(1, index_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                output.writeInt32(2, sqlType_);
-            }
-            if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                output.writeBytes(3, getNameBytes());
-            }
-            if (((bitField0_ & 0x00000008) == 0x00000008)) {
-                output.writeBool(4, isKey_);
-            }
-            if (((bitField0_ & 0x00000010) == 0x00000010)) {
-                output.writeBool(5, updated_);
-            }
-            if (((bitField0_ & 0x00000020) == 0x00000020)) {
-                output.writeBool(6, isNull_);
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                output.writeMessage(7, props_.get(i));
-            }
-            if (((bitField0_ & 0x00000040) == 0x00000040)) {
-                output.writeBytes(8, getValueBytes());
-            }
-            if (((bitField0_ & 0x00000080) == 0x00000080)) {
-                output.writeInt32(9, length_);
-            }
-            if (((bitField0_ & 0x00000100) == 0x00000100)) {
-                output.writeBytes(10, getMysqlTypeBytes());
-            }
-            getUnknownFields().writeTo(output);
-        }
-
-        private int memoizedSerializedSize = -1;
-
-        public int getSerializedSize() {
-            int size = memoizedSerializedSize;
-            if (size != -1) return size;
-
-            size = 0;
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt32Size(1, index_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt32Size(2, sqlType_);
-            }
-            if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(3, getNameBytes());
-            }
-            if (((bitField0_ & 0x00000008) == 0x00000008)) {
-                size += com.google.protobuf.CodedOutputStream.computeBoolSize(4, isKey_);
-            }
-            if (((bitField0_ & 0x00000010) == 0x00000010)) {
-                size += com.google.protobuf.CodedOutputStream.computeBoolSize(5, updated_);
-            }
-            if (((bitField0_ & 0x00000020) == 0x00000020)) {
-                size += com.google.protobuf.CodedOutputStream.computeBoolSize(6, isNull_);
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                size += com.google.protobuf.CodedOutputStream.computeMessageSize(7, props_.get(i));
-            }
-            if (((bitField0_ & 0x00000040) == 0x00000040)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(8, getValueBytes());
-            }
-            if (((bitField0_ & 0x00000080) == 0x00000080)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt32Size(9, length_);
-            }
-            if (((bitField0_ & 0x00000100) == 0x00000100)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(10, getMysqlTypeBytes());
-            }
-            size += getUnknownFields().getSerializedSize();
-            memoizedSerializedSize = size;
-            return size;
-        }
-
-        private static final long serialVersionUID = 0L;
-
-        @java.lang.Override
-        protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-            return super.writeReplace();
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(com.google.protobuf.ByteString data)
-                                                                                                                       throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(com.google.protobuf.ByteString data,
-                                                                                   com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                               throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(byte[] data)
-                                                                                               throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(byte[] data,
-                                                                                   com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                               throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(java.io.InputStream input)
-                                                                                                             throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(java.io.InputStream input,
-                                                                                   com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                               throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseDelimitedFrom(java.io.InputStream input)
-                                                                                                                      throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseDelimitedFrom(java.io.InputStream input,
-                                                                                            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                        throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(com.google.protobuf.CodedInputStream input)
-                                                                                                                              throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Column parseFrom(com.google.protobuf.CodedInputStream input,
-                                                                                   com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                               throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static Builder newBuilder() {
-            return Builder.create();
-        }
-
-        public Builder newBuilderForType() {
-            return newBuilder();
-        }
-
-        public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Column prototype) {
-            return newBuilder().mergeFrom(prototype);
-        }
-
-        public Builder toBuilder() {
-            return newBuilder(this);
-        }
-
-        @java.lang.Override
-        protected Builder newBuilderForType(com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-            Builder builder = new Builder(parent);
-            return builder;
-        }
-
-        /**
-         * Protobuf type {@code com.alibaba.otter.canal.protocol.Column}
-         *
-         * <pre>
-         * *每个字段的数据结构*
-         * </pre>
-         */
-        public static final class Builder extends com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:com.alibaba.otter.canal.protocol.Column)
         com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder {
-
-            public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Column_descriptor;
-            }
-
-            protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Column_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.Column.class,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder.class);
-            }
-
-            // Construct using
-            // com.alibaba.otter.canal.protocol.CanalEntry.Column.newBuilder()
-            private Builder(){
-                maybeForceBuilderInitialization();
-            }
-
-            private Builder(com.google.protobuf.GeneratedMessage.BuilderParent parent){
-                super(parent);
-                maybeForceBuilderInitialization();
-            }
-
-            private void maybeForceBuilderInitialization() {
-                if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-                    getPropsFieldBuilder();
-                }
-            }
-
-            private static Builder create() {
-                return new Builder();
-            }
-
-            public Builder clear() {
-                super.clear();
-                index_ = 0;
-                bitField0_ = (bitField0_ & ~0x00000001);
-                sqlType_ = 0;
-                bitField0_ = (bitField0_ & ~0x00000002);
-                name_ = "";
-                bitField0_ = (bitField0_ & ~0x00000004);
-                isKey_ = false;
-                bitField0_ = (bitField0_ & ~0x00000008);
-                updated_ = false;
-                bitField0_ = (bitField0_ & ~0x00000010);
-                isNull_ = false;
-                bitField0_ = (bitField0_ & ~0x00000020);
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000040);
-                } else {
-                    propsBuilder_.clear();
-                }
-                value_ = "";
-                bitField0_ = (bitField0_ & ~0x00000080);
-                length_ = 0;
-                bitField0_ = (bitField0_ & ~0x00000100);
-                mysqlType_ = "";
-                bitField0_ = (bitField0_ & ~0x00000200);
-                return this;
-            }
-
-            public Builder clone() {
-                return create().mergeFrom(buildPartial());
-            }
-
-            public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Column_descriptor;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Column getDefaultInstanceForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance();
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Column build() {
-                com.alibaba.otter.canal.protocol.CanalEntry.Column result = buildPartial();
-                if (!result.isInitialized()) {
-                    throw newUninitializedMessageException(result);
-                }
-                return result;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Column buildPartial() {
-                com.alibaba.otter.canal.protocol.CanalEntry.Column result = new com.alibaba.otter.canal.protocol.CanalEntry.Column(this);
-                int from_bitField0_ = bitField0_;
-                int to_bitField0_ = 0;
-                if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-                    to_bitField0_ |= 0x00000001;
-                }
-                result.index_ = index_;
-                if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-                    to_bitField0_ |= 0x00000002;
-                }
-                result.sqlType_ = sqlType_;
-                if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-                    to_bitField0_ |= 0x00000004;
-                }
-                result.name_ = name_;
-                if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-                    to_bitField0_ |= 0x00000008;
-                }
-                result.isKey_ = isKey_;
-                if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
-                    to_bitField0_ |= 0x00000010;
-                }
-                result.updated_ = updated_;
-                if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
-                    to_bitField0_ |= 0x00000020;
-                }
-                result.isNull_ = isNull_;
-                if (propsBuilder_ == null) {
-                    if (((bitField0_ & 0x00000040) == 0x00000040)) {
-                        props_ = java.util.Collections.unmodifiableList(props_);
-                        bitField0_ = (bitField0_ & ~0x00000040);
-                    }
-                    result.props_ = props_;
-                } else {
-                    result.props_ = propsBuilder_.build();
-                }
-                if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
-                    to_bitField0_ |= 0x00000040;
-                }
-                result.value_ = value_;
-                if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
-                    to_bitField0_ |= 0x00000080;
-                }
-                result.length_ = length_;
-                if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
-                    to_bitField0_ |= 0x00000100;
-                }
-                result.mysqlType_ = mysqlType_;
-                result.bitField0_ = to_bitField0_;
-                onBuilt();
-                return result;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.Message other) {
-                if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.Column) {
-                    return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.Column) other);
-                } else {
-                    super.mergeFrom(other);
-                    return this;
-                }
-            }
-
-            public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.Column other) {
-                if (other == com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance()) return this;
-                if (other.hasIndex()) {
-                    setIndex(other.getIndex());
-                }
-                if (other.hasSqlType()) {
-                    setSqlType(other.getSqlType());
-                }
-                if (other.hasName()) {
-                    bitField0_ |= 0x00000004;
-                    name_ = other.name_;
-                    onChanged();
-                }
-                if (other.hasIsKey()) {
-                    setIsKey(other.getIsKey());
-                }
-                if (other.hasUpdated()) {
-                    setUpdated(other.getUpdated());
-                }
-                if (other.hasIsNull()) {
-                    setIsNull(other.getIsNull());
-                }
-                if (propsBuilder_ == null) {
-                    if (!other.props_.isEmpty()) {
-                        if (props_.isEmpty()) {
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000040);
-                        } else {
-                            ensurePropsIsMutable();
-                            props_.addAll(other.props_);
-                        }
-                        onChanged();
-                    }
-                } else {
-                    if (!other.props_.isEmpty()) {
-                        if (propsBuilder_.isEmpty()) {
-                            propsBuilder_.dispose();
-                            propsBuilder_ = null;
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000040);
-                            propsBuilder_ = com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ? getPropsFieldBuilder() : null;
-                        } else {
-                            propsBuilder_.addAllMessages(other.props_);
-                        }
-                    }
-                }
-                if (other.hasValue()) {
-                    bitField0_ |= 0x00000080;
-                    value_ = other.value_;
-                    onChanged();
-                }
-                if (other.hasLength()) {
-                    setLength(other.getLength());
-                }
-                if (other.hasMysqlType()) {
-                    bitField0_ |= 0x00000200;
-                    mysqlType_ = other.mysqlType_;
-                    onChanged();
-                }
-                this.mergeUnknownFields(other.getUnknownFields());
-                return this;
-            }
-
-            public final boolean isInitialized() {
-                return true;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
-                                     com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                 throws java.io.IOException {
-                com.alibaba.otter.canal.protocol.CanalEntry.Column parsedMessage = null;
-                try {
-                    parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                    parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.Column) e.getUnfinishedMessage();
-                    throw e;
-                } finally {
-                    if (parsedMessage != null) {
-                        mergeFrom(parsedMessage);
-                    }
-                }
-                return this;
-            }
-
-            private int bitField0_;
-
-            private int index_;
-
-            /**
-             * <code>optional int32 index = 1;</code>
-             *
-             * <pre>
-             * *字段下标*
-             * </pre>
-             */
-            public boolean hasIndex() {
-                return ((bitField0_ & 0x00000001) == 0x00000001);
-            }
-
-            /**
-             * <code>optional int32 index = 1;</code>
-             *
-             * <pre>
-             * *字段下标*
-             * </pre>
-             */
-            public int getIndex() {
-                return index_;
-            }
-
-            /**
-             * <code>optional int32 index = 1;</code>
-             *
-             * <pre>
-             * *字段下标*
-             * </pre>
-             */
-            public Builder setIndex(int value) {
-                bitField0_ |= 0x00000001;
-                index_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int32 index = 1;</code>
-             *
-             * <pre>
-             * *字段下标*
-             * </pre>
-             */
-            public Builder clearIndex() {
-                bitField0_ = (bitField0_ & ~0x00000001);
-                index_ = 0;
-                onChanged();
-                return this;
-            }
-
-            private int sqlType_;
-
-            /**
-             * <code>optional int32 sqlType = 2;</code>
-             *
-             * <pre>
-             * *字段java中类型*
-             * </pre>
-             */
-            public boolean hasSqlType() {
-                return ((bitField0_ & 0x00000002) == 0x00000002);
-            }
-
-            /**
-             * <code>optional int32 sqlType = 2;</code>
-             *
-             * <pre>
-             * *字段java中类型*
-             * </pre>
-             */
-            public int getSqlType() {
-                return sqlType_;
-            }
-
-            /**
-             * <code>optional int32 sqlType = 2;</code>
-             *
-             * <pre>
-             * *字段java中类型*
-             * </pre>
-             */
-            public Builder setSqlType(int value) {
-                bitField0_ |= 0x00000002;
-                sqlType_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int32 sqlType = 2;</code>
-             *
-             * <pre>
-             * *字段java中类型*
-             * </pre>
-             */
-            public Builder clearSqlType() {
-                bitField0_ = (bitField0_ & ~0x00000002);
-                sqlType_ = 0;
-                onChanged();
-                return this;
-            }
-
-            private java.lang.Object name_ = "";
-
-            /**
-             * <code>optional string name = 3;</code>
-             *
-             * <pre>
-             * *字段名称(忽略大小写)，在mysql中是没有的*
-             * </pre>
-             */
-            public boolean hasName() {
-                return ((bitField0_ & 0x00000004) == 0x00000004);
-            }
-
-            /**
-             * <code>optional string name = 3;</code>
-             *
-             * <pre>
-             * *字段名称(忽略大小写)，在mysql中是没有的*
-             * </pre>
-             */
-            public java.lang.String getName() {
-                java.lang.Object ref = name_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        name_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string name = 3;</code>
-             *
-             * <pre>
-             * *字段名称(忽略大小写)，在mysql中是没有的*
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getNameBytes() {
-                java.lang.Object ref = name_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    name_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string name = 3;</code>
-             *
-             * <pre>
-             * *字段名称(忽略大小写)，在mysql中是没有的*
-             * </pre>
-             */
-            public Builder setName(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000004;
-                name_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string name = 3;</code>
-             *
-             * <pre>
-             * *字段名称(忽略大小写)，在mysql中是没有的*
-             * </pre>
-             */
-            public Builder clearName() {
-                bitField0_ = (bitField0_ & ~0x00000004);
-                name_ = getDefaultInstance().getName();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string name = 3;</code>
-             *
-             * <pre>
-             * *字段名称(忽略大小写)，在mysql中是没有的*
-             * </pre>
-             */
-            public Builder setNameBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000004;
-                name_ = value;
-                onChanged();
-                return this;
-            }
-
-            private boolean isKey_;
-
-            /**
-             * <code>optional bool isKey = 4;</code>
-             *
-             * <pre>
-             * *是否是主键*
-             * </pre>
-             */
-            public boolean hasIsKey() {
-                return ((bitField0_ & 0x00000008) == 0x00000008);
-            }
-
-            /**
-             * <code>optional bool isKey = 4;</code>
-             *
-             * <pre>
-             * *是否是主键*
-             * </pre>
-             */
-            public boolean getIsKey() {
-                return isKey_;
-            }
-
-            /**
-             * <code>optional bool isKey = 4;</code>
-             *
-             * <pre>
-             * *是否是主键*
-             * </pre>
-             */
-            public Builder setIsKey(boolean value) {
-                bitField0_ |= 0x00000008;
-                isKey_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional bool isKey = 4;</code>
-             *
-             * <pre>
-             * *是否是主键*
-             * </pre>
-             */
-            public Builder clearIsKey() {
-                bitField0_ = (bitField0_ & ~0x00000008);
-                isKey_ = false;
-                onChanged();
-                return this;
-            }
-
-            private boolean updated_;
-
-            /**
-             * <code>optional bool updated = 5;</code>
-             *
-             * <pre>
-             * *如果EventType=UPDATE,用于标识这个字段值是否有修改*
-             * </pre>
-             */
-            public boolean hasUpdated() {
-                return ((bitField0_ & 0x00000010) == 0x00000010);
-            }
-
-            /**
-             * <code>optional bool updated = 5;</code>
-             *
-             * <pre>
-             * *如果EventType=UPDATE,用于标识这个字段值是否有修改*
-             * </pre>
-             */
-            public boolean getUpdated() {
-                return updated_;
-            }
-
-            /**
-             * <code>optional bool updated = 5;</code>
-             *
-             * <pre>
-             * *如果EventType=UPDATE,用于标识这个字段值是否有修改*
-             * </pre>
-             */
-            public Builder setUpdated(boolean value) {
-                bitField0_ |= 0x00000010;
-                updated_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional bool updated = 5;</code>
-             *
-             * <pre>
-             * *如果EventType=UPDATE,用于标识这个字段值是否有修改*
-             * </pre>
-             */
-            public Builder clearUpdated() {
-                bitField0_ = (bitField0_ & ~0x00000010);
-                updated_ = false;
-                onChanged();
-                return this;
-            }
-
-            private boolean isNull_;
-
-            /**
-             * <code>optional bool isNull = 6 [default = false];</code>
-             *
-             * <pre>
-             * * 标识是否为空  *
-             * </pre>
-             */
-            public boolean hasIsNull() {
-                return ((bitField0_ & 0x00000020) == 0x00000020);
-            }
-
-            /**
-             * <code>optional bool isNull = 6 [default = false];</code>
-             *
-             * <pre>
-             * * 标识是否为空  *
-             * </pre>
-             */
-            public boolean getIsNull() {
-                return isNull_;
-            }
-
-            /**
-             * <code>optional bool isNull = 6 [default = false];</code>
-             *
-             * <pre>
-             * * 标识是否为空  *
-             * </pre>
-             */
-            public Builder setIsNull(boolean value) {
-                bitField0_ |= 0x00000020;
-                isNull_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional bool isNull = 6 [default = false];</code>
-             *
-             * <pre>
-             * * 标识是否为空  *
-             * </pre>
-             */
-            public Builder clearIsNull() {
-                bitField0_ = (bitField0_ & ~0x00000020);
-                isNull_ = false;
-                onChanged();
-                return this;
-            }
-
-            private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ = java.util.Collections.emptyList();
-
-            private void ensurePropsIsMutable() {
-                if (!((bitField0_ & 0x00000040) == 0x00000040)) {
-                    props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
-                    bitField0_ |= 0x00000040;
-                }
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-                if (propsBuilder_ == null) {
-                    return java.util.Collections.unmodifiableList(props_);
-                } else {
-                    return propsBuilder_.getMessageList();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public int getPropsCount() {
-                if (propsBuilder_ == null) {
-                    return props_.size();
-                } else {
-                    return propsBuilder_.getCount();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessage(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.set(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.set(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addAllProps(java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    com.google.protobuf.AbstractMessageLite.Builder.addAll(values, props_);
-                    onChanged();
-                } else {
-                    propsBuilder_.addAllMessages(values);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder clearProps() {
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000040);
-                    onChanged();
-                } else {
-                    propsBuilder_.clear();
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder removeProps(int index) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.remove(index);
-                    onChanged();
-                } else {
-                    propsBuilder_.remove(index);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(int index) {
-                return getPropsFieldBuilder().getBuilder(index);
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessageOrBuilder(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-                if (propsBuilder_ != null) {
-                    return propsBuilder_.getMessageOrBuilderList();
-                } else {
-                    return java.util.Collections.unmodifiableList(props_);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
-                return getPropsFieldBuilder().addBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(int index) {
-                return getPropsFieldBuilder().addBuilder(index,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> getPropsBuilderList() {
-                return getPropsFieldBuilder().getBuilderList();
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsFieldBuilder() {
-                if (propsBuilder_ == null) {
-                    propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(props_,
-                        ((bitField0_ & 0x00000040) == 0x00000040),
-                        getParentForChildren(),
-                        isClean());
-                    props_ = null;
-                }
-                return propsBuilder_;
-            }
-
-            private java.lang.Object value_ = "";
-
-            /**
-             * <code>optional string value = 8;</code>
-             *
-             * <pre>
-             * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-             * </pre>
-             */
-            public boolean hasValue() {
-                return ((bitField0_ & 0x00000080) == 0x00000080);
-            }
-
-            /**
-             * <code>optional string value = 8;</code>
-             *
-             * <pre>
-             * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-             * </pre>
-             */
-            public java.lang.String getValue() {
-                java.lang.Object ref = value_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        value_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string value = 8;</code>
-             *
-             * <pre>
-             * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getValueBytes() {
-                java.lang.Object ref = value_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    value_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string value = 8;</code>
-             *
-             * <pre>
-             * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-             * </pre>
-             */
-            public Builder setValue(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000080;
-                value_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string value = 8;</code>
-             *
-             * <pre>
-             * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-             * </pre>
-             */
-            public Builder clearValue() {
-                bitField0_ = (bitField0_ & ~0x00000080);
-                value_ = getDefaultInstance().getValue();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string value = 8;</code>
-             *
-             * <pre>
-             * * 字段值,timestamp,Datetime是一个时间格式的文本 *
-             * </pre>
-             */
-            public Builder setValueBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000080;
-                value_ = value;
-                onChanged();
-                return this;
-            }
-
-            private int length_;
-
-            /**
-             * <code>optional int32 length = 9;</code>
-             *
-             * <pre>
-             * * 对应数据对象原始长度 *
-             * </pre>
-             */
-            public boolean hasLength() {
-                return ((bitField0_ & 0x00000100) == 0x00000100);
-            }
-
-            /**
-             * <code>optional int32 length = 9;</code>
-             *
-             * <pre>
-             * * 对应数据对象原始长度 *
-             * </pre>
-             */
-            public int getLength() {
-                return length_;
-            }
-
-            /**
-             * <code>optional int32 length = 9;</code>
-             *
-             * <pre>
-             * * 对应数据对象原始长度 *
-             * </pre>
-             */
-            public Builder setLength(int value) {
-                bitField0_ |= 0x00000100;
-                length_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int32 length = 9;</code>
-             *
-             * <pre>
-             * * 对应数据对象原始长度 *
-             * </pre>
-             */
-            public Builder clearLength() {
-                bitField0_ = (bitField0_ & ~0x00000100);
-                length_ = 0;
-                onChanged();
-                return this;
-            }
-
-            private java.lang.Object mysqlType_ = "";
-
-            /**
-             * <code>optional string mysqlType = 10;</code>
-             *
-             * <pre>
-             * *字段mysql类型*
-             * </pre>
-             */
-            public boolean hasMysqlType() {
-                return ((bitField0_ & 0x00000200) == 0x00000200);
-            }
-
-            /**
-             * <code>optional string mysqlType = 10;</code>
-             *
-             * <pre>
-             * *字段mysql类型*
-             * </pre>
-             */
-            public java.lang.String getMysqlType() {
-                java.lang.Object ref = mysqlType_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        mysqlType_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string mysqlType = 10;</code>
-             *
-             * <pre>
-             * *字段mysql类型*
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getMysqlTypeBytes() {
-                java.lang.Object ref = mysqlType_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    mysqlType_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string mysqlType = 10;</code>
-             *
-             * <pre>
-             * *字段mysql类型*
-             * </pre>
-             */
-            public Builder setMysqlType(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000200;
-                mysqlType_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string mysqlType = 10;</code>
-             *
-             * <pre>
-             * *字段mysql类型*
-             * </pre>
-             */
-            public Builder clearMysqlType() {
-                bitField0_ = (bitField0_ & ~0x00000200);
-                mysqlType_ = getDefaultInstance().getMysqlType();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string mysqlType = 10;</code>
-             *
-             * <pre>
-             * *字段mysql类型*
-             * </pre>
-             */
-            public Builder setMysqlTypeBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000200;
-                mysqlType_ = value;
-                onChanged();
-                return this;
-            }
-
-            // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.Column)
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Column_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Column_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.alibaba.otter.canal.protocol.CanalEntry.Column.class, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder.class);
+      }
+
+      // Construct using com.alibaba.otter.canal.protocol.CanalEntry.Column.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getPropsFieldBuilder();
         }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
 
-        static {
-            defaultInstance = new Column(true);
-            defaultInstance.initFields();
+      public Builder clear() {
+        super.clear();
+        index_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        sqlType_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        name_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
+        isKey_ = false;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        updated_ = false;
+        bitField0_ = (bitField0_ & ~0x00000010);
+        isNull_ = false;
+        bitField0_ = (bitField0_ & ~0x00000020);
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000040);
+        } else {
+          propsBuilder_.clear();
         }
+        value_ = "";
+        bitField0_ = (bitField0_ & ~0x00000080);
+        length_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000100);
+        mysqlType_ = "";
+        bitField0_ = (bitField0_ & ~0x00000200);
+        return this;
+      }
 
-        // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.Column)
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Column_descriptor;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.Column getDefaultInstanceForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance();
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.Column build() {
+        com.alibaba.otter.canal.protocol.CanalEntry.Column result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.Column buildPartial() {
+        com.alibaba.otter.canal.protocol.CanalEntry.Column result = new com.alibaba.otter.canal.protocol.CanalEntry.Column(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.index_ = index_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.sqlType_ = sqlType_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.name_ = name_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.isKey_ = isKey_;
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.updated_ = updated_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        result.isNull_ = isNull_;
+        if (propsBuilder_ == null) {
+          if (((bitField0_ & 0x00000040) == 0x00000040)) {
+            props_ = java.util.Collections.unmodifiableList(props_);
+            bitField0_ = (bitField0_ & ~0x00000040);
+          }
+          result.props_ = props_;
+        } else {
+          result.props_ = propsBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        result.value_ = value_;
+        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
+          to_bitField0_ |= 0x00000080;
+        }
+        result.length_ = length_;
+        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+          to_bitField0_ |= 0x00000100;
+        }
+        result.mysqlType_ = mysqlType_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.Column) {
+          return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.Column)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.Column other) {
+        if (other == com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance()) return this;
+        if (other.hasIndex()) {
+          setIndex(other.getIndex());
+        }
+        if (other.hasSqlType()) {
+          setSqlType(other.getSqlType());
+        }
+        if (other.hasName()) {
+          bitField0_ |= 0x00000004;
+          name_ = other.name_;
+          onChanged();
+        }
+        if (other.hasIsKey()) {
+          setIsKey(other.getIsKey());
+        }
+        if (other.hasUpdated()) {
+          setUpdated(other.getUpdated());
+        }
+        if (other.hasIsNull()) {
+          setIsNull(other.getIsNull());
+        }
+        if (propsBuilder_ == null) {
+          if (!other.props_.isEmpty()) {
+            if (props_.isEmpty()) {
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000040);
+            } else {
+              ensurePropsIsMutable();
+              props_.addAll(other.props_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.props_.isEmpty()) {
+            if (propsBuilder_.isEmpty()) {
+              propsBuilder_.dispose();
+              propsBuilder_ = null;
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000040);
+              propsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getPropsFieldBuilder() : null;
+            } else {
+              propsBuilder_.addAllMessages(other.props_);
+            }
+          }
+        }
+        if (other.hasValue()) {
+          bitField0_ |= 0x00000080;
+          value_ = other.value_;
+          onChanged();
+        }
+        if (other.hasLength()) {
+          setLength(other.getLength());
+        }
+        if (other.hasMysqlType()) {
+          bitField0_ |= 0x00000200;
+          mysqlType_ = other.mysqlType_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.alibaba.otter.canal.protocol.CanalEntry.Column parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.Column) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private int index_ ;
+      /**
+       * <code>optional int32 index = 1;</code>
+       *
+       * <pre>
+       **字段下标*
+       * </pre>
+       */
+      public boolean hasIndex() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional int32 index = 1;</code>
+       *
+       * <pre>
+       **字段下标*
+       * </pre>
+       */
+      public int getIndex() {
+        return index_;
+      }
+      /**
+       * <code>optional int32 index = 1;</code>
+       *
+       * <pre>
+       **字段下标*
+       * </pre>
+       */
+      public Builder setIndex(int value) {
+        bitField0_ |= 0x00000001;
+        index_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 index = 1;</code>
+       *
+       * <pre>
+       **字段下标*
+       * </pre>
+       */
+      public Builder clearIndex() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        index_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int sqlType_ ;
+      /**
+       * <code>optional int32 sqlType = 2;</code>
+       *
+       * <pre>
+       **字段java中类型*
+       * </pre>
+       */
+      public boolean hasSqlType() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional int32 sqlType = 2;</code>
+       *
+       * <pre>
+       **字段java中类型*
+       * </pre>
+       */
+      public int getSqlType() {
+        return sqlType_;
+      }
+      /**
+       * <code>optional int32 sqlType = 2;</code>
+       *
+       * <pre>
+       **字段java中类型*
+       * </pre>
+       */
+      public Builder setSqlType(int value) {
+        bitField0_ |= 0x00000002;
+        sqlType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 sqlType = 2;</code>
+       *
+       * <pre>
+       **字段java中类型*
+       * </pre>
+       */
+      public Builder clearSqlType() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        sqlType_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object name_ = "";
+      /**
+       * <code>optional string name = 3;</code>
+       *
+       * <pre>
+       **字段名称(忽略大小写)，在mysql中是没有的*
+       * </pre>
+       */
+      public boolean hasName() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional string name = 3;</code>
+       *
+       * <pre>
+       **字段名称(忽略大小写)，在mysql中是没有的*
+       * </pre>
+       */
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            name_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string name = 3;</code>
+       *
+       * <pre>
+       **字段名称(忽略大小写)，在mysql中是没有的*
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getNameBytes() {
+        java.lang.Object ref = name_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          name_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string name = 3;</code>
+       *
+       * <pre>
+       **字段名称(忽略大小写)，在mysql中是没有的*
+       * </pre>
+       */
+      public Builder setName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        name_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string name = 3;</code>
+       *
+       * <pre>
+       **字段名称(忽略大小写)，在mysql中是没有的*
+       * </pre>
+       */
+      public Builder clearName() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        name_ = getDefaultInstance().getName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string name = 3;</code>
+       *
+       * <pre>
+       **字段名称(忽略大小写)，在mysql中是没有的*
+       * </pre>
+       */
+      public Builder setNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        name_ = value;
+        onChanged();
+        return this;
+      }
+
+      private boolean isKey_ ;
+      /**
+       * <code>optional bool isKey = 4;</code>
+       *
+       * <pre>
+       **是否是主键*
+       * </pre>
+       */
+      public boolean hasIsKey() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional bool isKey = 4;</code>
+       *
+       * <pre>
+       **是否是主键*
+       * </pre>
+       */
+      public boolean getIsKey() {
+        return isKey_;
+      }
+      /**
+       * <code>optional bool isKey = 4;</code>
+       *
+       * <pre>
+       **是否是主键*
+       * </pre>
+       */
+      public Builder setIsKey(boolean value) {
+        bitField0_ |= 0x00000008;
+        isKey_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool isKey = 4;</code>
+       *
+       * <pre>
+       **是否是主键*
+       * </pre>
+       */
+      public Builder clearIsKey() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        isKey_ = false;
+        onChanged();
+        return this;
+      }
+
+      private boolean updated_ ;
+      /**
+       * <code>optional bool updated = 5;</code>
+       *
+       * <pre>
+       **如果EventType=UPDATE,用于标识这个字段值是否有修改*
+       * </pre>
+       */
+      public boolean hasUpdated() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <code>optional bool updated = 5;</code>
+       *
+       * <pre>
+       **如果EventType=UPDATE,用于标识这个字段值是否有修改*
+       * </pre>
+       */
+      public boolean getUpdated() {
+        return updated_;
+      }
+      /**
+       * <code>optional bool updated = 5;</code>
+       *
+       * <pre>
+       **如果EventType=UPDATE,用于标识这个字段值是否有修改*
+       * </pre>
+       */
+      public Builder setUpdated(boolean value) {
+        bitField0_ |= 0x00000010;
+        updated_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool updated = 5;</code>
+       *
+       * <pre>
+       **如果EventType=UPDATE,用于标识这个字段值是否有修改*
+       * </pre>
+       */
+      public Builder clearUpdated() {
+        bitField0_ = (bitField0_ & ~0x00000010);
+        updated_ = false;
+        onChanged();
+        return this;
+      }
+
+      private boolean isNull_ ;
+      /**
+       * <code>optional bool isNull = 6 [default = false];</code>
+       *
+       * <pre>
+       ** 标识是否为空  *
+       * </pre>
+       */
+      public boolean hasIsNull() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>optional bool isNull = 6 [default = false];</code>
+       *
+       * <pre>
+       ** 标识是否为空  *
+       * </pre>
+       */
+      public boolean getIsNull() {
+        return isNull_;
+      }
+      /**
+       * <code>optional bool isNull = 6 [default = false];</code>
+       *
+       * <pre>
+       ** 标识是否为空  *
+       * </pre>
+       */
+      public Builder setIsNull(boolean value) {
+        bitField0_ |= 0x00000020;
+        isNull_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool isNull = 6 [default = false];</code>
+       *
+       * <pre>
+       ** 标识是否为空  *
+       * </pre>
+       */
+      public Builder clearIsNull() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        isNull_ = false;
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ =
+        java.util.Collections.emptyList();
+      private void ensurePropsIsMutable() {
+        if (!((bitField0_ & 0x00000040) == 0x00000040)) {
+          props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
+          bitField0_ |= 0x00000040;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
+
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+        if (propsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(props_);
+        } else {
+          return propsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public int getPropsCount() {
+        if (propsBuilder_ == null) {
+          return props_.size();
+        } else {
+          return propsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);
+        } else {
+          return propsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.set(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addAllProps(
+          java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, props_);
+          onChanged();
+        } else {
+          propsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder clearProps() {
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000040);
+          onChanged();
+        } else {
+          propsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder removeProps(int index) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.remove(index);
+          onChanged();
+        } else {
+          propsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+          int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);  } else {
+          return propsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+           getPropsOrBuilderList() {
+        if (propsBuilder_ != null) {
+          return propsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(props_);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
+        return getPropsFieldBuilder().addBuilder(
+            com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().addBuilder(
+            index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 7;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> 
+           getPropsBuilderList() {
+        return getPropsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+          getPropsFieldBuilder() {
+        if (propsBuilder_ == null) {
+          propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(
+                  props_,
+                  ((bitField0_ & 0x00000040) == 0x00000040),
+                  getParentForChildren(),
+                  isClean());
+          props_ = null;
+        }
+        return propsBuilder_;
+      }
+
+      private java.lang.Object value_ = "";
+      /**
+       * <code>optional string value = 8;</code>
+       *
+       * <pre>
+       ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+       * </pre>
+       */
+      public boolean hasValue() {
+        return ((bitField0_ & 0x00000080) == 0x00000080);
+      }
+      /**
+       * <code>optional string value = 8;</code>
+       *
+       * <pre>
+       ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+       * </pre>
+       */
+      public java.lang.String getValue() {
+        java.lang.Object ref = value_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            value_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string value = 8;</code>
+       *
+       * <pre>
+       ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getValueBytes() {
+        java.lang.Object ref = value_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          value_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string value = 8;</code>
+       *
+       * <pre>
+       ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+       * </pre>
+       */
+      public Builder setValue(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000080;
+        value_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string value = 8;</code>
+       *
+       * <pre>
+       ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+       * </pre>
+       */
+      public Builder clearValue() {
+        bitField0_ = (bitField0_ & ~0x00000080);
+        value_ = getDefaultInstance().getValue();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string value = 8;</code>
+       *
+       * <pre>
+       ** 字段值,timestamp,Datetime是一个时间格式的文本 *
+       * </pre>
+       */
+      public Builder setValueBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000080;
+        value_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int length_ ;
+      /**
+       * <code>optional int32 length = 9;</code>
+       *
+       * <pre>
+       ** 对应数据对象原始长度 *
+       * </pre>
+       */
+      public boolean hasLength() {
+        return ((bitField0_ & 0x00000100) == 0x00000100);
+      }
+      /**
+       * <code>optional int32 length = 9;</code>
+       *
+       * <pre>
+       ** 对应数据对象原始长度 *
+       * </pre>
+       */
+      public int getLength() {
+        return length_;
+      }
+      /**
+       * <code>optional int32 length = 9;</code>
+       *
+       * <pre>
+       ** 对应数据对象原始长度 *
+       * </pre>
+       */
+      public Builder setLength(int value) {
+        bitField0_ |= 0x00000100;
+        length_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int32 length = 9;</code>
+       *
+       * <pre>
+       ** 对应数据对象原始长度 *
+       * </pre>
+       */
+      public Builder clearLength() {
+        bitField0_ = (bitField0_ & ~0x00000100);
+        length_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object mysqlType_ = "";
+      /**
+       * <code>optional string mysqlType = 10;</code>
+       *
+       * <pre>
+       **字段mysql类型*
+       * </pre>
+       */
+      public boolean hasMysqlType() {
+        return ((bitField0_ & 0x00000200) == 0x00000200);
+      }
+      /**
+       * <code>optional string mysqlType = 10;</code>
+       *
+       * <pre>
+       **字段mysql类型*
+       * </pre>
+       */
+      public java.lang.String getMysqlType() {
+        java.lang.Object ref = mysqlType_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            mysqlType_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string mysqlType = 10;</code>
+       *
+       * <pre>
+       **字段mysql类型*
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getMysqlTypeBytes() {
+        java.lang.Object ref = mysqlType_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          mysqlType_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string mysqlType = 10;</code>
+       *
+       * <pre>
+       **字段mysql类型*
+       * </pre>
+       */
+      public Builder setMysqlType(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000200;
+        mysqlType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string mysqlType = 10;</code>
+       *
+       * <pre>
+       **字段mysql类型*
+       * </pre>
+       */
+      public Builder clearMysqlType() {
+        bitField0_ = (bitField0_ & ~0x00000200);
+        mysqlType_ = getDefaultInstance().getMysqlType();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string mysqlType = 10;</code>
+       *
+       * <pre>
+       **字段mysql类型*
+       * </pre>
+       */
+      public Builder setMysqlTypeBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000200;
+        mysqlType_ = value;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.Column)
     }
 
-    public interface RowDataOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.RowData)
-    com.google.protobuf.MessageOrBuilder {
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改前,删除前) *
-         * </pre>
-         */
-        java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> getBeforeColumnsList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改前,删除前) *
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.Column getBeforeColumns(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改前,删除前) *
-         * </pre>
-         */
-        int getBeforeColumnsCount();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改前,删除前) *
-         * </pre>
-         */
-        java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> getBeforeColumnsOrBuilderList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改前,删除前) *
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getBeforeColumnsOrBuilder(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改后,新增后)  *
-         * </pre>
-         */
-        java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> getAfterColumnsList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改后,新增后)  *
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.Column getAfterColumns(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改后,新增后)  *
-         * </pre>
-         */
-        int getAfterColumnsCount();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改后,新增后)  *
-         * </pre>
-         */
-        java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> getAfterColumnsOrBuilderList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改后,新增后)  *
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getAfterColumnsOrBuilder(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        int getPropsCount();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index);
+    static {
+      defaultInstance = new Column(true);
+      defaultInstance.initFields();
     }
 
+    // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.Column)
+  }
+
+  public interface RowDataOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.RowData)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改前,删除前) *
+     * </pre>
+     */
+    java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> 
+        getBeforeColumnsList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改前,删除前) *
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.Column getBeforeColumns(int index);
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改前,删除前) *
+     * </pre>
+     */
+    int getBeforeColumnsCount();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改前,删除前) *
+     * </pre>
+     */
+    java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> 
+        getBeforeColumnsOrBuilderList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改前,删除前) *
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getBeforeColumnsOrBuilder(
+        int index);
+
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改后,新增后)  *
+     * </pre>
+     */
+    java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> 
+        getAfterColumnsList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改后,新增后)  *
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.Column getAfterColumns(int index);
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改后,新增后)  *
+     * </pre>
+     */
+    int getAfterColumnsCount();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改后,新增后)  *
+     * </pre>
+     */
+    java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> 
+        getAfterColumnsOrBuilderList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改后,新增后)  *
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getAfterColumnsOrBuilder(
+        int index);
+
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> 
+        getPropsList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    int getPropsCount();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code com.alibaba.otter.canal.protocol.RowData}
+   */
+  public static final class RowData extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.RowData)
+      RowDataOrBuilder {
+    // Use RowData.newBuilder() to construct.
+    private RowData(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private RowData(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final RowData defaultInstance;
+    public static RowData getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public RowData getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private RowData(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                beforeColumns_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Column>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              beforeColumns_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Column.PARSER, extensionRegistry));
+              break;
+            }
+            case 18: {
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                afterColumns_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Column>();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              afterColumns_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Column.PARSER, extensionRegistry));
+              break;
+            }
+            case 26: {
+              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
+                mutable_bitField0_ |= 0x00000004;
+              }
+              props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER, extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          beforeColumns_ = java.util.Collections.unmodifiableList(beforeColumns_);
+        }
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          afterColumns_ = java.util.Collections.unmodifiableList(afterColumns_);
+        }
+        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+          props_ = java.util.Collections.unmodifiableList(props_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowData_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.alibaba.otter.canal.protocol.CanalEntry.RowData.class, com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<RowData> PARSER =
+        new com.google.protobuf.AbstractParser<RowData>() {
+      public RowData parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new RowData(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<RowData> getParserForType() {
+      return PARSER;
+    }
+
+    public static final int BEFORECOLUMNS_FIELD_NUMBER = 1;
+    private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> beforeColumns_;
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改前,删除前) *
+     * </pre>
+     */
+    public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> getBeforeColumnsList() {
+      return beforeColumns_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改前,删除前) *
+     * </pre>
+     */
+    public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> 
+        getBeforeColumnsOrBuilderList() {
+      return beforeColumns_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改前,删除前) *
+     * </pre>
+     */
+    public int getBeforeColumnsCount() {
+      return beforeColumns_.size();
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改前,删除前) *
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.Column getBeforeColumns(int index) {
+      return beforeColumns_.get(index);
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改前,删除前) *
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getBeforeColumnsOrBuilder(
+        int index) {
+      return beforeColumns_.get(index);
+    }
+
+    public static final int AFTERCOLUMNS_FIELD_NUMBER = 2;
+    private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> afterColumns_;
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改后,新增后)  *
+     * </pre>
+     */
+    public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> getAfterColumnsList() {
+      return afterColumns_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改后,新增后)  *
+     * </pre>
+     */
+    public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> 
+        getAfterColumnsOrBuilderList() {
+      return afterColumns_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改后,新增后)  *
+     * </pre>
+     */
+    public int getAfterColumnsCount() {
+      return afterColumns_.size();
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改后,新增后)  *
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.Column getAfterColumns(int index) {
+      return afterColumns_.get(index);
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+     *
+     * <pre>
+     ** 字段信息，增量数据(修改后,新增后)  *
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getAfterColumnsOrBuilder(
+        int index) {
+      return afterColumns_.get(index);
+    }
+
+    public static final int PROPS_FIELD_NUMBER = 3;
+    private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public int getPropsCount() {
+      return props_.size();
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+      return props_.get(index);
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index) {
+      return props_.get(index);
+    }
+
+    private void initFields() {
+      beforeColumns_ = java.util.Collections.emptyList();
+      afterColumns_ = java.util.Collections.emptyList();
+      props_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      for (int i = 0; i < beforeColumns_.size(); i++) {
+        output.writeMessage(1, beforeColumns_.get(i));
+      }
+      for (int i = 0; i < afterColumns_.size(); i++) {
+        output.writeMessage(2, afterColumns_.get(i));
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        output.writeMessage(3, props_.get(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < beforeColumns_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, beforeColumns_.get(i));
+      }
+      for (int i = 0; i < afterColumns_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, afterColumns_.get(i));
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, props_.get(i));
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.RowData prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
     /**
      * Protobuf type {@code com.alibaba.otter.canal.protocol.RowData}
      */
-    public static final class RowData extends com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.RowData)
-    RowDataOrBuilder {
-
-        // Use RowData.newBuilder() to construct.
-        private RowData(com.google.protobuf.GeneratedMessage.Builder<?> builder){
-            super(builder);
-            this.unknownFields = builder.getUnknownFields();
-        }
-
-        private RowData(boolean noInit){
-            this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance();
-        }
-
-        private static final RowData defaultInstance;
-
-        public static RowData getDefaultInstance() {
-            return defaultInstance;
-        }
-
-        public RowData getDefaultInstanceForType() {
-            return defaultInstance;
-        }
-
-        private final com.google.protobuf.UnknownFieldSet unknownFields;
-
-        @java.lang.Override
-        public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
-            return this.unknownFields;
-        }
-
-        private RowData(com.google.protobuf.CodedInputStream input,
-                        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                    throws com.google.protobuf.InvalidProtocolBufferException{
-            initFields();
-            int mutable_bitField0_ = 0;
-            com.google.protobuf.UnknownFieldSet.Builder unknownFields = com.google.protobuf.UnknownFieldSet.newBuilder();
-            try {
-                boolean done = false;
-                while (!done) {
-                    int tag = input.readTag();
-                    switch (tag) {
-                        case 0:
-                            done = true;
-                            break;
-                        default: {
-                            if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                                done = true;
-                            }
-                            break;
-                        }
-                        case 10: {
-                            if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                                beforeColumns_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Column>();
-                                mutable_bitField0_ |= 0x00000001;
-                            }
-                            beforeColumns_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Column.PARSER,
-                                extensionRegistry));
-                            break;
-                        }
-                        case 18: {
-                            if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                                afterColumns_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Column>();
-                                mutable_bitField0_ |= 0x00000002;
-                            }
-                            afterColumns_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Column.PARSER,
-                                extensionRegistry));
-                            break;
-                        }
-                        case 26: {
-                            if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-                                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
-                                mutable_bitField0_ |= 0x00000004;
-                            }
-                            props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER,
-                                extensionRegistry));
-                            break;
-                        }
-                    }
-                }
-            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                throw e.setUnfinishedMessage(this);
-            } catch (java.io.IOException e) {
-                throw new com.google.protobuf.InvalidProtocolBufferException(e.getMessage()).setUnfinishedMessage(this);
-            } finally {
-                if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                    beforeColumns_ = java.util.Collections.unmodifiableList(beforeColumns_);
-                }
-                if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
-                    afterColumns_ = java.util.Collections.unmodifiableList(afterColumns_);
-                }
-                if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-                    props_ = java.util.Collections.unmodifiableList(props_);
-                }
-                this.unknownFields = unknownFields.build();
-                makeExtensionsImmutable();
-            }
-        }
-
-        public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor;
-        }
-
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowData_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.RowData.class,
-                com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder.class);
-        }
-
-        public static com.google.protobuf.Parser<RowData> PARSER = new com.google.protobuf.AbstractParser<RowData>() {
-
-                                                                     public RowData parsePartialFrom(com.google.protobuf.CodedInputStream input,
-                                                                                                     com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                                 throws com.google.protobuf.InvalidProtocolBufferException {
-                                                                         return new RowData(input, extensionRegistry);
-                                                                     }
-                                                                 };
-
-        @java.lang.Override
-        public com.google.protobuf.Parser<RowData> getParserForType() {
-            return PARSER;
-        }
-
-        public static final int                                                    BEFORECOLUMNS_FIELD_NUMBER = 1;
-        private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> beforeColumns_;
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改前,删除前) *
-         * </pre>
-         */
-        public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> getBeforeColumnsList() {
-            return beforeColumns_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改前,删除前) *
-         * </pre>
-         */
-        public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> getBeforeColumnsOrBuilderList() {
-            return beforeColumns_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改前,删除前) *
-         * </pre>
-         */
-        public int getBeforeColumnsCount() {
-            return beforeColumns_.size();
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改前,删除前) *
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.Column getBeforeColumns(int index) {
-            return beforeColumns_.get(index);
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改前,删除前) *
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getBeforeColumnsOrBuilder(int index) {
-            return beforeColumns_.get(index);
-        }
-
-        public static final int                                                    AFTERCOLUMNS_FIELD_NUMBER = 2;
-        private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> afterColumns_;
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改后,新增后)  *
-         * </pre>
-         */
-        public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> getAfterColumnsList() {
-            return afterColumns_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改后,新增后)  *
-         * </pre>
-         */
-        public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> getAfterColumnsOrBuilderList() {
-            return afterColumns_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改后,新增后)  *
-         * </pre>
-         */
-        public int getAfterColumnsCount() {
-            return afterColumns_.size();
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改后,新增后)  *
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.Column getAfterColumns(int index) {
-            return afterColumns_.get(index);
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-         *
-         * <pre>
-         * * 字段信息，增量数据(修改后,新增后)  *
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getAfterColumnsOrBuilder(int index) {
-            return afterColumns_.get(index);
-        }
-
-        public static final int                                                  PROPS_FIELD_NUMBER = 3;
-        private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public int getPropsCount() {
-            return props_.size();
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-            return props_.get(index);
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-            return props_.get(index);
-        }
-
-        private void initFields() {
-            beforeColumns_ = java.util.Collections.emptyList();
-            afterColumns_ = java.util.Collections.emptyList();
-            props_ = java.util.Collections.emptyList();
-        }
-
-        private byte memoizedIsInitialized = -1;
-
-        public final boolean isInitialized() {
-            byte isInitialized = memoizedIsInitialized;
-            if (isInitialized == 1) return true;
-            if (isInitialized == 0) return false;
-
-            memoizedIsInitialized = 1;
-            return true;
-        }
-
-        public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
-            getSerializedSize();
-            for (int i = 0; i < beforeColumns_.size(); i++) {
-                output.writeMessage(1, beforeColumns_.get(i));
-            }
-            for (int i = 0; i < afterColumns_.size(); i++) {
-                output.writeMessage(2, afterColumns_.get(i));
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                output.writeMessage(3, props_.get(i));
-            }
-            getUnknownFields().writeTo(output);
-        }
-
-        private int memoizedSerializedSize = -1;
-
-        public int getSerializedSize() {
-            int size = memoizedSerializedSize;
-            if (size != -1) return size;
-
-            size = 0;
-            for (int i = 0; i < beforeColumns_.size(); i++) {
-                size += com.google.protobuf.CodedOutputStream.computeMessageSize(1, beforeColumns_.get(i));
-            }
-            for (int i = 0; i < afterColumns_.size(); i++) {
-                size += com.google.protobuf.CodedOutputStream.computeMessageSize(2, afterColumns_.get(i));
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, props_.get(i));
-            }
-            size += getUnknownFields().getSerializedSize();
-            memoizedSerializedSize = size;
-            return size;
-        }
-
-        private static final long serialVersionUID = 0L;
-
-        @java.lang.Override
-        protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-            return super.writeReplace();
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(com.google.protobuf.ByteString data)
-                                                                                                                        throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(com.google.protobuf.ByteString data,
-                                                                                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(byte[] data)
-                                                                                                throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(byte[] data,
-                                                                                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(java.io.InputStream input)
-                                                                                                              throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(java.io.InputStream input,
-                                                                                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseDelimitedFrom(java.io.InputStream input)
-                                                                                                                       throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseDelimitedFrom(java.io.InputStream input,
-                                                                                             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                         throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(com.google.protobuf.CodedInputStream input)
-                                                                                                                               throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowData parseFrom(com.google.protobuf.CodedInputStream input,
-                                                                                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static Builder newBuilder() {
-            return Builder.create();
-        }
-
-        public Builder newBuilderForType() {
-            return newBuilder();
-        }
-
-        public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.RowData prototype) {
-            return newBuilder().mergeFrom(prototype);
-        }
-
-        public Builder toBuilder() {
-            return newBuilder(this);
-        }
-
-        @java.lang.Override
-        protected Builder newBuilderForType(com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-            Builder builder = new Builder(parent);
-            return builder;
-        }
-
-        /**
-         * Protobuf type {@code com.alibaba.otter.canal.protocol.RowData}
-         */
-        public static final class Builder extends com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:com.alibaba.otter.canal.protocol.RowData)
         com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder {
-
-            public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor;
-            }
-
-            protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowData_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.RowData.class,
-                    com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder.class);
-            }
-
-            // Construct using
-            // com.alibaba.otter.canal.protocol.CanalEntry.RowData.newBuilder()
-            private Builder(){
-                maybeForceBuilderInitialization();
-            }
-
-            private Builder(com.google.protobuf.GeneratedMessage.BuilderParent parent){
-                super(parent);
-                maybeForceBuilderInitialization();
-            }
-
-            private void maybeForceBuilderInitialization() {
-                if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-                    getBeforeColumnsFieldBuilder();
-                    getAfterColumnsFieldBuilder();
-                    getPropsFieldBuilder();
-                }
-            }
-
-            private static Builder create() {
-                return new Builder();
-            }
-
-            public Builder clear() {
-                super.clear();
-                if (beforeColumnsBuilder_ == null) {
-                    beforeColumns_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000001);
-                } else {
-                    beforeColumnsBuilder_.clear();
-                }
-                if (afterColumnsBuilder_ == null) {
-                    afterColumns_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000002);
-                } else {
-                    afterColumnsBuilder_.clear();
-                }
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000004);
-                } else {
-                    propsBuilder_.clear();
-                }
-                return this;
-            }
-
-            public Builder clone() {
-                return create().mergeFrom(buildPartial());
-            }
-
-            public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.RowData getDefaultInstanceForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.RowData.getDefaultInstance();
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.RowData build() {
-                com.alibaba.otter.canal.protocol.CanalEntry.RowData result = buildPartial();
-                if (!result.isInitialized()) {
-                    throw newUninitializedMessageException(result);
-                }
-                return result;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.RowData buildPartial() {
-                com.alibaba.otter.canal.protocol.CanalEntry.RowData result = new com.alibaba.otter.canal.protocol.CanalEntry.RowData(this);
-                int from_bitField0_ = bitField0_;
-                if (beforeColumnsBuilder_ == null) {
-                    if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                        beforeColumns_ = java.util.Collections.unmodifiableList(beforeColumns_);
-                        bitField0_ = (bitField0_ & ~0x00000001);
-                    }
-                    result.beforeColumns_ = beforeColumns_;
-                } else {
-                    result.beforeColumns_ = beforeColumnsBuilder_.build();
-                }
-                if (afterColumnsBuilder_ == null) {
-                    if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                        afterColumns_ = java.util.Collections.unmodifiableList(afterColumns_);
-                        bitField0_ = (bitField0_ & ~0x00000002);
-                    }
-                    result.afterColumns_ = afterColumns_;
-                } else {
-                    result.afterColumns_ = afterColumnsBuilder_.build();
-                }
-                if (propsBuilder_ == null) {
-                    if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                        props_ = java.util.Collections.unmodifiableList(props_);
-                        bitField0_ = (bitField0_ & ~0x00000004);
-                    }
-                    result.props_ = props_;
-                } else {
-                    result.props_ = propsBuilder_.build();
-                }
-                onBuilt();
-                return result;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.Message other) {
-                if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.RowData) {
-                    return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.RowData) other);
-                } else {
-                    super.mergeFrom(other);
-                    return this;
-                }
-            }
-
-            public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.RowData other) {
-                if (other == com.alibaba.otter.canal.protocol.CanalEntry.RowData.getDefaultInstance()) return this;
-                if (beforeColumnsBuilder_ == null) {
-                    if (!other.beforeColumns_.isEmpty()) {
-                        if (beforeColumns_.isEmpty()) {
-                            beforeColumns_ = other.beforeColumns_;
-                            bitField0_ = (bitField0_ & ~0x00000001);
-                        } else {
-                            ensureBeforeColumnsIsMutable();
-                            beforeColumns_.addAll(other.beforeColumns_);
-                        }
-                        onChanged();
-                    }
-                } else {
-                    if (!other.beforeColumns_.isEmpty()) {
-                        if (beforeColumnsBuilder_.isEmpty()) {
-                            beforeColumnsBuilder_.dispose();
-                            beforeColumnsBuilder_ = null;
-                            beforeColumns_ = other.beforeColumns_;
-                            bitField0_ = (bitField0_ & ~0x00000001);
-                            beforeColumnsBuilder_ = com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ? getBeforeColumnsFieldBuilder() : null;
-                        } else {
-                            beforeColumnsBuilder_.addAllMessages(other.beforeColumns_);
-                        }
-                    }
-                }
-                if (afterColumnsBuilder_ == null) {
-                    if (!other.afterColumns_.isEmpty()) {
-                        if (afterColumns_.isEmpty()) {
-                            afterColumns_ = other.afterColumns_;
-                            bitField0_ = (bitField0_ & ~0x00000002);
-                        } else {
-                            ensureAfterColumnsIsMutable();
-                            afterColumns_.addAll(other.afterColumns_);
-                        }
-                        onChanged();
-                    }
-                } else {
-                    if (!other.afterColumns_.isEmpty()) {
-                        if (afterColumnsBuilder_.isEmpty()) {
-                            afterColumnsBuilder_.dispose();
-                            afterColumnsBuilder_ = null;
-                            afterColumns_ = other.afterColumns_;
-                            bitField0_ = (bitField0_ & ~0x00000002);
-                            afterColumnsBuilder_ = com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ? getAfterColumnsFieldBuilder() : null;
-                        } else {
-                            afterColumnsBuilder_.addAllMessages(other.afterColumns_);
-                        }
-                    }
-                }
-                if (propsBuilder_ == null) {
-                    if (!other.props_.isEmpty()) {
-                        if (props_.isEmpty()) {
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000004);
-                        } else {
-                            ensurePropsIsMutable();
-                            props_.addAll(other.props_);
-                        }
-                        onChanged();
-                    }
-                } else {
-                    if (!other.props_.isEmpty()) {
-                        if (propsBuilder_.isEmpty()) {
-                            propsBuilder_.dispose();
-                            propsBuilder_ = null;
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000004);
-                            propsBuilder_ = com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ? getPropsFieldBuilder() : null;
-                        } else {
-                            propsBuilder_.addAllMessages(other.props_);
-                        }
-                    }
-                }
-                this.mergeUnknownFields(other.getUnknownFields());
-                return this;
-            }
-
-            public final boolean isInitialized() {
-                return true;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
-                                     com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                 throws java.io.IOException {
-                com.alibaba.otter.canal.protocol.CanalEntry.RowData parsedMessage = null;
-                try {
-                    parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                    parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.RowData) e.getUnfinishedMessage();
-                    throw e;
-                } finally {
-                    if (parsedMessage != null) {
-                        mergeFrom(parsedMessage);
-                    }
-                }
-                return this;
-            }
-
-            private int                                                                bitField0_;
-
-            private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> beforeColumns_ = java.util.Collections.emptyList();
-
-            private void ensureBeforeColumnsIsMutable() {
-                if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-                    beforeColumns_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Column>(beforeColumns_);
-                    bitField0_ |= 0x00000001;
-                }
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> beforeColumnsBuilder_;
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> getBeforeColumnsList() {
-                if (beforeColumnsBuilder_ == null) {
-                    return java.util.Collections.unmodifiableList(beforeColumns_);
-                } else {
-                    return beforeColumnsBuilder_.getMessageList();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public int getBeforeColumnsCount() {
-                if (beforeColumnsBuilder_ == null) {
-                    return beforeColumns_.size();
-                } else {
-                    return beforeColumnsBuilder_.getCount();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Column getBeforeColumns(int index) {
-                if (beforeColumnsBuilder_ == null) {
-                    return beforeColumns_.get(index);
-                } else {
-                    return beforeColumnsBuilder_.getMessage(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public Builder setBeforeColumns(int index, com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
-                if (beforeColumnsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensureBeforeColumnsIsMutable();
-                    beforeColumns_.set(index, value);
-                    onChanged();
-                } else {
-                    beforeColumnsBuilder_.setMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public Builder setBeforeColumns(int index,
-                                            com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
-                if (beforeColumnsBuilder_ == null) {
-                    ensureBeforeColumnsIsMutable();
-                    beforeColumns_.set(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    beforeColumnsBuilder_.setMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public Builder addBeforeColumns(com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
-                if (beforeColumnsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensureBeforeColumnsIsMutable();
-                    beforeColumns_.add(value);
-                    onChanged();
-                } else {
-                    beforeColumnsBuilder_.addMessage(value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public Builder addBeforeColumns(int index, com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
-                if (beforeColumnsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensureBeforeColumnsIsMutable();
-                    beforeColumns_.add(index, value);
-                    onChanged();
-                } else {
-                    beforeColumnsBuilder_.addMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public Builder addBeforeColumns(com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
-                if (beforeColumnsBuilder_ == null) {
-                    ensureBeforeColumnsIsMutable();
-                    beforeColumns_.add(builderForValue.build());
-                    onChanged();
-                } else {
-                    beforeColumnsBuilder_.addMessage(builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public Builder addBeforeColumns(int index,
-                                            com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
-                if (beforeColumnsBuilder_ == null) {
-                    ensureBeforeColumnsIsMutable();
-                    beforeColumns_.add(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    beforeColumnsBuilder_.addMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public Builder addAllBeforeColumns(java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Column> values) {
-                if (beforeColumnsBuilder_ == null) {
-                    ensureBeforeColumnsIsMutable();
-                    com.google.protobuf.AbstractMessageLite.Builder.addAll(values, beforeColumns_);
-                    onChanged();
-                } else {
-                    beforeColumnsBuilder_.addAllMessages(values);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public Builder clearBeforeColumns() {
-                if (beforeColumnsBuilder_ == null) {
-                    beforeColumns_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000001);
-                    onChanged();
-                } else {
-                    beforeColumnsBuilder_.clear();
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public Builder removeBeforeColumns(int index) {
-                if (beforeColumnsBuilder_ == null) {
-                    ensureBeforeColumnsIsMutable();
-                    beforeColumns_.remove(index);
-                    onChanged();
-                } else {
-                    beforeColumnsBuilder_.remove(index);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder getBeforeColumnsBuilder(int index) {
-                return getBeforeColumnsFieldBuilder().getBuilder(index);
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getBeforeColumnsOrBuilder(int index) {
-                if (beforeColumnsBuilder_ == null) {
-                    return beforeColumns_.get(index);
-                } else {
-                    return beforeColumnsBuilder_.getMessageOrBuilder(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> getBeforeColumnsOrBuilderList() {
-                if (beforeColumnsBuilder_ != null) {
-                    return beforeColumnsBuilder_.getMessageOrBuilderList();
-                } else {
-                    return java.util.Collections.unmodifiableList(beforeColumns_);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder addBeforeColumnsBuilder() {
-                return getBeforeColumnsFieldBuilder().addBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder addBeforeColumnsBuilder(int index) {
-                return getBeforeColumnsFieldBuilder().addBuilder(index,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改前,删除前) *
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder> getBeforeColumnsBuilderList() {
-                return getBeforeColumnsFieldBuilder().getBuilderList();
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> getBeforeColumnsFieldBuilder() {
-                if (beforeColumnsBuilder_ == null) {
-                    beforeColumnsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder>(beforeColumns_,
-                        ((bitField0_ & 0x00000001) == 0x00000001),
-                        getParentForChildren(),
-                        isClean());
-                    beforeColumns_ = null;
-                }
-                return beforeColumnsBuilder_;
-            }
-
-            private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> afterColumns_ = java.util.Collections.emptyList();
-
-            private void ensureAfterColumnsIsMutable() {
-                if (!((bitField0_ & 0x00000002) == 0x00000002)) {
-                    afterColumns_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Column>(afterColumns_);
-                    bitField0_ |= 0x00000002;
-                }
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> afterColumnsBuilder_;
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> getAfterColumnsList() {
-                if (afterColumnsBuilder_ == null) {
-                    return java.util.Collections.unmodifiableList(afterColumns_);
-                } else {
-                    return afterColumnsBuilder_.getMessageList();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public int getAfterColumnsCount() {
-                if (afterColumnsBuilder_ == null) {
-                    return afterColumns_.size();
-                } else {
-                    return afterColumnsBuilder_.getCount();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Column getAfterColumns(int index) {
-                if (afterColumnsBuilder_ == null) {
-                    return afterColumns_.get(index);
-                } else {
-                    return afterColumnsBuilder_.getMessage(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public Builder setAfterColumns(int index, com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
-                if (afterColumnsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensureAfterColumnsIsMutable();
-                    afterColumns_.set(index, value);
-                    onChanged();
-                } else {
-                    afterColumnsBuilder_.setMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public Builder setAfterColumns(int index,
-                                           com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
-                if (afterColumnsBuilder_ == null) {
-                    ensureAfterColumnsIsMutable();
-                    afterColumns_.set(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    afterColumnsBuilder_.setMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public Builder addAfterColumns(com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
-                if (afterColumnsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensureAfterColumnsIsMutable();
-                    afterColumns_.add(value);
-                    onChanged();
-                } else {
-                    afterColumnsBuilder_.addMessage(value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public Builder addAfterColumns(int index, com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
-                if (afterColumnsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensureAfterColumnsIsMutable();
-                    afterColumns_.add(index, value);
-                    onChanged();
-                } else {
-                    afterColumnsBuilder_.addMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public Builder addAfterColumns(com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
-                if (afterColumnsBuilder_ == null) {
-                    ensureAfterColumnsIsMutable();
-                    afterColumns_.add(builderForValue.build());
-                    onChanged();
-                } else {
-                    afterColumnsBuilder_.addMessage(builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public Builder addAfterColumns(int index,
-                                           com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
-                if (afterColumnsBuilder_ == null) {
-                    ensureAfterColumnsIsMutable();
-                    afterColumns_.add(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    afterColumnsBuilder_.addMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public Builder addAllAfterColumns(java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Column> values) {
-                if (afterColumnsBuilder_ == null) {
-                    ensureAfterColumnsIsMutable();
-                    com.google.protobuf.AbstractMessageLite.Builder.addAll(values, afterColumns_);
-                    onChanged();
-                } else {
-                    afterColumnsBuilder_.addAllMessages(values);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public Builder clearAfterColumns() {
-                if (afterColumnsBuilder_ == null) {
-                    afterColumns_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000002);
-                    onChanged();
-                } else {
-                    afterColumnsBuilder_.clear();
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public Builder removeAfterColumns(int index) {
-                if (afterColumnsBuilder_ == null) {
-                    ensureAfterColumnsIsMutable();
-                    afterColumns_.remove(index);
-                    onChanged();
-                } else {
-                    afterColumnsBuilder_.remove(index);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder getAfterColumnsBuilder(int index) {
-                return getAfterColumnsFieldBuilder().getBuilder(index);
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getAfterColumnsOrBuilder(int index) {
-                if (afterColumnsBuilder_ == null) {
-                    return afterColumns_.get(index);
-                } else {
-                    return afterColumnsBuilder_.getMessageOrBuilder(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> getAfterColumnsOrBuilderList() {
-                if (afterColumnsBuilder_ != null) {
-                    return afterColumnsBuilder_.getMessageOrBuilderList();
-                } else {
-                    return java.util.Collections.unmodifiableList(afterColumns_);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder addAfterColumnsBuilder() {
-                return getAfterColumnsFieldBuilder().addBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder addAfterColumnsBuilder(int index) {
-                return getAfterColumnsFieldBuilder().addBuilder(index,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
-             *
-             * <pre>
-             * * 字段信息，增量数据(修改后,新增后)  *
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder> getAfterColumnsBuilderList() {
-                return getAfterColumnsFieldBuilder().getBuilderList();
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> getAfterColumnsFieldBuilder() {
-                if (afterColumnsBuilder_ == null) {
-                    afterColumnsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder>(afterColumns_,
-                        ((bitField0_ & 0x00000002) == 0x00000002),
-                        getParentForChildren(),
-                        isClean());
-                    afterColumns_ = null;
-                }
-                return afterColumnsBuilder_;
-            }
-
-            private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ = java.util.Collections.emptyList();
-
-            private void ensurePropsIsMutable() {
-                if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-                    props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
-                    bitField0_ |= 0x00000004;
-                }
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-                if (propsBuilder_ == null) {
-                    return java.util.Collections.unmodifiableList(props_);
-                } else {
-                    return propsBuilder_.getMessageList();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public int getPropsCount() {
-                if (propsBuilder_ == null) {
-                    return props_.size();
-                } else {
-                    return propsBuilder_.getCount();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessage(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.set(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.set(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addAllProps(java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    com.google.protobuf.AbstractMessageLite.Builder.addAll(values, props_);
-                    onChanged();
-                } else {
-                    propsBuilder_.addAllMessages(values);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder clearProps() {
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000004);
-                    onChanged();
-                } else {
-                    propsBuilder_.clear();
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder removeProps(int index) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.remove(index);
-                    onChanged();
-                } else {
-                    propsBuilder_.remove(index);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(int index) {
-                return getPropsFieldBuilder().getBuilder(index);
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessageOrBuilder(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-                if (propsBuilder_ != null) {
-                    return propsBuilder_.getMessageOrBuilderList();
-                } else {
-                    return java.util.Collections.unmodifiableList(props_);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
-                return getPropsFieldBuilder().addBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(int index) {
-                return getPropsFieldBuilder().addBuilder(index,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> getPropsBuilderList() {
-                return getPropsFieldBuilder().getBuilderList();
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsFieldBuilder() {
-                if (propsBuilder_ == null) {
-                    propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(props_,
-                        ((bitField0_ & 0x00000004) == 0x00000004),
-                        getParentForChildren(),
-                        isClean());
-                    props_ = null;
-                }
-                return propsBuilder_;
-            }
-
-            // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.RowData)
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowData_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.alibaba.otter.canal.protocol.CanalEntry.RowData.class, com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder.class);
+      }
+
+      // Construct using com.alibaba.otter.canal.protocol.CanalEntry.RowData.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getBeforeColumnsFieldBuilder();
+          getAfterColumnsFieldBuilder();
+          getPropsFieldBuilder();
         }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
 
-        static {
-            defaultInstance = new RowData(true);
-            defaultInstance.initFields();
+      public Builder clear() {
+        super.clear();
+        if (beforeColumnsBuilder_ == null) {
+          beforeColumns_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          beforeColumnsBuilder_.clear();
         }
+        if (afterColumnsBuilder_ == null) {
+          afterColumns_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+        } else {
+          afterColumnsBuilder_.clear();
+        }
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+        } else {
+          propsBuilder_.clear();
+        }
+        return this;
+      }
 
-        // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.RowData)
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.RowData getDefaultInstanceForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.RowData.getDefaultInstance();
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.RowData build() {
+        com.alibaba.otter.canal.protocol.CanalEntry.RowData result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.RowData buildPartial() {
+        com.alibaba.otter.canal.protocol.CanalEntry.RowData result = new com.alibaba.otter.canal.protocol.CanalEntry.RowData(this);
+        int from_bitField0_ = bitField0_;
+        if (beforeColumnsBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            beforeColumns_ = java.util.Collections.unmodifiableList(beforeColumns_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.beforeColumns_ = beforeColumns_;
+        } else {
+          result.beforeColumns_ = beforeColumnsBuilder_.build();
+        }
+        if (afterColumnsBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            afterColumns_ = java.util.Collections.unmodifiableList(afterColumns_);
+            bitField0_ = (bitField0_ & ~0x00000002);
+          }
+          result.afterColumns_ = afterColumns_;
+        } else {
+          result.afterColumns_ = afterColumnsBuilder_.build();
+        }
+        if (propsBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+            props_ = java.util.Collections.unmodifiableList(props_);
+            bitField0_ = (bitField0_ & ~0x00000004);
+          }
+          result.props_ = props_;
+        } else {
+          result.props_ = propsBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.RowData) {
+          return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.RowData)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.RowData other) {
+        if (other == com.alibaba.otter.canal.protocol.CanalEntry.RowData.getDefaultInstance()) return this;
+        if (beforeColumnsBuilder_ == null) {
+          if (!other.beforeColumns_.isEmpty()) {
+            if (beforeColumns_.isEmpty()) {
+              beforeColumns_ = other.beforeColumns_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureBeforeColumnsIsMutable();
+              beforeColumns_.addAll(other.beforeColumns_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.beforeColumns_.isEmpty()) {
+            if (beforeColumnsBuilder_.isEmpty()) {
+              beforeColumnsBuilder_.dispose();
+              beforeColumnsBuilder_ = null;
+              beforeColumns_ = other.beforeColumns_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              beforeColumnsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getBeforeColumnsFieldBuilder() : null;
+            } else {
+              beforeColumnsBuilder_.addAllMessages(other.beforeColumns_);
+            }
+          }
+        }
+        if (afterColumnsBuilder_ == null) {
+          if (!other.afterColumns_.isEmpty()) {
+            if (afterColumns_.isEmpty()) {
+              afterColumns_ = other.afterColumns_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+            } else {
+              ensureAfterColumnsIsMutable();
+              afterColumns_.addAll(other.afterColumns_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.afterColumns_.isEmpty()) {
+            if (afterColumnsBuilder_.isEmpty()) {
+              afterColumnsBuilder_.dispose();
+              afterColumnsBuilder_ = null;
+              afterColumns_ = other.afterColumns_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+              afterColumnsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getAfterColumnsFieldBuilder() : null;
+            } else {
+              afterColumnsBuilder_.addAllMessages(other.afterColumns_);
+            }
+          }
+        }
+        if (propsBuilder_ == null) {
+          if (!other.props_.isEmpty()) {
+            if (props_.isEmpty()) {
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+            } else {
+              ensurePropsIsMutable();
+              props_.addAll(other.props_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.props_.isEmpty()) {
+            if (propsBuilder_.isEmpty()) {
+              propsBuilder_.dispose();
+              propsBuilder_ = null;
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+              propsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getPropsFieldBuilder() : null;
+            } else {
+              propsBuilder_.addAllMessages(other.props_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.alibaba.otter.canal.protocol.CanalEntry.RowData parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.RowData) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> beforeColumns_ =
+        java.util.Collections.emptyList();
+      private void ensureBeforeColumnsIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          beforeColumns_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Column>(beforeColumns_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> beforeColumnsBuilder_;
+
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> getBeforeColumnsList() {
+        if (beforeColumnsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(beforeColumns_);
+        } else {
+          return beforeColumnsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public int getBeforeColumnsCount() {
+        if (beforeColumnsBuilder_ == null) {
+          return beforeColumns_.size();
+        } else {
+          return beforeColumnsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Column getBeforeColumns(int index) {
+        if (beforeColumnsBuilder_ == null) {
+          return beforeColumns_.get(index);
+        } else {
+          return beforeColumnsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public Builder setBeforeColumns(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
+        if (beforeColumnsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureBeforeColumnsIsMutable();
+          beforeColumns_.set(index, value);
+          onChanged();
+        } else {
+          beforeColumnsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public Builder setBeforeColumns(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
+        if (beforeColumnsBuilder_ == null) {
+          ensureBeforeColumnsIsMutable();
+          beforeColumns_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          beforeColumnsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public Builder addBeforeColumns(com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
+        if (beforeColumnsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureBeforeColumnsIsMutable();
+          beforeColumns_.add(value);
+          onChanged();
+        } else {
+          beforeColumnsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public Builder addBeforeColumns(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
+        if (beforeColumnsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureBeforeColumnsIsMutable();
+          beforeColumns_.add(index, value);
+          onChanged();
+        } else {
+          beforeColumnsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public Builder addBeforeColumns(
+          com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
+        if (beforeColumnsBuilder_ == null) {
+          ensureBeforeColumnsIsMutable();
+          beforeColumns_.add(builderForValue.build());
+          onChanged();
+        } else {
+          beforeColumnsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public Builder addBeforeColumns(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
+        if (beforeColumnsBuilder_ == null) {
+          ensureBeforeColumnsIsMutable();
+          beforeColumns_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          beforeColumnsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public Builder addAllBeforeColumns(
+          java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Column> values) {
+        if (beforeColumnsBuilder_ == null) {
+          ensureBeforeColumnsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, beforeColumns_);
+          onChanged();
+        } else {
+          beforeColumnsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public Builder clearBeforeColumns() {
+        if (beforeColumnsBuilder_ == null) {
+          beforeColumns_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          beforeColumnsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public Builder removeBeforeColumns(int index) {
+        if (beforeColumnsBuilder_ == null) {
+          ensureBeforeColumnsIsMutable();
+          beforeColumns_.remove(index);
+          onChanged();
+        } else {
+          beforeColumnsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder getBeforeColumnsBuilder(
+          int index) {
+        return getBeforeColumnsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getBeforeColumnsOrBuilder(
+          int index) {
+        if (beforeColumnsBuilder_ == null) {
+          return beforeColumns_.get(index);  } else {
+          return beforeColumnsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> 
+           getBeforeColumnsOrBuilderList() {
+        if (beforeColumnsBuilder_ != null) {
+          return beforeColumnsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(beforeColumns_);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder addBeforeColumnsBuilder() {
+        return getBeforeColumnsFieldBuilder().addBuilder(
+            com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder addBeforeColumnsBuilder(
+          int index) {
+        return getBeforeColumnsFieldBuilder().addBuilder(
+            index, com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column beforeColumns = 1;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改前,删除前) *
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder> 
+           getBeforeColumnsBuilderList() {
+        return getBeforeColumnsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> 
+          getBeforeColumnsFieldBuilder() {
+        if (beforeColumnsBuilder_ == null) {
+          beforeColumnsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder>(
+                  beforeColumns_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  getParentForChildren(),
+                  isClean());
+          beforeColumns_ = null;
+        }
+        return beforeColumnsBuilder_;
+      }
+
+      private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> afterColumns_ =
+        java.util.Collections.emptyList();
+      private void ensureAfterColumnsIsMutable() {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+          afterColumns_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Column>(afterColumns_);
+          bitField0_ |= 0x00000002;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> afterColumnsBuilder_;
+
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column> getAfterColumnsList() {
+        if (afterColumnsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(afterColumns_);
+        } else {
+          return afterColumnsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public int getAfterColumnsCount() {
+        if (afterColumnsBuilder_ == null) {
+          return afterColumns_.size();
+        } else {
+          return afterColumnsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Column getAfterColumns(int index) {
+        if (afterColumnsBuilder_ == null) {
+          return afterColumns_.get(index);
+        } else {
+          return afterColumnsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public Builder setAfterColumns(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
+        if (afterColumnsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureAfterColumnsIsMutable();
+          afterColumns_.set(index, value);
+          onChanged();
+        } else {
+          afterColumnsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public Builder setAfterColumns(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
+        if (afterColumnsBuilder_ == null) {
+          ensureAfterColumnsIsMutable();
+          afterColumns_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          afterColumnsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public Builder addAfterColumns(com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
+        if (afterColumnsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureAfterColumnsIsMutable();
+          afterColumns_.add(value);
+          onChanged();
+        } else {
+          afterColumnsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public Builder addAfterColumns(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Column value) {
+        if (afterColumnsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureAfterColumnsIsMutable();
+          afterColumns_.add(index, value);
+          onChanged();
+        } else {
+          afterColumnsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public Builder addAfterColumns(
+          com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
+        if (afterColumnsBuilder_ == null) {
+          ensureAfterColumnsIsMutable();
+          afterColumns_.add(builderForValue.build());
+          onChanged();
+        } else {
+          afterColumnsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public Builder addAfterColumns(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder builderForValue) {
+        if (afterColumnsBuilder_ == null) {
+          ensureAfterColumnsIsMutable();
+          afterColumns_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          afterColumnsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public Builder addAllAfterColumns(
+          java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Column> values) {
+        if (afterColumnsBuilder_ == null) {
+          ensureAfterColumnsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, afterColumns_);
+          onChanged();
+        } else {
+          afterColumnsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public Builder clearAfterColumns() {
+        if (afterColumnsBuilder_ == null) {
+          afterColumns_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+          onChanged();
+        } else {
+          afterColumnsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public Builder removeAfterColumns(int index) {
+        if (afterColumnsBuilder_ == null) {
+          ensureAfterColumnsIsMutable();
+          afterColumns_.remove(index);
+          onChanged();
+        } else {
+          afterColumnsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder getAfterColumnsBuilder(
+          int index) {
+        return getAfterColumnsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder getAfterColumnsOrBuilder(
+          int index) {
+        if (afterColumnsBuilder_ == null) {
+          return afterColumns_.get(index);  } else {
+          return afterColumnsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> 
+           getAfterColumnsOrBuilderList() {
+        if (afterColumnsBuilder_ != null) {
+          return afterColumnsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(afterColumns_);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder addAfterColumnsBuilder() {
+        return getAfterColumnsFieldBuilder().addBuilder(
+            com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder addAfterColumnsBuilder(
+          int index) {
+        return getAfterColumnsFieldBuilder().addBuilder(
+            index, com.alibaba.otter.canal.protocol.CanalEntry.Column.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Column afterColumns = 2;</code>
+       *
+       * <pre>
+       ** 字段信息，增量数据(修改后,新增后)  *
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder> 
+           getAfterColumnsBuilderList() {
+        return getAfterColumnsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder> 
+          getAfterColumnsFieldBuilder() {
+        if (afterColumnsBuilder_ == null) {
+          afterColumnsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              com.alibaba.otter.canal.protocol.CanalEntry.Column, com.alibaba.otter.canal.protocol.CanalEntry.Column.Builder, com.alibaba.otter.canal.protocol.CanalEntry.ColumnOrBuilder>(
+                  afterColumns_,
+                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  getParentForChildren(),
+                  isClean());
+          afterColumns_ = null;
+        }
+        return afterColumnsBuilder_;
+      }
+
+      private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ =
+        java.util.Collections.emptyList();
+      private void ensurePropsIsMutable() {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+          props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
+          bitField0_ |= 0x00000004;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
+
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+        if (propsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(props_);
+        } else {
+          return propsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public int getPropsCount() {
+        if (propsBuilder_ == null) {
+          return props_.size();
+        } else {
+          return propsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);
+        } else {
+          return propsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.set(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addAllProps(
+          java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, props_);
+          onChanged();
+        } else {
+          propsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder clearProps() {
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+          onChanged();
+        } else {
+          propsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder removeProps(int index) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.remove(index);
+          onChanged();
+        } else {
+          propsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+          int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);  } else {
+          return propsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+           getPropsOrBuilderList() {
+        if (propsBuilder_ != null) {
+          return propsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(props_);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
+        return getPropsFieldBuilder().addBuilder(
+            com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().addBuilder(
+            index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> 
+           getPropsBuilderList() {
+        return getPropsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+          getPropsFieldBuilder() {
+        if (propsBuilder_ == null) {
+          propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(
+                  props_,
+                  ((bitField0_ & 0x00000004) == 0x00000004),
+                  getParentForChildren(),
+                  isClean());
+          props_ = null;
+        }
+        return propsBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.RowData)
     }
 
-    public interface RowChangeOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.RowChange)
-    com.google.protobuf.MessageOrBuilder {
-
-        /**
-         * <code>optional int64 tableId = 1;</code>
-         *
-         * <pre>
-         * *tableId,由数据库产生*
-         * </pre>
-         */
-        boolean hasTableId();
-
-        /**
-         * <code>optional int64 tableId = 1;</code>
-         *
-         * <pre>
-         * *tableId,由数据库产生*
-         * </pre>
-         */
-        long getTableId();
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
-         *
-         * <pre>
-         * *数据变更类型*
-         * </pre>
-         */
-        boolean hasEventType();
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
-         *
-         * <pre>
-         * *数据变更类型*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType();
-
-        /**
-         * <code>optional bool isDdl = 10 [default = false];</code>
-         *
-         * <pre>
-         * * 标识是否是ddl语句  *
-         * </pre>
-         */
-        boolean hasIsDdl();
-
-        /**
-         * <code>optional bool isDdl = 10 [default = false];</code>
-         *
-         * <pre>
-         * * 标识是否是ddl语句  *
-         * </pre>
-         */
-        boolean getIsDdl();
-
-        /**
-         * <code>optional string sql = 11;</code>
-         *
-         * <pre>
-         * * ddl/query的sql语句  *
-         * </pre>
-         */
-        boolean hasSql();
-
-        /**
-         * <code>optional string sql = 11;</code>
-         *
-         * <pre>
-         * * ddl/query的sql语句  *
-         * </pre>
-         */
-        java.lang.String getSql();
-
-        /**
-         * <code>optional string sql = 11;</code>
-         *
-         * <pre>
-         * * ddl/query的sql语句  *
-         * </pre>
-         */
-        com.google.protobuf.ByteString getSqlBytes();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-         *
-         * <pre>
-         * * 一次数据库变更可能存在多行  *
-         * </pre>
-         */
-        java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData> getRowDatasList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-         *
-         * <pre>
-         * * 一次数据库变更可能存在多行  *
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.RowData getRowDatas(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-         *
-         * <pre>
-         * * 一次数据库变更可能存在多行  *
-         * </pre>
-         */
-        int getRowDatasCount();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-         *
-         * <pre>
-         * * 一次数据库变更可能存在多行  *
-         * </pre>
-         */
-        java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder> getRowDatasOrBuilderList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-         *
-         * <pre>
-         * * 一次数据库变更可能存在多行  *
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder getRowDatasOrBuilder(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        int getPropsCount();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index);
-
-        /**
-         * <code>optional string ddlSchemaName = 14;</code>
-         *
-         * <pre>
-         * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-         * </pre>
-         */
-        boolean hasDdlSchemaName();
-
-        /**
-         * <code>optional string ddlSchemaName = 14;</code>
-         *
-         * <pre>
-         * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-         * </pre>
-         */
-        java.lang.String getDdlSchemaName();
-
-        /**
-         * <code>optional string ddlSchemaName = 14;</code>
-         *
-         * <pre>
-         * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-         * </pre>
-         */
-        com.google.protobuf.ByteString getDdlSchemaNameBytes();
+    static {
+      defaultInstance = new RowData(true);
+      defaultInstance.initFields();
     }
 
+    // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.RowData)
+  }
+
+  public interface RowChangeOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.RowChange)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int64 tableId = 1;</code>
+     *
+     * <pre>
+     **tableId,由数据库产生*
+     * </pre>
+     */
+    boolean hasTableId();
+    /**
+     * <code>optional int64 tableId = 1;</code>
+     *
+     * <pre>
+     **tableId,由数据库产生*
+     * </pre>
+     */
+    long getTableId();
+
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
+     *
+     * <pre>
+     **数据变更类型*
+     * </pre>
+     */
+    boolean hasEventType();
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
+     *
+     * <pre>
+     **数据变更类型*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType();
+
+    /**
+     * <code>optional bool isDdl = 10 [default = false];</code>
+     *
+     * <pre>
+     ** 标识是否是ddl语句  *
+     * </pre>
+     */
+    boolean hasIsDdl();
+    /**
+     * <code>optional bool isDdl = 10 [default = false];</code>
+     *
+     * <pre>
+     ** 标识是否是ddl语句  *
+     * </pre>
+     */
+    boolean getIsDdl();
+
+    /**
+     * <code>optional string sql = 11;</code>
+     *
+     * <pre>
+     ** ddl/query的sql语句  *
+     * </pre>
+     */
+    boolean hasSql();
+    /**
+     * <code>optional string sql = 11;</code>
+     *
+     * <pre>
+     ** ddl/query的sql语句  *
+     * </pre>
+     */
+    java.lang.String getSql();
+    /**
+     * <code>optional string sql = 11;</code>
+     *
+     * <pre>
+     ** ddl/query的sql语句  *
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getSqlBytes();
+
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+     *
+     * <pre>
+     ** 一次数据库变更可能存在多行  *
+     * </pre>
+     */
+    java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData> 
+        getRowDatasList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+     *
+     * <pre>
+     ** 一次数据库变更可能存在多行  *
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.RowData getRowDatas(int index);
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+     *
+     * <pre>
+     ** 一次数据库变更可能存在多行  *
+     * </pre>
+     */
+    int getRowDatasCount();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+     *
+     * <pre>
+     ** 一次数据库变更可能存在多行  *
+     * </pre>
+     */
+    java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder> 
+        getRowDatasOrBuilderList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+     *
+     * <pre>
+     ** 一次数据库变更可能存在多行  *
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder getRowDatasOrBuilder(
+        int index);
+
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> 
+        getPropsList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    int getPropsCount();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index);
+
+    /**
+     * <code>optional string ddlSchemaName = 14;</code>
+     *
+     * <pre>
+     ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+     * </pre>
+     */
+    boolean hasDdlSchemaName();
+    /**
+     * <code>optional string ddlSchemaName = 14;</code>
+     *
+     * <pre>
+     ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+     * </pre>
+     */
+    java.lang.String getDdlSchemaName();
+    /**
+     * <code>optional string ddlSchemaName = 14;</code>
+     *
+     * <pre>
+     ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getDdlSchemaNameBytes();
+  }
+  /**
+   * Protobuf type {@code com.alibaba.otter.canal.protocol.RowChange}
+   *
+   * <pre>
+   **message row 每行变更数据的数据结构*
+   * </pre>
+   */
+  public static final class RowChange extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.RowChange)
+      RowChangeOrBuilder {
+    // Use RowChange.newBuilder() to construct.
+    private RowChange(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private RowChange(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final RowChange defaultInstance;
+    public static RowChange getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public RowChange getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private RowChange(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              tableId_ = input.readInt64();
+              break;
+            }
+            case 16: {
+              int rawValue = input.readEnum();
+              com.alibaba.otter.canal.protocol.CanalEntry.EventType value = com.alibaba.otter.canal.protocol.CanalEntry.EventType.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(2, rawValue);
+              } else {
+                bitField0_ |= 0x00000002;
+                eventType_ = value;
+              }
+              break;
+            }
+            case 80: {
+              bitField0_ |= 0x00000004;
+              isDdl_ = input.readBool();
+              break;
+            }
+            case 90: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000008;
+              sql_ = bs;
+              break;
+            }
+            case 98: {
+              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+                rowDatas_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.RowData>();
+                mutable_bitField0_ |= 0x00000010;
+              }
+              rowDatas_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.RowData.PARSER, extensionRegistry));
+              break;
+            }
+            case 106: {
+              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
+                mutable_bitField0_ |= 0x00000020;
+              }
+              props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER, extensionRegistry));
+              break;
+            }
+            case 114: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000010;
+              ddlSchemaName_ = bs;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+          rowDatas_ = java.util.Collections.unmodifiableList(rowDatas_);
+        }
+        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+          props_ = java.util.Collections.unmodifiableList(props_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowChange_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.alibaba.otter.canal.protocol.CanalEntry.RowChange.class, com.alibaba.otter.canal.protocol.CanalEntry.RowChange.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<RowChange> PARSER =
+        new com.google.protobuf.AbstractParser<RowChange>() {
+      public RowChange parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new RowChange(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<RowChange> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int TABLEID_FIELD_NUMBER = 1;
+    private long tableId_;
+    /**
+     * <code>optional int64 tableId = 1;</code>
+     *
+     * <pre>
+     **tableId,由数据库产生*
+     * </pre>
+     */
+    public boolean hasTableId() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional int64 tableId = 1;</code>
+     *
+     * <pre>
+     **tableId,由数据库产生*
+     * </pre>
+     */
+    public long getTableId() {
+      return tableId_;
+    }
+
+    public static final int EVENTTYPE_FIELD_NUMBER = 2;
+    private com.alibaba.otter.canal.protocol.CanalEntry.EventType eventType_;
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
+     *
+     * <pre>
+     **数据变更类型*
+     * </pre>
+     */
+    public boolean hasEventType() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
+     *
+     * <pre>
+     **数据变更类型*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType() {
+      return eventType_;
+    }
+
+    public static final int ISDDL_FIELD_NUMBER = 10;
+    private boolean isDdl_;
+    /**
+     * <code>optional bool isDdl = 10 [default = false];</code>
+     *
+     * <pre>
+     ** 标识是否是ddl语句  *
+     * </pre>
+     */
+    public boolean hasIsDdl() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional bool isDdl = 10 [default = false];</code>
+     *
+     * <pre>
+     ** 标识是否是ddl语句  *
+     * </pre>
+     */
+    public boolean getIsDdl() {
+      return isDdl_;
+    }
+
+    public static final int SQL_FIELD_NUMBER = 11;
+    private java.lang.Object sql_;
+    /**
+     * <code>optional string sql = 11;</code>
+     *
+     * <pre>
+     ** ddl/query的sql语句  *
+     * </pre>
+     */
+    public boolean hasSql() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <code>optional string sql = 11;</code>
+     *
+     * <pre>
+     ** ddl/query的sql语句  *
+     * </pre>
+     */
+    public java.lang.String getSql() {
+      java.lang.Object ref = sql_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          sql_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string sql = 11;</code>
+     *
+     * <pre>
+     ** ddl/query的sql语句  *
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getSqlBytes() {
+      java.lang.Object ref = sql_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        sql_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ROWDATAS_FIELD_NUMBER = 12;
+    private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData> rowDatas_;
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+     *
+     * <pre>
+     ** 一次数据库变更可能存在多行  *
+     * </pre>
+     */
+    public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData> getRowDatasList() {
+      return rowDatas_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+     *
+     * <pre>
+     ** 一次数据库变更可能存在多行  *
+     * </pre>
+     */
+    public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder> 
+        getRowDatasOrBuilderList() {
+      return rowDatas_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+     *
+     * <pre>
+     ** 一次数据库变更可能存在多行  *
+     * </pre>
+     */
+    public int getRowDatasCount() {
+      return rowDatas_.size();
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+     *
+     * <pre>
+     ** 一次数据库变更可能存在多行  *
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.RowData getRowDatas(int index) {
+      return rowDatas_.get(index);
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+     *
+     * <pre>
+     ** 一次数据库变更可能存在多行  *
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder getRowDatasOrBuilder(
+        int index) {
+      return rowDatas_.get(index);
+    }
+
+    public static final int PROPS_FIELD_NUMBER = 13;
+    private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public int getPropsCount() {
+      return props_.size();
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+      return props_.get(index);
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index) {
+      return props_.get(index);
+    }
+
+    public static final int DDLSCHEMANAME_FIELD_NUMBER = 14;
+    private java.lang.Object ddlSchemaName_;
+    /**
+     * <code>optional string ddlSchemaName = 14;</code>
+     *
+     * <pre>
+     ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+     * </pre>
+     */
+    public boolean hasDdlSchemaName() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional string ddlSchemaName = 14;</code>
+     *
+     * <pre>
+     ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+     * </pre>
+     */
+    public java.lang.String getDdlSchemaName() {
+      java.lang.Object ref = ddlSchemaName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          ddlSchemaName_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string ddlSchemaName = 14;</code>
+     *
+     * <pre>
+     ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getDdlSchemaNameBytes() {
+      java.lang.Object ref = ddlSchemaName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        ddlSchemaName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private void initFields() {
+      tableId_ = 0L;
+      eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
+      isDdl_ = false;
+      sql_ = "";
+      rowDatas_ = java.util.Collections.emptyList();
+      props_ = java.util.Collections.emptyList();
+      ddlSchemaName_ = "";
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt64(1, tableId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeEnum(2, eventType_.getNumber());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeBool(10, isDdl_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        output.writeBytes(11, getSqlBytes());
+      }
+      for (int i = 0; i < rowDatas_.size(); i++) {
+        output.writeMessage(12, rowDatas_.get(i));
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        output.writeMessage(13, props_.get(i));
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeBytes(14, getDdlSchemaNameBytes());
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, tableId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(2, eventType_.getNumber());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(10, isDdl_);
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(11, getSqlBytes());
+      }
+      for (int i = 0; i < rowDatas_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(12, rowDatas_.get(i));
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(13, props_.get(i));
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(14, getDdlSchemaNameBytes());
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.RowChange prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
     /**
      * Protobuf type {@code com.alibaba.otter.canal.protocol.RowChange}
      *
      * <pre>
-     * *message row 每行变更数据的数据结构*
+     **message row 每行变更数据的数据结构*
      * </pre>
      */
-    public static final class RowChange extends com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.RowChange)
-    RowChangeOrBuilder {
-
-        // Use RowChange.newBuilder() to construct.
-        private RowChange(com.google.protobuf.GeneratedMessage.Builder<?> builder){
-            super(builder);
-            this.unknownFields = builder.getUnknownFields();
-        }
-
-        private RowChange(boolean noInit){
-            this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance();
-        }
-
-        private static final RowChange defaultInstance;
-
-        public static RowChange getDefaultInstance() {
-            return defaultInstance;
-        }
-
-        public RowChange getDefaultInstanceForType() {
-            return defaultInstance;
-        }
-
-        private final com.google.protobuf.UnknownFieldSet unknownFields;
-
-        @java.lang.Override
-        public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
-            return this.unknownFields;
-        }
-
-        private RowChange(com.google.protobuf.CodedInputStream input,
-                          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                      throws com.google.protobuf.InvalidProtocolBufferException{
-            initFields();
-            int mutable_bitField0_ = 0;
-            com.google.protobuf.UnknownFieldSet.Builder unknownFields = com.google.protobuf.UnknownFieldSet.newBuilder();
-            try {
-                boolean done = false;
-                while (!done) {
-                    int tag = input.readTag();
-                    switch (tag) {
-                        case 0:
-                            done = true;
-                            break;
-                        default: {
-                            if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                                done = true;
-                            }
-                            break;
-                        }
-                        case 8: {
-                            bitField0_ |= 0x00000001;
-                            tableId_ = input.readInt64();
-                            break;
-                        }
-                        case 16: {
-                            int rawValue = input.readEnum();
-                            com.alibaba.otter.canal.protocol.CanalEntry.EventType value = com.alibaba.otter.canal.protocol.CanalEntry.EventType.valueOf(rawValue);
-                            if (value == null) {
-                                unknownFields.mergeVarintField(2, rawValue);
-                            } else {
-                                bitField0_ |= 0x00000002;
-                                eventType_ = value;
-                            }
-                            break;
-                        }
-                        case 80: {
-                            bitField0_ |= 0x00000004;
-                            isDdl_ = input.readBool();
-                            break;
-                        }
-                        case 90: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000008;
-                            sql_ = bs;
-                            break;
-                        }
-                        case 98: {
-                            if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                                rowDatas_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.RowData>();
-                                mutable_bitField0_ |= 0x00000010;
-                            }
-                            rowDatas_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.RowData.PARSER,
-                                extensionRegistry));
-                            break;
-                        }
-                        case 106: {
-                            if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-                                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
-                                mutable_bitField0_ |= 0x00000020;
-                            }
-                            props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER,
-                                extensionRegistry));
-                            break;
-                        }
-                        case 114: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000010;
-                            ddlSchemaName_ = bs;
-                            break;
-                        }
-                    }
-                }
-            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                throw e.setUnfinishedMessage(this);
-            } catch (java.io.IOException e) {
-                throw new com.google.protobuf.InvalidProtocolBufferException(e.getMessage()).setUnfinishedMessage(this);
-            } finally {
-                if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                    rowDatas_ = java.util.Collections.unmodifiableList(rowDatas_);
-                }
-                if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-                    props_ = java.util.Collections.unmodifiableList(props_);
-                }
-                this.unknownFields = unknownFields.build();
-                makeExtensionsImmutable();
-            }
-        }
-
-        public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor;
-        }
-
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowChange_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.RowChange.class,
-                com.alibaba.otter.canal.protocol.CanalEntry.RowChange.Builder.class);
-        }
-
-        public static com.google.protobuf.Parser<RowChange> PARSER = new com.google.protobuf.AbstractParser<RowChange>() {
-
-                                                                       public RowChange parsePartialFrom(com.google.protobuf.CodedInputStream input,
-                                                                                                         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                                     throws com.google.protobuf.InvalidProtocolBufferException {
-                                                                           return new RowChange(input,
-                                                                               extensionRegistry);
-                                                                       }
-                                                                   };
-
-        @java.lang.Override
-        public com.google.protobuf.Parser<RowChange> getParserForType() {
-            return PARSER;
-        }
-
-        private int             bitField0_;
-        public static final int TABLEID_FIELD_NUMBER = 1;
-        private long            tableId_;
-
-        /**
-         * <code>optional int64 tableId = 1;</code>
-         *
-         * <pre>
-         * *tableId,由数据库产生*
-         * </pre>
-         */
-        public boolean hasTableId() {
-            return ((bitField0_ & 0x00000001) == 0x00000001);
-        }
-
-        /**
-         * <code>optional int64 tableId = 1;</code>
-         *
-         * <pre>
-         * *tableId,由数据库产生*
-         * </pre>
-         */
-        public long getTableId() {
-            return tableId_;
-        }
-
-        public static final int                                       EVENTTYPE_FIELD_NUMBER = 2;
-        private com.alibaba.otter.canal.protocol.CanalEntry.EventType eventType_;
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
-         *
-         * <pre>
-         * *数据变更类型*
-         * </pre>
-         */
-        public boolean hasEventType() {
-            return ((bitField0_ & 0x00000002) == 0x00000002);
-        }
-
-        /**
-         * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
-         *
-         * <pre>
-         * *数据变更类型*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType() {
-            return eventType_;
-        }
-
-        public static final int ISDDL_FIELD_NUMBER = 10;
-        private boolean         isDdl_;
-
-        /**
-         * <code>optional bool isDdl = 10 [default = false];</code>
-         *
-         * <pre>
-         * * 标识是否是ddl语句  *
-         * </pre>
-         */
-        public boolean hasIsDdl() {
-            return ((bitField0_ & 0x00000004) == 0x00000004);
-        }
-
-        /**
-         * <code>optional bool isDdl = 10 [default = false];</code>
-         *
-         * <pre>
-         * * 标识是否是ddl语句  *
-         * </pre>
-         */
-        public boolean getIsDdl() {
-            return isDdl_;
-        }
-
-        public static final int  SQL_FIELD_NUMBER = 11;
-        private java.lang.Object sql_;
-
-        /**
-         * <code>optional string sql = 11;</code>
-         *
-         * <pre>
-         * * ddl/query的sql语句  *
-         * </pre>
-         */
-        public boolean hasSql() {
-            return ((bitField0_ & 0x00000008) == 0x00000008);
-        }
-
-        /**
-         * <code>optional string sql = 11;</code>
-         *
-         * <pre>
-         * * ddl/query的sql语句  *
-         * </pre>
-         */
-        public java.lang.String getSql() {
-            java.lang.Object ref = sql_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    sql_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string sql = 11;</code>
-         *
-         * <pre>
-         * * ddl/query的sql语句  *
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getSqlBytes() {
-            java.lang.Object ref = sql_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                sql_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        public static final int                                                     ROWDATAS_FIELD_NUMBER = 12;
-        private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData> rowDatas_;
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-         *
-         * <pre>
-         * * 一次数据库变更可能存在多行  *
-         * </pre>
-         */
-        public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData> getRowDatasList() {
-            return rowDatas_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-         *
-         * <pre>
-         * * 一次数据库变更可能存在多行  *
-         * </pre>
-         */
-        public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder> getRowDatasOrBuilderList() {
-            return rowDatas_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-         *
-         * <pre>
-         * * 一次数据库变更可能存在多行  *
-         * </pre>
-         */
-        public int getRowDatasCount() {
-            return rowDatas_.size();
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-         *
-         * <pre>
-         * * 一次数据库变更可能存在多行  *
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.RowData getRowDatas(int index) {
-            return rowDatas_.get(index);
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-         *
-         * <pre>
-         * * 一次数据库变更可能存在多行  *
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder getRowDatasOrBuilder(int index) {
-            return rowDatas_.get(index);
-        }
-
-        public static final int                                                  PROPS_FIELD_NUMBER = 13;
-        private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public int getPropsCount() {
-            return props_.size();
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-            return props_.get(index);
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-            return props_.get(index);
-        }
-
-        public static final int  DDLSCHEMANAME_FIELD_NUMBER = 14;
-        private java.lang.Object ddlSchemaName_;
-
-        /**
-         * <code>optional string ddlSchemaName = 14;</code>
-         *
-         * <pre>
-         * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-         * </pre>
-         */
-        public boolean hasDdlSchemaName() {
-            return ((bitField0_ & 0x00000010) == 0x00000010);
-        }
-
-        /**
-         * <code>optional string ddlSchemaName = 14;</code>
-         *
-         * <pre>
-         * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-         * </pre>
-         */
-        public java.lang.String getDdlSchemaName() {
-            java.lang.Object ref = ddlSchemaName_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    ddlSchemaName_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string ddlSchemaName = 14;</code>
-         *
-         * <pre>
-         * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getDdlSchemaNameBytes() {
-            java.lang.Object ref = ddlSchemaName_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                ddlSchemaName_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        private void initFields() {
-            tableId_ = 0L;
-            eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
-            isDdl_ = false;
-            sql_ = "";
-            rowDatas_ = java.util.Collections.emptyList();
-            props_ = java.util.Collections.emptyList();
-            ddlSchemaName_ = "";
-        }
-
-        private byte memoizedIsInitialized = -1;
-
-        public final boolean isInitialized() {
-            byte isInitialized = memoizedIsInitialized;
-            if (isInitialized == 1) return true;
-            if (isInitialized == 0) return false;
-
-            memoizedIsInitialized = 1;
-            return true;
-        }
-
-        public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
-            getSerializedSize();
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                output.writeInt64(1, tableId_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                output.writeEnum(2, eventType_.getNumber());
-            }
-            if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                output.writeBool(10, isDdl_);
-            }
-            if (((bitField0_ & 0x00000008) == 0x00000008)) {
-                output.writeBytes(11, getSqlBytes());
-            }
-            for (int i = 0; i < rowDatas_.size(); i++) {
-                output.writeMessage(12, rowDatas_.get(i));
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                output.writeMessage(13, props_.get(i));
-            }
-            if (((bitField0_ & 0x00000010) == 0x00000010)) {
-                output.writeBytes(14, getDdlSchemaNameBytes());
-            }
-            getUnknownFields().writeTo(output);
-        }
-
-        private int memoizedSerializedSize = -1;
-
-        public int getSerializedSize() {
-            int size = memoizedSerializedSize;
-            if (size != -1) return size;
-
-            size = 0;
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt64Size(1, tableId_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                size += com.google.protobuf.CodedOutputStream.computeEnumSize(2, eventType_.getNumber());
-            }
-            if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                size += com.google.protobuf.CodedOutputStream.computeBoolSize(10, isDdl_);
-            }
-            if (((bitField0_ & 0x00000008) == 0x00000008)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(11, getSqlBytes());
-            }
-            for (int i = 0; i < rowDatas_.size(); i++) {
-                size += com.google.protobuf.CodedOutputStream.computeMessageSize(12, rowDatas_.get(i));
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                size += com.google.protobuf.CodedOutputStream.computeMessageSize(13, props_.get(i));
-            }
-            if (((bitField0_ & 0x00000010) == 0x00000010)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(14, getDdlSchemaNameBytes());
-            }
-            size += getUnknownFields().getSerializedSize();
-            memoizedSerializedSize = size;
-            return size;
-        }
-
-        private static final long serialVersionUID = 0L;
-
-        @java.lang.Override
-        protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-            return super.writeReplace();
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(com.google.protobuf.ByteString data)
-                                                                                                                          throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(com.google.protobuf.ByteString data,
-                                                                                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                  throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(byte[] data)
-                                                                                                  throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(byte[] data,
-                                                                                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                  throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(java.io.InputStream input)
-                                                                                                                throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(java.io.InputStream input,
-                                                                                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                  throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseDelimitedFrom(java.io.InputStream input)
-                                                                                                                         throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseDelimitedFrom(java.io.InputStream input,
-                                                                                               com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                           throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(com.google.protobuf.CodedInputStream input)
-                                                                                                                                 throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.RowChange parseFrom(com.google.protobuf.CodedInputStream input,
-                                                                                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                  throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static Builder newBuilder() {
-            return Builder.create();
-        }
-
-        public Builder newBuilderForType() {
-            return newBuilder();
-        }
-
-        public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.RowChange prototype) {
-            return newBuilder().mergeFrom(prototype);
-        }
-
-        public Builder toBuilder() {
-            return newBuilder(this);
-        }
-
-        @java.lang.Override
-        protected Builder newBuilderForType(com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-            Builder builder = new Builder(parent);
-            return builder;
-        }
-
-        /**
-         * Protobuf type {@code com.alibaba.otter.canal.protocol.RowChange}
-         *
-         * <pre>
-         * *message row 每行变更数据的数据结构*
-         * </pre>
-         */
-        public static final class Builder extends com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:com.alibaba.otter.canal.protocol.RowChange)
         com.alibaba.otter.canal.protocol.CanalEntry.RowChangeOrBuilder {
-
-            public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor;
-            }
-
-            protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowChange_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.RowChange.class,
-                    com.alibaba.otter.canal.protocol.CanalEntry.RowChange.Builder.class);
-            }
-
-            // Construct using
-            // com.alibaba.otter.canal.protocol.CanalEntry.RowChange.newBuilder()
-            private Builder(){
-                maybeForceBuilderInitialization();
-            }
-
-            private Builder(com.google.protobuf.GeneratedMessage.BuilderParent parent){
-                super(parent);
-                maybeForceBuilderInitialization();
-            }
-
-            private void maybeForceBuilderInitialization() {
-                if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-                    getRowDatasFieldBuilder();
-                    getPropsFieldBuilder();
-                }
-            }
-
-            private static Builder create() {
-                return new Builder();
-            }
-
-            public Builder clear() {
-                super.clear();
-                tableId_ = 0L;
-                bitField0_ = (bitField0_ & ~0x00000001);
-                eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
-                bitField0_ = (bitField0_ & ~0x00000002);
-                isDdl_ = false;
-                bitField0_ = (bitField0_ & ~0x00000004);
-                sql_ = "";
-                bitField0_ = (bitField0_ & ~0x00000008);
-                if (rowDatasBuilder_ == null) {
-                    rowDatas_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000010);
-                } else {
-                    rowDatasBuilder_.clear();
-                }
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000020);
-                } else {
-                    propsBuilder_.clear();
-                }
-                ddlSchemaName_ = "";
-                bitField0_ = (bitField0_ & ~0x00000040);
-                return this;
-            }
-
-            public Builder clone() {
-                return create().mergeFrom(buildPartial());
-            }
-
-            public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.RowChange getDefaultInstanceForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.RowChange.getDefaultInstance();
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.RowChange build() {
-                com.alibaba.otter.canal.protocol.CanalEntry.RowChange result = buildPartial();
-                if (!result.isInitialized()) {
-                    throw newUninitializedMessageException(result);
-                }
-                return result;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.RowChange buildPartial() {
-                com.alibaba.otter.canal.protocol.CanalEntry.RowChange result = new com.alibaba.otter.canal.protocol.CanalEntry.RowChange(this);
-                int from_bitField0_ = bitField0_;
-                int to_bitField0_ = 0;
-                if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-                    to_bitField0_ |= 0x00000001;
-                }
-                result.tableId_ = tableId_;
-                if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-                    to_bitField0_ |= 0x00000002;
-                }
-                result.eventType_ = eventType_;
-                if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-                    to_bitField0_ |= 0x00000004;
-                }
-                result.isDdl_ = isDdl_;
-                if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-                    to_bitField0_ |= 0x00000008;
-                }
-                result.sql_ = sql_;
-                if (rowDatasBuilder_ == null) {
-                    if (((bitField0_ & 0x00000010) == 0x00000010)) {
-                        rowDatas_ = java.util.Collections.unmodifiableList(rowDatas_);
-                        bitField0_ = (bitField0_ & ~0x00000010);
-                    }
-                    result.rowDatas_ = rowDatas_;
-                } else {
-                    result.rowDatas_ = rowDatasBuilder_.build();
-                }
-                if (propsBuilder_ == null) {
-                    if (((bitField0_ & 0x00000020) == 0x00000020)) {
-                        props_ = java.util.Collections.unmodifiableList(props_);
-                        bitField0_ = (bitField0_ & ~0x00000020);
-                    }
-                    result.props_ = props_;
-                } else {
-                    result.props_ = propsBuilder_.build();
-                }
-                if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-                    to_bitField0_ |= 0x00000010;
-                }
-                result.ddlSchemaName_ = ddlSchemaName_;
-                result.bitField0_ = to_bitField0_;
-                onBuilt();
-                return result;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.Message other) {
-                if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.RowChange) {
-                    return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.RowChange) other);
-                } else {
-                    super.mergeFrom(other);
-                    return this;
-                }
-            }
-
-            public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.RowChange other) {
-                if (other == com.alibaba.otter.canal.protocol.CanalEntry.RowChange.getDefaultInstance()) return this;
-                if (other.hasTableId()) {
-                    setTableId(other.getTableId());
-                }
-                if (other.hasEventType()) {
-                    setEventType(other.getEventType());
-                }
-                if (other.hasIsDdl()) {
-                    setIsDdl(other.getIsDdl());
-                }
-                if (other.hasSql()) {
-                    bitField0_ |= 0x00000008;
-                    sql_ = other.sql_;
-                    onChanged();
-                }
-                if (rowDatasBuilder_ == null) {
-                    if (!other.rowDatas_.isEmpty()) {
-                        if (rowDatas_.isEmpty()) {
-                            rowDatas_ = other.rowDatas_;
-                            bitField0_ = (bitField0_ & ~0x00000010);
-                        } else {
-                            ensureRowDatasIsMutable();
-                            rowDatas_.addAll(other.rowDatas_);
-                        }
-                        onChanged();
-                    }
-                } else {
-                    if (!other.rowDatas_.isEmpty()) {
-                        if (rowDatasBuilder_.isEmpty()) {
-                            rowDatasBuilder_.dispose();
-                            rowDatasBuilder_ = null;
-                            rowDatas_ = other.rowDatas_;
-                            bitField0_ = (bitField0_ & ~0x00000010);
-                            rowDatasBuilder_ = com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ? getRowDatasFieldBuilder() : null;
-                        } else {
-                            rowDatasBuilder_.addAllMessages(other.rowDatas_);
-                        }
-                    }
-                }
-                if (propsBuilder_ == null) {
-                    if (!other.props_.isEmpty()) {
-                        if (props_.isEmpty()) {
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000020);
-                        } else {
-                            ensurePropsIsMutable();
-                            props_.addAll(other.props_);
-                        }
-                        onChanged();
-                    }
-                } else {
-                    if (!other.props_.isEmpty()) {
-                        if (propsBuilder_.isEmpty()) {
-                            propsBuilder_.dispose();
-                            propsBuilder_ = null;
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000020);
-                            propsBuilder_ = com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ? getPropsFieldBuilder() : null;
-                        } else {
-                            propsBuilder_.addAllMessages(other.props_);
-                        }
-                    }
-                }
-                if (other.hasDdlSchemaName()) {
-                    bitField0_ |= 0x00000040;
-                    ddlSchemaName_ = other.ddlSchemaName_;
-                    onChanged();
-                }
-                this.mergeUnknownFields(other.getUnknownFields());
-                return this;
-            }
-
-            public final boolean isInitialized() {
-                return true;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
-                                     com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                 throws java.io.IOException {
-                com.alibaba.otter.canal.protocol.CanalEntry.RowChange parsedMessage = null;
-                try {
-                    parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                    parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.RowChange) e.getUnfinishedMessage();
-                    throw e;
-                } finally {
-                    if (parsedMessage != null) {
-                        mergeFrom(parsedMessage);
-                    }
-                }
-                return this;
-            }
-
-            private int  bitField0_;
-
-            private long tableId_;
-
-            /**
-             * <code>optional int64 tableId = 1;</code>
-             *
-             * <pre>
-             * *tableId,由数据库产生*
-             * </pre>
-             */
-            public boolean hasTableId() {
-                return ((bitField0_ & 0x00000001) == 0x00000001);
-            }
-
-            /**
-             * <code>optional int64 tableId = 1;</code>
-             *
-             * <pre>
-             * *tableId,由数据库产生*
-             * </pre>
-             */
-            public long getTableId() {
-                return tableId_;
-            }
-
-            /**
-             * <code>optional int64 tableId = 1;</code>
-             *
-             * <pre>
-             * *tableId,由数据库产生*
-             * </pre>
-             */
-            public Builder setTableId(long value) {
-                bitField0_ |= 0x00000001;
-                tableId_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int64 tableId = 1;</code>
-             *
-             * <pre>
-             * *tableId,由数据库产生*
-             * </pre>
-             */
-            public Builder clearTableId() {
-                bitField0_ = (bitField0_ & ~0x00000001);
-                tableId_ = 0L;
-                onChanged();
-                return this;
-            }
-
-            private com.alibaba.otter.canal.protocol.CanalEntry.EventType eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
-             *
-             * <pre>
-             * *数据变更类型*
-             * </pre>
-             */
-            public boolean hasEventType() {
-                return ((bitField0_ & 0x00000002) == 0x00000002);
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
-             *
-             * <pre>
-             * *数据变更类型*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType() {
-                return eventType_;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
-             *
-             * <pre>
-             * *数据变更类型*
-             * </pre>
-             */
-            public Builder setEventType(com.alibaba.otter.canal.protocol.CanalEntry.EventType value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000002;
-                eventType_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
-             *
-             * <pre>
-             * *数据变更类型*
-             * </pre>
-             */
-            public Builder clearEventType() {
-                bitField0_ = (bitField0_ & ~0x00000002);
-                eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
-                onChanged();
-                return this;
-            }
-
-            private boolean isDdl_;
-
-            /**
-             * <code>optional bool isDdl = 10 [default = false];</code>
-             *
-             * <pre>
-             * * 标识是否是ddl语句  *
-             * </pre>
-             */
-            public boolean hasIsDdl() {
-                return ((bitField0_ & 0x00000004) == 0x00000004);
-            }
-
-            /**
-             * <code>optional bool isDdl = 10 [default = false];</code>
-             *
-             * <pre>
-             * * 标识是否是ddl语句  *
-             * </pre>
-             */
-            public boolean getIsDdl() {
-                return isDdl_;
-            }
-
-            /**
-             * <code>optional bool isDdl = 10 [default = false];</code>
-             *
-             * <pre>
-             * * 标识是否是ddl语句  *
-             * </pre>
-             */
-            public Builder setIsDdl(boolean value) {
-                bitField0_ |= 0x00000004;
-                isDdl_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional bool isDdl = 10 [default = false];</code>
-             *
-             * <pre>
-             * * 标识是否是ddl语句  *
-             * </pre>
-             */
-            public Builder clearIsDdl() {
-                bitField0_ = (bitField0_ & ~0x00000004);
-                isDdl_ = false;
-                onChanged();
-                return this;
-            }
-
-            private java.lang.Object sql_ = "";
-
-            /**
-             * <code>optional string sql = 11;</code>
-             *
-             * <pre>
-             * * ddl/query的sql语句  *
-             * </pre>
-             */
-            public boolean hasSql() {
-                return ((bitField0_ & 0x00000008) == 0x00000008);
-            }
-
-            /**
-             * <code>optional string sql = 11;</code>
-             *
-             * <pre>
-             * * ddl/query的sql语句  *
-             * </pre>
-             */
-            public java.lang.String getSql() {
-                java.lang.Object ref = sql_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        sql_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string sql = 11;</code>
-             *
-             * <pre>
-             * * ddl/query的sql语句  *
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getSqlBytes() {
-                java.lang.Object ref = sql_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    sql_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string sql = 11;</code>
-             *
-             * <pre>
-             * * ddl/query的sql语句  *
-             * </pre>
-             */
-            public Builder setSql(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000008;
-                sql_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string sql = 11;</code>
-             *
-             * <pre>
-             * * ddl/query的sql语句  *
-             * </pre>
-             */
-            public Builder clearSql() {
-                bitField0_ = (bitField0_ & ~0x00000008);
-                sql_ = getDefaultInstance().getSql();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string sql = 11;</code>
-             *
-             * <pre>
-             * * ddl/query的sql语句  *
-             * </pre>
-             */
-            public Builder setSqlBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000008;
-                sql_ = value;
-                onChanged();
-                return this;
-            }
-
-            private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData> rowDatas_ = java.util.Collections.emptyList();
-
-            private void ensureRowDatasIsMutable() {
-                if (!((bitField0_ & 0x00000010) == 0x00000010)) {
-                    rowDatas_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.RowData>(rowDatas_);
-                    bitField0_ |= 0x00000010;
-                }
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.RowData, com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder, com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder> rowDatasBuilder_;
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData> getRowDatasList() {
-                if (rowDatasBuilder_ == null) {
-                    return java.util.Collections.unmodifiableList(rowDatas_);
-                } else {
-                    return rowDatasBuilder_.getMessageList();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public int getRowDatasCount() {
-                if (rowDatasBuilder_ == null) {
-                    return rowDatas_.size();
-                } else {
-                    return rowDatasBuilder_.getCount();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.RowData getRowDatas(int index) {
-                if (rowDatasBuilder_ == null) {
-                    return rowDatas_.get(index);
-                } else {
-                    return rowDatasBuilder_.getMessage(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public Builder setRowDatas(int index, com.alibaba.otter.canal.protocol.CanalEntry.RowData value) {
-                if (rowDatasBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensureRowDatasIsMutable();
-                    rowDatas_.set(index, value);
-                    onChanged();
-                } else {
-                    rowDatasBuilder_.setMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public Builder setRowDatas(int index,
-                                       com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder builderForValue) {
-                if (rowDatasBuilder_ == null) {
-                    ensureRowDatasIsMutable();
-                    rowDatas_.set(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    rowDatasBuilder_.setMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public Builder addRowDatas(com.alibaba.otter.canal.protocol.CanalEntry.RowData value) {
-                if (rowDatasBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensureRowDatasIsMutable();
-                    rowDatas_.add(value);
-                    onChanged();
-                } else {
-                    rowDatasBuilder_.addMessage(value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public Builder addRowDatas(int index, com.alibaba.otter.canal.protocol.CanalEntry.RowData value) {
-                if (rowDatasBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensureRowDatasIsMutable();
-                    rowDatas_.add(index, value);
-                    onChanged();
-                } else {
-                    rowDatasBuilder_.addMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public Builder addRowDatas(com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder builderForValue) {
-                if (rowDatasBuilder_ == null) {
-                    ensureRowDatasIsMutable();
-                    rowDatas_.add(builderForValue.build());
-                    onChanged();
-                } else {
-                    rowDatasBuilder_.addMessage(builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public Builder addRowDatas(int index,
-                                       com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder builderForValue) {
-                if (rowDatasBuilder_ == null) {
-                    ensureRowDatasIsMutable();
-                    rowDatas_.add(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    rowDatasBuilder_.addMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public Builder addAllRowDatas(java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.RowData> values) {
-                if (rowDatasBuilder_ == null) {
-                    ensureRowDatasIsMutable();
-                    com.google.protobuf.AbstractMessageLite.Builder.addAll(values, rowDatas_);
-                    onChanged();
-                } else {
-                    rowDatasBuilder_.addAllMessages(values);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public Builder clearRowDatas() {
-                if (rowDatasBuilder_ == null) {
-                    rowDatas_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000010);
-                    onChanged();
-                } else {
-                    rowDatasBuilder_.clear();
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public Builder removeRowDatas(int index) {
-                if (rowDatasBuilder_ == null) {
-                    ensureRowDatasIsMutable();
-                    rowDatas_.remove(index);
-                    onChanged();
-                } else {
-                    rowDatasBuilder_.remove(index);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder getRowDatasBuilder(int index) {
-                return getRowDatasFieldBuilder().getBuilder(index);
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder getRowDatasOrBuilder(int index) {
-                if (rowDatasBuilder_ == null) {
-                    return rowDatas_.get(index);
-                } else {
-                    return rowDatasBuilder_.getMessageOrBuilder(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder> getRowDatasOrBuilderList() {
-                if (rowDatasBuilder_ != null) {
-                    return rowDatasBuilder_.getMessageOrBuilderList();
-                } else {
-                    return java.util.Collections.unmodifiableList(rowDatas_);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder addRowDatasBuilder() {
-                return getRowDatasFieldBuilder().addBuilder(com.alibaba.otter.canal.protocol.CanalEntry.RowData.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder addRowDatasBuilder(int index) {
-                return getRowDatasFieldBuilder().addBuilder(index,
-                    com.alibaba.otter.canal.protocol.CanalEntry.RowData.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
-             *
-             * <pre>
-             * * 一次数据库变更可能存在多行  *
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder> getRowDatasBuilderList() {
-                return getRowDatasFieldBuilder().getBuilderList();
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.RowData, com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder, com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder> getRowDatasFieldBuilder() {
-                if (rowDatasBuilder_ == null) {
-                    rowDatasBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.RowData, com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder, com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder>(rowDatas_,
-                        ((bitField0_ & 0x00000010) == 0x00000010),
-                        getParentForChildren(),
-                        isClean());
-                    rowDatas_ = null;
-                }
-                return rowDatasBuilder_;
-            }
-
-            private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ = java.util.Collections.emptyList();
-
-            private void ensurePropsIsMutable() {
-                if (!((bitField0_ & 0x00000020) == 0x00000020)) {
-                    props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
-                    bitField0_ |= 0x00000020;
-                }
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-                if (propsBuilder_ == null) {
-                    return java.util.Collections.unmodifiableList(props_);
-                } else {
-                    return propsBuilder_.getMessageList();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public int getPropsCount() {
-                if (propsBuilder_ == null) {
-                    return props_.size();
-                } else {
-                    return propsBuilder_.getCount();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessage(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.set(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.set(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addAllProps(java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    com.google.protobuf.AbstractMessageLite.Builder.addAll(values, props_);
-                    onChanged();
-                } else {
-                    propsBuilder_.addAllMessages(values);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder clearProps() {
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000020);
-                    onChanged();
-                } else {
-                    propsBuilder_.clear();
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder removeProps(int index) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.remove(index);
-                    onChanged();
-                } else {
-                    propsBuilder_.remove(index);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(int index) {
-                return getPropsFieldBuilder().getBuilder(index);
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessageOrBuilder(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-                if (propsBuilder_ != null) {
-                    return propsBuilder_.getMessageOrBuilderList();
-                } else {
-                    return java.util.Collections.unmodifiableList(props_);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
-                return getPropsFieldBuilder().addBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(int index) {
-                return getPropsFieldBuilder().addBuilder(index,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> getPropsBuilderList() {
-                return getPropsFieldBuilder().getBuilderList();
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsFieldBuilder() {
-                if (propsBuilder_ == null) {
-                    propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(props_,
-                        ((bitField0_ & 0x00000020) == 0x00000020),
-                        getParentForChildren(),
-                        isClean());
-                    props_ = null;
-                }
-                return propsBuilder_;
-            }
-
-            private java.lang.Object ddlSchemaName_ = "";
-
-            /**
-             * <code>optional string ddlSchemaName = 14;</code>
-             *
-             * <pre>
-             * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-             * </pre>
-             */
-            public boolean hasDdlSchemaName() {
-                return ((bitField0_ & 0x00000040) == 0x00000040);
-            }
-
-            /**
-             * <code>optional string ddlSchemaName = 14;</code>
-             *
-             * <pre>
-             * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-             * </pre>
-             */
-            public java.lang.String getDdlSchemaName() {
-                java.lang.Object ref = ddlSchemaName_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        ddlSchemaName_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string ddlSchemaName = 14;</code>
-             *
-             * <pre>
-             * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getDdlSchemaNameBytes() {
-                java.lang.Object ref = ddlSchemaName_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    ddlSchemaName_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string ddlSchemaName = 14;</code>
-             *
-             * <pre>
-             * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-             * </pre>
-             */
-            public Builder setDdlSchemaName(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000040;
-                ddlSchemaName_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string ddlSchemaName = 14;</code>
-             *
-             * <pre>
-             * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-             * </pre>
-             */
-            public Builder clearDdlSchemaName() {
-                bitField0_ = (bitField0_ & ~0x00000040);
-                ddlSchemaName_ = getDefaultInstance().getDdlSchemaName();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string ddlSchemaName = 14;</code>
-             *
-             * <pre>
-             * * ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
-             * </pre>
-             */
-            public Builder setDdlSchemaNameBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000040;
-                ddlSchemaName_ = value;
-                onChanged();
-                return this;
-            }
-
-            // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.RowChange)
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowChange_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.alibaba.otter.canal.protocol.CanalEntry.RowChange.class, com.alibaba.otter.canal.protocol.CanalEntry.RowChange.Builder.class);
+      }
+
+      // Construct using com.alibaba.otter.canal.protocol.CanalEntry.RowChange.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getRowDatasFieldBuilder();
+          getPropsFieldBuilder();
         }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
 
-        static {
-            defaultInstance = new RowChange(true);
-            defaultInstance.initFields();
+      public Builder clear() {
+        super.clear();
+        tableId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        isDdl_ = false;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        sql_ = "";
+        bitField0_ = (bitField0_ & ~0x00000008);
+        if (rowDatasBuilder_ == null) {
+          rowDatas_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000010);
+        } else {
+          rowDatasBuilder_.clear();
         }
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000020);
+        } else {
+          propsBuilder_.clear();
+        }
+        ddlSchemaName_ = "";
+        bitField0_ = (bitField0_ & ~0x00000040);
+        return this;
+      }
 
-        // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.RowChange)
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.RowChange getDefaultInstanceForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.RowChange.getDefaultInstance();
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.RowChange build() {
+        com.alibaba.otter.canal.protocol.CanalEntry.RowChange result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.RowChange buildPartial() {
+        com.alibaba.otter.canal.protocol.CanalEntry.RowChange result = new com.alibaba.otter.canal.protocol.CanalEntry.RowChange(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.tableId_ = tableId_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.eventType_ = eventType_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.isDdl_ = isDdl_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.sql_ = sql_;
+        if (rowDatasBuilder_ == null) {
+          if (((bitField0_ & 0x00000010) == 0x00000010)) {
+            rowDatas_ = java.util.Collections.unmodifiableList(rowDatas_);
+            bitField0_ = (bitField0_ & ~0x00000010);
+          }
+          result.rowDatas_ = rowDatas_;
+        } else {
+          result.rowDatas_ = rowDatasBuilder_.build();
+        }
+        if (propsBuilder_ == null) {
+          if (((bitField0_ & 0x00000020) == 0x00000020)) {
+            props_ = java.util.Collections.unmodifiableList(props_);
+            bitField0_ = (bitField0_ & ~0x00000020);
+          }
+          result.props_ = props_;
+        } else {
+          result.props_ = propsBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.ddlSchemaName_ = ddlSchemaName_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.RowChange) {
+          return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.RowChange)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.RowChange other) {
+        if (other == com.alibaba.otter.canal.protocol.CanalEntry.RowChange.getDefaultInstance()) return this;
+        if (other.hasTableId()) {
+          setTableId(other.getTableId());
+        }
+        if (other.hasEventType()) {
+          setEventType(other.getEventType());
+        }
+        if (other.hasIsDdl()) {
+          setIsDdl(other.getIsDdl());
+        }
+        if (other.hasSql()) {
+          bitField0_ |= 0x00000008;
+          sql_ = other.sql_;
+          onChanged();
+        }
+        if (rowDatasBuilder_ == null) {
+          if (!other.rowDatas_.isEmpty()) {
+            if (rowDatas_.isEmpty()) {
+              rowDatas_ = other.rowDatas_;
+              bitField0_ = (bitField0_ & ~0x00000010);
+            } else {
+              ensureRowDatasIsMutable();
+              rowDatas_.addAll(other.rowDatas_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.rowDatas_.isEmpty()) {
+            if (rowDatasBuilder_.isEmpty()) {
+              rowDatasBuilder_.dispose();
+              rowDatasBuilder_ = null;
+              rowDatas_ = other.rowDatas_;
+              bitField0_ = (bitField0_ & ~0x00000010);
+              rowDatasBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getRowDatasFieldBuilder() : null;
+            } else {
+              rowDatasBuilder_.addAllMessages(other.rowDatas_);
+            }
+          }
+        }
+        if (propsBuilder_ == null) {
+          if (!other.props_.isEmpty()) {
+            if (props_.isEmpty()) {
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000020);
+            } else {
+              ensurePropsIsMutable();
+              props_.addAll(other.props_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.props_.isEmpty()) {
+            if (propsBuilder_.isEmpty()) {
+              propsBuilder_.dispose();
+              propsBuilder_ = null;
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000020);
+              propsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getPropsFieldBuilder() : null;
+            } else {
+              propsBuilder_.addAllMessages(other.props_);
+            }
+          }
+        }
+        if (other.hasDdlSchemaName()) {
+          bitField0_ |= 0x00000040;
+          ddlSchemaName_ = other.ddlSchemaName_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.alibaba.otter.canal.protocol.CanalEntry.RowChange parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.RowChange) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private long tableId_ ;
+      /**
+       * <code>optional int64 tableId = 1;</code>
+       *
+       * <pre>
+       **tableId,由数据库产生*
+       * </pre>
+       */
+      public boolean hasTableId() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional int64 tableId = 1;</code>
+       *
+       * <pre>
+       **tableId,由数据库产生*
+       * </pre>
+       */
+      public long getTableId() {
+        return tableId_;
+      }
+      /**
+       * <code>optional int64 tableId = 1;</code>
+       *
+       * <pre>
+       **tableId,由数据库产生*
+       * </pre>
+       */
+      public Builder setTableId(long value) {
+        bitField0_ |= 0x00000001;
+        tableId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 tableId = 1;</code>
+       *
+       * <pre>
+       **tableId,由数据库产生*
+       * </pre>
+       */
+      public Builder clearTableId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        tableId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private com.alibaba.otter.canal.protocol.CanalEntry.EventType eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
+       *
+       * <pre>
+       **数据变更类型*
+       * </pre>
+       */
+      public boolean hasEventType() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
+       *
+       * <pre>
+       **数据变更类型*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.EventType getEventType() {
+        return eventType_;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
+       *
+       * <pre>
+       **数据变更类型*
+       * </pre>
+       */
+      public Builder setEventType(com.alibaba.otter.canal.protocol.CanalEntry.EventType value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00000002;
+        eventType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional .com.alibaba.otter.canal.protocol.EventType eventType = 2 [default = UPDATE];</code>
+       *
+       * <pre>
+       **数据变更类型*
+       * </pre>
+       */
+      public Builder clearEventType() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        eventType_ = com.alibaba.otter.canal.protocol.CanalEntry.EventType.UPDATE;
+        onChanged();
+        return this;
+      }
+
+      private boolean isDdl_ ;
+      /**
+       * <code>optional bool isDdl = 10 [default = false];</code>
+       *
+       * <pre>
+       ** 标识是否是ddl语句  *
+       * </pre>
+       */
+      public boolean hasIsDdl() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <code>optional bool isDdl = 10 [default = false];</code>
+       *
+       * <pre>
+       ** 标识是否是ddl语句  *
+       * </pre>
+       */
+      public boolean getIsDdl() {
+        return isDdl_;
+      }
+      /**
+       * <code>optional bool isDdl = 10 [default = false];</code>
+       *
+       * <pre>
+       ** 标识是否是ddl语句  *
+       * </pre>
+       */
+      public Builder setIsDdl(boolean value) {
+        bitField0_ |= 0x00000004;
+        isDdl_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bool isDdl = 10 [default = false];</code>
+       *
+       * <pre>
+       ** 标识是否是ddl语句  *
+       * </pre>
+       */
+      public Builder clearIsDdl() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        isDdl_ = false;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object sql_ = "";
+      /**
+       * <code>optional string sql = 11;</code>
+       *
+       * <pre>
+       ** ddl/query的sql语句  *
+       * </pre>
+       */
+      public boolean hasSql() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional string sql = 11;</code>
+       *
+       * <pre>
+       ** ddl/query的sql语句  *
+       * </pre>
+       */
+      public java.lang.String getSql() {
+        java.lang.Object ref = sql_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            sql_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string sql = 11;</code>
+       *
+       * <pre>
+       ** ddl/query的sql语句  *
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getSqlBytes() {
+        java.lang.Object ref = sql_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          sql_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string sql = 11;</code>
+       *
+       * <pre>
+       ** ddl/query的sql语句  *
+       * </pre>
+       */
+      public Builder setSql(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+        sql_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string sql = 11;</code>
+       *
+       * <pre>
+       ** ddl/query的sql语句  *
+       * </pre>
+       */
+      public Builder clearSql() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        sql_ = getDefaultInstance().getSql();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string sql = 11;</code>
+       *
+       * <pre>
+       ** ddl/query的sql语句  *
+       * </pre>
+       */
+      public Builder setSqlBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000008;
+        sql_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData> rowDatas_ =
+        java.util.Collections.emptyList();
+      private void ensureRowDatasIsMutable() {
+        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
+          rowDatas_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.RowData>(rowDatas_);
+          bitField0_ |= 0x00000010;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.RowData, com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder, com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder> rowDatasBuilder_;
+
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData> getRowDatasList() {
+        if (rowDatasBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(rowDatas_);
+        } else {
+          return rowDatasBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public int getRowDatasCount() {
+        if (rowDatasBuilder_ == null) {
+          return rowDatas_.size();
+        } else {
+          return rowDatasBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.RowData getRowDatas(int index) {
+        if (rowDatasBuilder_ == null) {
+          return rowDatas_.get(index);
+        } else {
+          return rowDatasBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public Builder setRowDatas(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.RowData value) {
+        if (rowDatasBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureRowDatasIsMutable();
+          rowDatas_.set(index, value);
+          onChanged();
+        } else {
+          rowDatasBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public Builder setRowDatas(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder builderForValue) {
+        if (rowDatasBuilder_ == null) {
+          ensureRowDatasIsMutable();
+          rowDatas_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          rowDatasBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public Builder addRowDatas(com.alibaba.otter.canal.protocol.CanalEntry.RowData value) {
+        if (rowDatasBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureRowDatasIsMutable();
+          rowDatas_.add(value);
+          onChanged();
+        } else {
+          rowDatasBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public Builder addRowDatas(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.RowData value) {
+        if (rowDatasBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureRowDatasIsMutable();
+          rowDatas_.add(index, value);
+          onChanged();
+        } else {
+          rowDatasBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public Builder addRowDatas(
+          com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder builderForValue) {
+        if (rowDatasBuilder_ == null) {
+          ensureRowDatasIsMutable();
+          rowDatas_.add(builderForValue.build());
+          onChanged();
+        } else {
+          rowDatasBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public Builder addRowDatas(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder builderForValue) {
+        if (rowDatasBuilder_ == null) {
+          ensureRowDatasIsMutable();
+          rowDatas_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          rowDatasBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public Builder addAllRowDatas(
+          java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.RowData> values) {
+        if (rowDatasBuilder_ == null) {
+          ensureRowDatasIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, rowDatas_);
+          onChanged();
+        } else {
+          rowDatasBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public Builder clearRowDatas() {
+        if (rowDatasBuilder_ == null) {
+          rowDatas_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000010);
+          onChanged();
+        } else {
+          rowDatasBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public Builder removeRowDatas(int index) {
+        if (rowDatasBuilder_ == null) {
+          ensureRowDatasIsMutable();
+          rowDatas_.remove(index);
+          onChanged();
+        } else {
+          rowDatasBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder getRowDatasBuilder(
+          int index) {
+        return getRowDatasFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder getRowDatasOrBuilder(
+          int index) {
+        if (rowDatasBuilder_ == null) {
+          return rowDatas_.get(index);  } else {
+          return rowDatasBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder> 
+           getRowDatasOrBuilderList() {
+        if (rowDatasBuilder_ != null) {
+          return rowDatasBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(rowDatas_);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder addRowDatasBuilder() {
+        return getRowDatasFieldBuilder().addBuilder(
+            com.alibaba.otter.canal.protocol.CanalEntry.RowData.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder addRowDatasBuilder(
+          int index) {
+        return getRowDatasFieldBuilder().addBuilder(
+            index, com.alibaba.otter.canal.protocol.CanalEntry.RowData.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.RowData rowDatas = 12;</code>
+       *
+       * <pre>
+       ** 一次数据库变更可能存在多行  *
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder> 
+           getRowDatasBuilderList() {
+        return getRowDatasFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.RowData, com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder, com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder> 
+          getRowDatasFieldBuilder() {
+        if (rowDatasBuilder_ == null) {
+          rowDatasBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              com.alibaba.otter.canal.protocol.CanalEntry.RowData, com.alibaba.otter.canal.protocol.CanalEntry.RowData.Builder, com.alibaba.otter.canal.protocol.CanalEntry.RowDataOrBuilder>(
+                  rowDatas_,
+                  ((bitField0_ & 0x00000010) == 0x00000010),
+                  getParentForChildren(),
+                  isClean());
+          rowDatas_ = null;
+        }
+        return rowDatasBuilder_;
+      }
+
+      private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ =
+        java.util.Collections.emptyList();
+      private void ensurePropsIsMutable() {
+        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
+          props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
+          bitField0_ |= 0x00000020;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
+
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+        if (propsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(props_);
+        } else {
+          return propsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public int getPropsCount() {
+        if (propsBuilder_ == null) {
+          return props_.size();
+        } else {
+          return propsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);
+        } else {
+          return propsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.set(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addAllProps(
+          java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, props_);
+          onChanged();
+        } else {
+          propsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder clearProps() {
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000020);
+          onChanged();
+        } else {
+          propsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder removeProps(int index) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.remove(index);
+          onChanged();
+        } else {
+          propsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+          int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);  } else {
+          return propsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+           getPropsOrBuilderList() {
+        if (propsBuilder_ != null) {
+          return propsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(props_);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
+        return getPropsFieldBuilder().addBuilder(
+            com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().addBuilder(
+            index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 13;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> 
+           getPropsBuilderList() {
+        return getPropsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+          getPropsFieldBuilder() {
+        if (propsBuilder_ == null) {
+          propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(
+                  props_,
+                  ((bitField0_ & 0x00000020) == 0x00000020),
+                  getParentForChildren(),
+                  isClean());
+          props_ = null;
+        }
+        return propsBuilder_;
+      }
+
+      private java.lang.Object ddlSchemaName_ = "";
+      /**
+       * <code>optional string ddlSchemaName = 14;</code>
+       *
+       * <pre>
+       ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+       * </pre>
+       */
+      public boolean hasDdlSchemaName() {
+        return ((bitField0_ & 0x00000040) == 0x00000040);
+      }
+      /**
+       * <code>optional string ddlSchemaName = 14;</code>
+       *
+       * <pre>
+       ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+       * </pre>
+       */
+      public java.lang.String getDdlSchemaName() {
+        java.lang.Object ref = ddlSchemaName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            ddlSchemaName_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string ddlSchemaName = 14;</code>
+       *
+       * <pre>
+       ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getDdlSchemaNameBytes() {
+        java.lang.Object ref = ddlSchemaName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          ddlSchemaName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string ddlSchemaName = 14;</code>
+       *
+       * <pre>
+       ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+       * </pre>
+       */
+      public Builder setDdlSchemaName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000040;
+        ddlSchemaName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string ddlSchemaName = 14;</code>
+       *
+       * <pre>
+       ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+       * </pre>
+       */
+      public Builder clearDdlSchemaName() {
+        bitField0_ = (bitField0_ & ~0x00000040);
+        ddlSchemaName_ = getDefaultInstance().getDdlSchemaName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string ddlSchemaName = 14;</code>
+       *
+       * <pre>
+       ** ddl/query的schemaName，会存在跨库ddl，需要保留执行ddl的当前schemaName  *
+       * </pre>
+       */
+      public Builder setDdlSchemaNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000040;
+        ddlSchemaName_ = value;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.RowChange)
     }
 
-    public interface TransactionBeginOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.TransactionBegin)
-    com.google.protobuf.MessageOrBuilder {
-
-        /**
-         * <code>optional int64 executeTime = 1;</code>
-         *
-         * <pre>
-         * *已废弃，请使用header里的executeTime*
-         * </pre>
-         */
-        boolean hasExecuteTime();
-
-        /**
-         * <code>optional int64 executeTime = 1;</code>
-         *
-         * <pre>
-         * *已废弃，请使用header里的executeTime*
-         * </pre>
-         */
-        long getExecuteTime();
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *已废弃，Begin里不提供事务id*
-         * </pre>
-         */
-        boolean hasTransactionId();
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *已废弃，Begin里不提供事务id*
-         * </pre>
-         */
-        java.lang.String getTransactionId();
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *已废弃，Begin里不提供事务id*
-         * </pre>
-         */
-        com.google.protobuf.ByteString getTransactionIdBytes();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        int getPropsCount();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index);
-
-        /**
-         * <code>optional int64 threadId = 4;</code>
-         *
-         * <pre>
-         * *执行的thread Id*
-         * </pre>
-         */
-        boolean hasThreadId();
-
-        /**
-         * <code>optional int64 threadId = 4;</code>
-         *
-         * <pre>
-         * *执行的thread Id*
-         * </pre>
-         */
-        long getThreadId();
+    static {
+      defaultInstance = new RowChange(true);
+      defaultInstance.initFields();
     }
 
+    // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.RowChange)
+  }
+
+  public interface TransactionBeginOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.TransactionBegin)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int64 executeTime = 1;</code>
+     *
+     * <pre>
+     **已废弃，请使用header里的executeTime*
+     * </pre>
+     */
+    boolean hasExecuteTime();
+    /**
+     * <code>optional int64 executeTime = 1;</code>
+     *
+     * <pre>
+     **已废弃，请使用header里的executeTime*
+     * </pre>
+     */
+    long getExecuteTime();
+
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **已废弃，Begin里不提供事务id*
+     * </pre>
+     */
+    boolean hasTransactionId();
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **已废弃，Begin里不提供事务id*
+     * </pre>
+     */
+    java.lang.String getTransactionId();
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **已废弃，Begin里不提供事务id*
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getTransactionIdBytes();
+
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> 
+        getPropsList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    int getPropsCount();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index);
+
+    /**
+     * <code>optional int64 threadId = 4;</code>
+     *
+     * <pre>
+     **执行的thread Id*
+     * </pre>
+     */
+    boolean hasThreadId();
+    /**
+     * <code>optional int64 threadId = 4;</code>
+     *
+     * <pre>
+     **执行的thread Id*
+     * </pre>
+     */
+    long getThreadId();
+  }
+  /**
+   * Protobuf type {@code com.alibaba.otter.canal.protocol.TransactionBegin}
+   *
+   * <pre>
+   **开始事务的一些信息*
+   * </pre>
+   */
+  public static final class TransactionBegin extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.TransactionBegin)
+      TransactionBeginOrBuilder {
+    // Use TransactionBegin.newBuilder() to construct.
+    private TransactionBegin(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private TransactionBegin(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final TransactionBegin defaultInstance;
+    public static TransactionBegin getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public TransactionBegin getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private TransactionBegin(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              executeTime_ = input.readInt64();
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              transactionId_ = bs;
+              break;
+            }
+            case 26: {
+              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
+                mutable_bitField0_ |= 0x00000004;
+              }
+              props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER, extensionRegistry));
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000004;
+              threadId_ = input.readInt64();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+          props_ = java.util.Collections.unmodifiableList(props_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.class, com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<TransactionBegin> PARSER =
+        new com.google.protobuf.AbstractParser<TransactionBegin>() {
+      public TransactionBegin parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new TransactionBegin(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<TransactionBegin> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int EXECUTETIME_FIELD_NUMBER = 1;
+    private long executeTime_;
+    /**
+     * <code>optional int64 executeTime = 1;</code>
+     *
+     * <pre>
+     **已废弃，请使用header里的executeTime*
+     * </pre>
+     */
+    public boolean hasExecuteTime() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional int64 executeTime = 1;</code>
+     *
+     * <pre>
+     **已废弃，请使用header里的executeTime*
+     * </pre>
+     */
+    public long getExecuteTime() {
+      return executeTime_;
+    }
+
+    public static final int TRANSACTIONID_FIELD_NUMBER = 2;
+    private java.lang.Object transactionId_;
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **已废弃，Begin里不提供事务id*
+     * </pre>
+     */
+    public boolean hasTransactionId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **已废弃，Begin里不提供事务id*
+     * </pre>
+     */
+    public java.lang.String getTransactionId() {
+      java.lang.Object ref = transactionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          transactionId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **已废弃，Begin里不提供事务id*
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getTransactionIdBytes() {
+      java.lang.Object ref = transactionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        transactionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int PROPS_FIELD_NUMBER = 3;
+    private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public int getPropsCount() {
+      return props_.size();
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+      return props_.get(index);
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index) {
+      return props_.get(index);
+    }
+
+    public static final int THREADID_FIELD_NUMBER = 4;
+    private long threadId_;
+    /**
+     * <code>optional int64 threadId = 4;</code>
+     *
+     * <pre>
+     **执行的thread Id*
+     * </pre>
+     */
+    public boolean hasThreadId() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <code>optional int64 threadId = 4;</code>
+     *
+     * <pre>
+     **执行的thread Id*
+     * </pre>
+     */
+    public long getThreadId() {
+      return threadId_;
+    }
+
+    private void initFields() {
+      executeTime_ = 0L;
+      transactionId_ = "";
+      props_ = java.util.Collections.emptyList();
+      threadId_ = 0L;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt64(1, executeTime_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeBytes(2, getTransactionIdBytes());
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        output.writeMessage(3, props_.get(i));
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeInt64(4, threadId_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, executeTime_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(2, getTransactionIdBytes());
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, props_.get(i));
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(4, threadId_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
     /**
      * Protobuf type {@code com.alibaba.otter.canal.protocol.TransactionBegin}
      *
      * <pre>
-     * *开始事务的一些信息*
+     **开始事务的一些信息*
      * </pre>
      */
-    public static final class TransactionBegin extends com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.TransactionBegin)
-    TransactionBeginOrBuilder {
-
-        // Use TransactionBegin.newBuilder() to construct.
-        private TransactionBegin(com.google.protobuf.GeneratedMessage.Builder<?> builder){
-            super(builder);
-            this.unknownFields = builder.getUnknownFields();
-        }
-
-        private TransactionBegin(boolean noInit){
-            this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance();
-        }
-
-        private static final TransactionBegin defaultInstance;
-
-        public static TransactionBegin getDefaultInstance() {
-            return defaultInstance;
-        }
-
-        public TransactionBegin getDefaultInstanceForType() {
-            return defaultInstance;
-        }
-
-        private final com.google.protobuf.UnknownFieldSet unknownFields;
-
-        @java.lang.Override
-        public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
-            return this.unknownFields;
-        }
-
-        private TransactionBegin(com.google.protobuf.CodedInputStream input,
-                                 com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                             throws com.google.protobuf.InvalidProtocolBufferException{
-            initFields();
-            int mutable_bitField0_ = 0;
-            com.google.protobuf.UnknownFieldSet.Builder unknownFields = com.google.protobuf.UnknownFieldSet.newBuilder();
-            try {
-                boolean done = false;
-                while (!done) {
-                    int tag = input.readTag();
-                    switch (tag) {
-                        case 0:
-                            done = true;
-                            break;
-                        default: {
-                            if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                                done = true;
-                            }
-                            break;
-                        }
-                        case 8: {
-                            bitField0_ |= 0x00000001;
-                            executeTime_ = input.readInt64();
-                            break;
-                        }
-                        case 18: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000002;
-                            transactionId_ = bs;
-                            break;
-                        }
-                        case 26: {
-                            if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-                                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
-                                mutable_bitField0_ |= 0x00000004;
-                            }
-                            props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER,
-                                extensionRegistry));
-                            break;
-                        }
-                        case 32: {
-                            bitField0_ |= 0x00000004;
-                            threadId_ = input.readInt64();
-                            break;
-                        }
-                    }
-                }
-            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                throw e.setUnfinishedMessage(this);
-            } catch (java.io.IOException e) {
-                throw new com.google.protobuf.InvalidProtocolBufferException(e.getMessage()).setUnfinishedMessage(this);
-            } finally {
-                if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-                    props_ = java.util.Collections.unmodifiableList(props_);
-                }
-                this.unknownFields = unknownFields.build();
-                makeExtensionsImmutable();
-            }
-        }
-
-        public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor;
-        }
-
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.class,
-                com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.Builder.class);
-        }
-
-        public static com.google.protobuf.Parser<TransactionBegin> PARSER = new com.google.protobuf.AbstractParser<TransactionBegin>() {
-
-                                                                              public TransactionBegin parsePartialFrom(com.google.protobuf.CodedInputStream input,
-                                                                                                                       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                                                   throws com.google.protobuf.InvalidProtocolBufferException {
-                                                                                  return new TransactionBegin(input,
-                                                                                      extensionRegistry);
-                                                                              }
-                                                                          };
-
-        @java.lang.Override
-        public com.google.protobuf.Parser<TransactionBegin> getParserForType() {
-            return PARSER;
-        }
-
-        private int             bitField0_;
-        public static final int EXECUTETIME_FIELD_NUMBER = 1;
-        private long            executeTime_;
-
-        /**
-         * <code>optional int64 executeTime = 1;</code>
-         *
-         * <pre>
-         * *已废弃，请使用header里的executeTime*
-         * </pre>
-         */
-        public boolean hasExecuteTime() {
-            return ((bitField0_ & 0x00000001) == 0x00000001);
-        }
-
-        /**
-         * <code>optional int64 executeTime = 1;</code>
-         *
-         * <pre>
-         * *已废弃，请使用header里的executeTime*
-         * </pre>
-         */
-        public long getExecuteTime() {
-            return executeTime_;
-        }
-
-        public static final int  TRANSACTIONID_FIELD_NUMBER = 2;
-        private java.lang.Object transactionId_;
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *已废弃，Begin里不提供事务id*
-         * </pre>
-         */
-        public boolean hasTransactionId() {
-            return ((bitField0_ & 0x00000002) == 0x00000002);
-        }
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *已废弃，Begin里不提供事务id*
-         * </pre>
-         */
-        public java.lang.String getTransactionId() {
-            java.lang.Object ref = transactionId_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    transactionId_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *已废弃，Begin里不提供事务id*
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getTransactionIdBytes() {
-            java.lang.Object ref = transactionId_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                transactionId_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        public static final int                                                  PROPS_FIELD_NUMBER = 3;
-        private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public int getPropsCount() {
-            return props_.size();
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-            return props_.get(index);
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-            return props_.get(index);
-        }
-
-        public static final int THREADID_FIELD_NUMBER = 4;
-        private long            threadId_;
-
-        /**
-         * <code>optional int64 threadId = 4;</code>
-         *
-         * <pre>
-         * *执行的thread Id*
-         * </pre>
-         */
-        public boolean hasThreadId() {
-            return ((bitField0_ & 0x00000004) == 0x00000004);
-        }
-
-        /**
-         * <code>optional int64 threadId = 4;</code>
-         *
-         * <pre>
-         * *执行的thread Id*
-         * </pre>
-         */
-        public long getThreadId() {
-            return threadId_;
-        }
-
-        private void initFields() {
-            executeTime_ = 0L;
-            transactionId_ = "";
-            props_ = java.util.Collections.emptyList();
-            threadId_ = 0L;
-        }
-
-        private byte memoizedIsInitialized = -1;
-
-        public final boolean isInitialized() {
-            byte isInitialized = memoizedIsInitialized;
-            if (isInitialized == 1) return true;
-            if (isInitialized == 0) return false;
-
-            memoizedIsInitialized = 1;
-            return true;
-        }
-
-        public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
-            getSerializedSize();
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                output.writeInt64(1, executeTime_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                output.writeBytes(2, getTransactionIdBytes());
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                output.writeMessage(3, props_.get(i));
-            }
-            if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                output.writeInt64(4, threadId_);
-            }
-            getUnknownFields().writeTo(output);
-        }
-
-        private int memoizedSerializedSize = -1;
-
-        public int getSerializedSize() {
-            int size = memoizedSerializedSize;
-            if (size != -1) return size;
-
-            size = 0;
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt64Size(1, executeTime_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(2, getTransactionIdBytes());
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, props_.get(i));
-            }
-            if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt64Size(4, threadId_);
-            }
-            size += getUnknownFields().getSerializedSize();
-            memoizedSerializedSize = size;
-            return size;
-        }
-
-        private static final long serialVersionUID = 0L;
-
-        @java.lang.Override
-        protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-            return super.writeReplace();
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(com.google.protobuf.ByteString data)
-                                                                                                                                 throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(com.google.protobuf.ByteString data,
-                                                                                             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                         throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(byte[] data)
-                                                                                                         throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(byte[] data,
-                                                                                             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                         throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(java.io.InputStream input)
-                                                                                                                       throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(java.io.InputStream input,
-                                                                                             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                         throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseDelimitedFrom(java.io.InputStream input)
-                                                                                                                                throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseDelimitedFrom(java.io.InputStream input,
-                                                                                                      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                                  throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(com.google.protobuf.CodedInputStream input)
-                                                                                                                                        throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parseFrom(com.google.protobuf.CodedInputStream input,
-                                                                                             com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                         throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static Builder newBuilder() {
-            return Builder.create();
-        }
-
-        public Builder newBuilderForType() {
-            return newBuilder();
-        }
-
-        public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin prototype) {
-            return newBuilder().mergeFrom(prototype);
-        }
-
-        public Builder toBuilder() {
-            return newBuilder(this);
-        }
-
-        @java.lang.Override
-        protected Builder newBuilderForType(com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-            Builder builder = new Builder(parent);
-            return builder;
-        }
-
-        /**
-         * Protobuf type
-         * {@code com.alibaba.otter.canal.protocol.TransactionBegin}
-         *
-         * <pre>
-         * *开始事务的一些信息*
-         * </pre>
-         */
-        public static final class Builder extends com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:com.alibaba.otter.canal.protocol.TransactionBegin)
         com.alibaba.otter.canal.protocol.CanalEntry.TransactionBeginOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor;
+      }
 
-            public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor;
-            }
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.class, com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.Builder.class);
+      }
 
-            protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.class,
-                    com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.Builder.class);
-            }
+      // Construct using com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
 
-            // Construct using
-            // com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.newBuilder()
-            private Builder(){
-                maybeForceBuilderInitialization();
-            }
-
-            private Builder(com.google.protobuf.GeneratedMessage.BuilderParent parent){
-                super(parent);
-                maybeForceBuilderInitialization();
-            }
-
-            private void maybeForceBuilderInitialization() {
-                if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-                    getPropsFieldBuilder();
-                }
-            }
-
-            private static Builder create() {
-                return new Builder();
-            }
-
-            public Builder clear() {
-                super.clear();
-                executeTime_ = 0L;
-                bitField0_ = (bitField0_ & ~0x00000001);
-                transactionId_ = "";
-                bitField0_ = (bitField0_ & ~0x00000002);
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000004);
-                } else {
-                    propsBuilder_.clear();
-                }
-                threadId_ = 0L;
-                bitField0_ = (bitField0_ & ~0x00000008);
-                return this;
-            }
-
-            public Builder clone() {
-                return create().mergeFrom(buildPartial());
-            }
-
-            public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin getDefaultInstanceForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.getDefaultInstance();
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin build() {
-                com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin result = buildPartial();
-                if (!result.isInitialized()) {
-                    throw newUninitializedMessageException(result);
-                }
-                return result;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin buildPartial() {
-                com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin result = new com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin(this);
-                int from_bitField0_ = bitField0_;
-                int to_bitField0_ = 0;
-                if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-                    to_bitField0_ |= 0x00000001;
-                }
-                result.executeTime_ = executeTime_;
-                if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-                    to_bitField0_ |= 0x00000002;
-                }
-                result.transactionId_ = transactionId_;
-                if (propsBuilder_ == null) {
-                    if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                        props_ = java.util.Collections.unmodifiableList(props_);
-                        bitField0_ = (bitField0_ & ~0x00000004);
-                    }
-                    result.props_ = props_;
-                } else {
-                    result.props_ = propsBuilder_.build();
-                }
-                if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-                    to_bitField0_ |= 0x00000004;
-                }
-                result.threadId_ = threadId_;
-                result.bitField0_ = to_bitField0_;
-                onBuilt();
-                return result;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.Message other) {
-                if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin) {
-                    return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin) other);
-                } else {
-                    super.mergeFrom(other);
-                    return this;
-                }
-            }
-
-            public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin other) {
-                if (other == com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.getDefaultInstance()) return this;
-                if (other.hasExecuteTime()) {
-                    setExecuteTime(other.getExecuteTime());
-                }
-                if (other.hasTransactionId()) {
-                    bitField0_ |= 0x00000002;
-                    transactionId_ = other.transactionId_;
-                    onChanged();
-                }
-                if (propsBuilder_ == null) {
-                    if (!other.props_.isEmpty()) {
-                        if (props_.isEmpty()) {
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000004);
-                        } else {
-                            ensurePropsIsMutable();
-                            props_.addAll(other.props_);
-                        }
-                        onChanged();
-                    }
-                } else {
-                    if (!other.props_.isEmpty()) {
-                        if (propsBuilder_.isEmpty()) {
-                            propsBuilder_.dispose();
-                            propsBuilder_ = null;
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000004);
-                            propsBuilder_ = com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ? getPropsFieldBuilder() : null;
-                        } else {
-                            propsBuilder_.addAllMessages(other.props_);
-                        }
-                    }
-                }
-                if (other.hasThreadId()) {
-                    setThreadId(other.getThreadId());
-                }
-                this.mergeUnknownFields(other.getUnknownFields());
-                return this;
-            }
-
-            public final boolean isInitialized() {
-                return true;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
-                                     com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                 throws java.io.IOException {
-                com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parsedMessage = null;
-                try {
-                    parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                    parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin) e.getUnfinishedMessage();
-                    throw e;
-                } finally {
-                    if (parsedMessage != null) {
-                        mergeFrom(parsedMessage);
-                    }
-                }
-                return this;
-            }
-
-            private int  bitField0_;
-
-            private long executeTime_;
-
-            /**
-             * <code>optional int64 executeTime = 1;</code>
-             *
-             * <pre>
-             * *已废弃，请使用header里的executeTime*
-             * </pre>
-             */
-            public boolean hasExecuteTime() {
-                return ((bitField0_ & 0x00000001) == 0x00000001);
-            }
-
-            /**
-             * <code>optional int64 executeTime = 1;</code>
-             *
-             * <pre>
-             * *已废弃，请使用header里的executeTime*
-             * </pre>
-             */
-            public long getExecuteTime() {
-                return executeTime_;
-            }
-
-            /**
-             * <code>optional int64 executeTime = 1;</code>
-             *
-             * <pre>
-             * *已废弃，请使用header里的executeTime*
-             * </pre>
-             */
-            public Builder setExecuteTime(long value) {
-                bitField0_ |= 0x00000001;
-                executeTime_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int64 executeTime = 1;</code>
-             *
-             * <pre>
-             * *已废弃，请使用header里的executeTime*
-             * </pre>
-             */
-            public Builder clearExecuteTime() {
-                bitField0_ = (bitField0_ & ~0x00000001);
-                executeTime_ = 0L;
-                onChanged();
-                return this;
-            }
-
-            private java.lang.Object transactionId_ = "";
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *已废弃，Begin里不提供事务id*
-             * </pre>
-             */
-            public boolean hasTransactionId() {
-                return ((bitField0_ & 0x00000002) == 0x00000002);
-            }
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *已废弃，Begin里不提供事务id*
-             * </pre>
-             */
-            public java.lang.String getTransactionId() {
-                java.lang.Object ref = transactionId_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        transactionId_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *已废弃，Begin里不提供事务id*
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getTransactionIdBytes() {
-                java.lang.Object ref = transactionId_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    transactionId_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *已废弃，Begin里不提供事务id*
-             * </pre>
-             */
-            public Builder setTransactionId(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000002;
-                transactionId_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *已废弃，Begin里不提供事务id*
-             * </pre>
-             */
-            public Builder clearTransactionId() {
-                bitField0_ = (bitField0_ & ~0x00000002);
-                transactionId_ = getDefaultInstance().getTransactionId();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *已废弃，Begin里不提供事务id*
-             * </pre>
-             */
-            public Builder setTransactionIdBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000002;
-                transactionId_ = value;
-                onChanged();
-                return this;
-            }
-
-            private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ = java.util.Collections.emptyList();
-
-            private void ensurePropsIsMutable() {
-                if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-                    props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
-                    bitField0_ |= 0x00000004;
-                }
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-                if (propsBuilder_ == null) {
-                    return java.util.Collections.unmodifiableList(props_);
-                } else {
-                    return propsBuilder_.getMessageList();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public int getPropsCount() {
-                if (propsBuilder_ == null) {
-                    return props_.size();
-                } else {
-                    return propsBuilder_.getCount();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessage(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.set(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.set(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addAllProps(java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    com.google.protobuf.AbstractMessageLite.Builder.addAll(values, props_);
-                    onChanged();
-                } else {
-                    propsBuilder_.addAllMessages(values);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder clearProps() {
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000004);
-                    onChanged();
-                } else {
-                    propsBuilder_.clear();
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder removeProps(int index) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.remove(index);
-                    onChanged();
-                } else {
-                    propsBuilder_.remove(index);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(int index) {
-                return getPropsFieldBuilder().getBuilder(index);
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessageOrBuilder(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-                if (propsBuilder_ != null) {
-                    return propsBuilder_.getMessageOrBuilderList();
-                } else {
-                    return java.util.Collections.unmodifiableList(props_);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
-                return getPropsFieldBuilder().addBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(int index) {
-                return getPropsFieldBuilder().addBuilder(index,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> getPropsBuilderList() {
-                return getPropsFieldBuilder().getBuilderList();
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsFieldBuilder() {
-                if (propsBuilder_ == null) {
-                    propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(props_,
-                        ((bitField0_ & 0x00000004) == 0x00000004),
-                        getParentForChildren(),
-                        isClean());
-                    props_ = null;
-                }
-                return propsBuilder_;
-            }
-
-            private long threadId_;
-
-            /**
-             * <code>optional int64 threadId = 4;</code>
-             *
-             * <pre>
-             * *执行的thread Id*
-             * </pre>
-             */
-            public boolean hasThreadId() {
-                return ((bitField0_ & 0x00000008) == 0x00000008);
-            }
-
-            /**
-             * <code>optional int64 threadId = 4;</code>
-             *
-             * <pre>
-             * *执行的thread Id*
-             * </pre>
-             */
-            public long getThreadId() {
-                return threadId_;
-            }
-
-            /**
-             * <code>optional int64 threadId = 4;</code>
-             *
-             * <pre>
-             * *执行的thread Id*
-             * </pre>
-             */
-            public Builder setThreadId(long value) {
-                bitField0_ |= 0x00000008;
-                threadId_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int64 threadId = 4;</code>
-             *
-             * <pre>
-             * *执行的thread Id*
-             * </pre>
-             */
-            public Builder clearThreadId() {
-                bitField0_ = (bitField0_ & ~0x00000008);
-                threadId_ = 0L;
-                onChanged();
-                return this;
-            }
-
-            // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.TransactionBegin)
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getPropsFieldBuilder();
         }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
 
-        static {
-            defaultInstance = new TransactionBegin(true);
-            defaultInstance.initFields();
+      public Builder clear() {
+        super.clear();
+        executeTime_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        transactionId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+        } else {
+          propsBuilder_.clear();
         }
+        threadId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000008);
+        return this;
+      }
 
-        // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.TransactionBegin)
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin getDefaultInstanceForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.getDefaultInstance();
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin build() {
+        com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin buildPartial() {
+        com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin result = new com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.executeTime_ = executeTime_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.transactionId_ = transactionId_;
+        if (propsBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+            props_ = java.util.Collections.unmodifiableList(props_);
+            bitField0_ = (bitField0_ & ~0x00000004);
+          }
+          result.props_ = props_;
+        } else {
+          result.props_ = propsBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.threadId_ = threadId_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin) {
+          return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin other) {
+        if (other == com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin.getDefaultInstance()) return this;
+        if (other.hasExecuteTime()) {
+          setExecuteTime(other.getExecuteTime());
+        }
+        if (other.hasTransactionId()) {
+          bitField0_ |= 0x00000002;
+          transactionId_ = other.transactionId_;
+          onChanged();
+        }
+        if (propsBuilder_ == null) {
+          if (!other.props_.isEmpty()) {
+            if (props_.isEmpty()) {
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+            } else {
+              ensurePropsIsMutable();
+              props_.addAll(other.props_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.props_.isEmpty()) {
+            if (propsBuilder_.isEmpty()) {
+              propsBuilder_.dispose();
+              propsBuilder_ = null;
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+              propsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getPropsFieldBuilder() : null;
+            } else {
+              propsBuilder_.addAllMessages(other.props_);
+            }
+          }
+        }
+        if (other.hasThreadId()) {
+          setThreadId(other.getThreadId());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.TransactionBegin) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private long executeTime_ ;
+      /**
+       * <code>optional int64 executeTime = 1;</code>
+       *
+       * <pre>
+       **已废弃，请使用header里的executeTime*
+       * </pre>
+       */
+      public boolean hasExecuteTime() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional int64 executeTime = 1;</code>
+       *
+       * <pre>
+       **已废弃，请使用header里的executeTime*
+       * </pre>
+       */
+      public long getExecuteTime() {
+        return executeTime_;
+      }
+      /**
+       * <code>optional int64 executeTime = 1;</code>
+       *
+       * <pre>
+       **已废弃，请使用header里的executeTime*
+       * </pre>
+       */
+      public Builder setExecuteTime(long value) {
+        bitField0_ |= 0x00000001;
+        executeTime_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 executeTime = 1;</code>
+       *
+       * <pre>
+       **已废弃，请使用header里的executeTime*
+       * </pre>
+       */
+      public Builder clearExecuteTime() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        executeTime_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object transactionId_ = "";
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **已废弃，Begin里不提供事务id*
+       * </pre>
+       */
+      public boolean hasTransactionId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **已废弃，Begin里不提供事务id*
+       * </pre>
+       */
+      public java.lang.String getTransactionId() {
+        java.lang.Object ref = transactionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            transactionId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **已废弃，Begin里不提供事务id*
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getTransactionIdBytes() {
+        java.lang.Object ref = transactionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          transactionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **已废弃，Begin里不提供事务id*
+       * </pre>
+       */
+      public Builder setTransactionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        transactionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **已废弃，Begin里不提供事务id*
+       * </pre>
+       */
+      public Builder clearTransactionId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        transactionId_ = getDefaultInstance().getTransactionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **已废弃，Begin里不提供事务id*
+       * </pre>
+       */
+      public Builder setTransactionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        transactionId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ =
+        java.util.Collections.emptyList();
+      private void ensurePropsIsMutable() {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+          props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
+          bitField0_ |= 0x00000004;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
+
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+        if (propsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(props_);
+        } else {
+          return propsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public int getPropsCount() {
+        if (propsBuilder_ == null) {
+          return props_.size();
+        } else {
+          return propsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);
+        } else {
+          return propsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.set(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addAllProps(
+          java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, props_);
+          onChanged();
+        } else {
+          propsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder clearProps() {
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+          onChanged();
+        } else {
+          propsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder removeProps(int index) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.remove(index);
+          onChanged();
+        } else {
+          propsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+          int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);  } else {
+          return propsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+           getPropsOrBuilderList() {
+        if (propsBuilder_ != null) {
+          return propsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(props_);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
+        return getPropsFieldBuilder().addBuilder(
+            com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().addBuilder(
+            index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> 
+           getPropsBuilderList() {
+        return getPropsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+          getPropsFieldBuilder() {
+        if (propsBuilder_ == null) {
+          propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(
+                  props_,
+                  ((bitField0_ & 0x00000004) == 0x00000004),
+                  getParentForChildren(),
+                  isClean());
+          props_ = null;
+        }
+        return propsBuilder_;
+      }
+
+      private long threadId_ ;
+      /**
+       * <code>optional int64 threadId = 4;</code>
+       *
+       * <pre>
+       **执行的thread Id*
+       * </pre>
+       */
+      public boolean hasThreadId() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      /**
+       * <code>optional int64 threadId = 4;</code>
+       *
+       * <pre>
+       **执行的thread Id*
+       * </pre>
+       */
+      public long getThreadId() {
+        return threadId_;
+      }
+      /**
+       * <code>optional int64 threadId = 4;</code>
+       *
+       * <pre>
+       **执行的thread Id*
+       * </pre>
+       */
+      public Builder setThreadId(long value) {
+        bitField0_ |= 0x00000008;
+        threadId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 threadId = 4;</code>
+       *
+       * <pre>
+       **执行的thread Id*
+       * </pre>
+       */
+      public Builder clearThreadId() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        threadId_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.TransactionBegin)
     }
 
-    public interface TransactionEndOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.TransactionEnd)
-    com.google.protobuf.MessageOrBuilder {
-
-        /**
-         * <code>optional int64 executeTime = 1;</code>
-         *
-         * <pre>
-         * *已废弃，请使用header里的executeTime*
-         * </pre>
-         */
-        boolean hasExecuteTime();
-
-        /**
-         * <code>optional int64 executeTime = 1;</code>
-         *
-         * <pre>
-         * *已废弃，请使用header里的executeTime*
-         * </pre>
-         */
-        long getExecuteTime();
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *事务号*
-         * </pre>
-         */
-        boolean hasTransactionId();
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *事务号*
-         * </pre>
-         */
-        java.lang.String getTransactionId();
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *事务号*
-         * </pre>
-         */
-        com.google.protobuf.ByteString getTransactionIdBytes();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        int getPropsCount();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList();
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index);
+    static {
+      defaultInstance = new TransactionBegin(true);
+      defaultInstance.initFields();
     }
 
+    // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.TransactionBegin)
+  }
+
+  public interface TransactionEndOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.TransactionEnd)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional int64 executeTime = 1;</code>
+     *
+     * <pre>
+     **已废弃，请使用header里的executeTime*
+     * </pre>
+     */
+    boolean hasExecuteTime();
+    /**
+     * <code>optional int64 executeTime = 1;</code>
+     *
+     * <pre>
+     **已废弃，请使用header里的executeTime*
+     * </pre>
+     */
+    long getExecuteTime();
+
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **事务号*
+     * </pre>
+     */
+    boolean hasTransactionId();
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **事务号*
+     * </pre>
+     */
+    java.lang.String getTransactionId();
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **事务号*
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getTransactionIdBytes();
+
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> 
+        getPropsList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index);
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    int getPropsCount();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList();
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code com.alibaba.otter.canal.protocol.TransactionEnd}
+   *
+   * <pre>
+   **结束事务的一些信息*
+   * </pre>
+   */
+  public static final class TransactionEnd extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.TransactionEnd)
+      TransactionEndOrBuilder {
+    // Use TransactionEnd.newBuilder() to construct.
+    private TransactionEnd(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private TransactionEnd(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final TransactionEnd defaultInstance;
+    public static TransactionEnd getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public TransactionEnd getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private TransactionEnd(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              executeTime_ = input.readInt64();
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              transactionId_ = bs;
+              break;
+            }
+            case 26: {
+              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
+                mutable_bitField0_ |= 0x00000004;
+              }
+              props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER, extensionRegistry));
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+          props_ = java.util.Collections.unmodifiableList(props_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.class, com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<TransactionEnd> PARSER =
+        new com.google.protobuf.AbstractParser<TransactionEnd>() {
+      public TransactionEnd parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new TransactionEnd(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<TransactionEnd> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int EXECUTETIME_FIELD_NUMBER = 1;
+    private long executeTime_;
+    /**
+     * <code>optional int64 executeTime = 1;</code>
+     *
+     * <pre>
+     **已废弃，请使用header里的executeTime*
+     * </pre>
+     */
+    public boolean hasExecuteTime() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional int64 executeTime = 1;</code>
+     *
+     * <pre>
+     **已废弃，请使用header里的executeTime*
+     * </pre>
+     */
+    public long getExecuteTime() {
+      return executeTime_;
+    }
+
+    public static final int TRANSACTIONID_FIELD_NUMBER = 2;
+    private java.lang.Object transactionId_;
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **事务号*
+     * </pre>
+     */
+    public boolean hasTransactionId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **事务号*
+     * </pre>
+     */
+    public java.lang.String getTransactionId() {
+      java.lang.Object ref = transactionId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          transactionId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string transactionId = 2;</code>
+     *
+     * <pre>
+     **事务号*
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getTransactionIdBytes() {
+      java.lang.Object ref = transactionId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        transactionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int PROPS_FIELD_NUMBER = 3;
+    private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+        getPropsOrBuilderList() {
+      return props_;
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public int getPropsCount() {
+      return props_.size();
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+      return props_.get(index);
+    }
+    /**
+     * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+     *
+     * <pre>
+     **预留扩展*
+     * </pre>
+     */
+    public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+        int index) {
+      return props_.get(index);
+    }
+
+    private void initFields() {
+      executeTime_ = 0L;
+      transactionId_ = "";
+      props_ = java.util.Collections.emptyList();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt64(1, executeTime_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeBytes(2, getTransactionIdBytes());
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        output.writeMessage(3, props_.get(i));
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, executeTime_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(2, getTransactionIdBytes());
+      }
+      for (int i = 0; i < props_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, props_.get(i));
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
     /**
      * Protobuf type {@code com.alibaba.otter.canal.protocol.TransactionEnd}
      *
      * <pre>
-     * *结束事务的一些信息*
+     **结束事务的一些信息*
      * </pre>
      */
-    public static final class TransactionEnd extends com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.TransactionEnd)
-    TransactionEndOrBuilder {
-
-        // Use TransactionEnd.newBuilder() to construct.
-        private TransactionEnd(com.google.protobuf.GeneratedMessage.Builder<?> builder){
-            super(builder);
-            this.unknownFields = builder.getUnknownFields();
-        }
-
-        private TransactionEnd(boolean noInit){
-            this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance();
-        }
-
-        private static final TransactionEnd defaultInstance;
-
-        public static TransactionEnd getDefaultInstance() {
-            return defaultInstance;
-        }
-
-        public TransactionEnd getDefaultInstanceForType() {
-            return defaultInstance;
-        }
-
-        private final com.google.protobuf.UnknownFieldSet unknownFields;
-
-        @java.lang.Override
-        public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
-            return this.unknownFields;
-        }
-
-        private TransactionEnd(com.google.protobuf.CodedInputStream input,
-                               com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                           throws com.google.protobuf.InvalidProtocolBufferException{
-            initFields();
-            int mutable_bitField0_ = 0;
-            com.google.protobuf.UnknownFieldSet.Builder unknownFields = com.google.protobuf.UnknownFieldSet.newBuilder();
-            try {
-                boolean done = false;
-                while (!done) {
-                    int tag = input.readTag();
-                    switch (tag) {
-                        case 0:
-                            done = true;
-                            break;
-                        default: {
-                            if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                                done = true;
-                            }
-                            break;
-                        }
-                        case 8: {
-                            bitField0_ |= 0x00000001;
-                            executeTime_ = input.readInt64();
-                            break;
-                        }
-                        case 18: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000002;
-                            transactionId_ = bs;
-                            break;
-                        }
-                        case 26: {
-                            if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-                                props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>();
-                                mutable_bitField0_ |= 0x00000004;
-                            }
-                            props_.add(input.readMessage(com.alibaba.otter.canal.protocol.CanalEntry.Pair.PARSER,
-                                extensionRegistry));
-                            break;
-                        }
-                    }
-                }
-            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                throw e.setUnfinishedMessage(this);
-            } catch (java.io.IOException e) {
-                throw new com.google.protobuf.InvalidProtocolBufferException(e.getMessage()).setUnfinishedMessage(this);
-            } finally {
-                if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-                    props_ = java.util.Collections.unmodifiableList(props_);
-                }
-                this.unknownFields = unknownFields.build();
-                makeExtensionsImmutable();
-            }
-        }
-
-        public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor;
-        }
-
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.class,
-                com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.Builder.class);
-        }
-
-        public static com.google.protobuf.Parser<TransactionEnd> PARSER = new com.google.protobuf.AbstractParser<TransactionEnd>() {
-
-                                                                            public TransactionEnd parsePartialFrom(com.google.protobuf.CodedInputStream input,
-                                                                                                                   com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                                               throws com.google.protobuf.InvalidProtocolBufferException {
-                                                                                return new TransactionEnd(input,
-                                                                                    extensionRegistry);
-                                                                            }
-                                                                        };
-
-        @java.lang.Override
-        public com.google.protobuf.Parser<TransactionEnd> getParserForType() {
-            return PARSER;
-        }
-
-        private int             bitField0_;
-        public static final int EXECUTETIME_FIELD_NUMBER = 1;
-        private long            executeTime_;
-
-        /**
-         * <code>optional int64 executeTime = 1;</code>
-         *
-         * <pre>
-         * *已废弃，请使用header里的executeTime*
-         * </pre>
-         */
-        public boolean hasExecuteTime() {
-            return ((bitField0_ & 0x00000001) == 0x00000001);
-        }
-
-        /**
-         * <code>optional int64 executeTime = 1;</code>
-         *
-         * <pre>
-         * *已废弃，请使用header里的executeTime*
-         * </pre>
-         */
-        public long getExecuteTime() {
-            return executeTime_;
-        }
-
-        public static final int  TRANSACTIONID_FIELD_NUMBER = 2;
-        private java.lang.Object transactionId_;
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *事务号*
-         * </pre>
-         */
-        public boolean hasTransactionId() {
-            return ((bitField0_ & 0x00000002) == 0x00000002);
-        }
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *事务号*
-         * </pre>
-         */
-        public java.lang.String getTransactionId() {
-            java.lang.Object ref = transactionId_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    transactionId_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string transactionId = 2;</code>
-         *
-         * <pre>
-         * *事务号*
-         * </pre>
-         */
-        public com.google.protobuf.ByteString getTransactionIdBytes() {
-            java.lang.Object ref = transactionId_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                transactionId_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        public static final int                                                  PROPS_FIELD_NUMBER = 3;
-        private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_;
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-            return props_;
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public int getPropsCount() {
-            return props_.size();
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-            return props_.get(index);
-        }
-
-        /**
-         * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-            return props_.get(index);
-        }
-
-        private void initFields() {
-            executeTime_ = 0L;
-            transactionId_ = "";
-            props_ = java.util.Collections.emptyList();
-        }
-
-        private byte memoizedIsInitialized = -1;
-
-        public final boolean isInitialized() {
-            byte isInitialized = memoizedIsInitialized;
-            if (isInitialized == 1) return true;
-            if (isInitialized == 0) return false;
-
-            memoizedIsInitialized = 1;
-            return true;
-        }
-
-        public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
-            getSerializedSize();
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                output.writeInt64(1, executeTime_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                output.writeBytes(2, getTransactionIdBytes());
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                output.writeMessage(3, props_.get(i));
-            }
-            getUnknownFields().writeTo(output);
-        }
-
-        private int memoizedSerializedSize = -1;
-
-        public int getSerializedSize() {
-            int size = memoizedSerializedSize;
-            if (size != -1) return size;
-
-            size = 0;
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                size += com.google.protobuf.CodedOutputStream.computeInt64Size(1, executeTime_);
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(2, getTransactionIdBytes());
-            }
-            for (int i = 0; i < props_.size(); i++) {
-                size += com.google.protobuf.CodedOutputStream.computeMessageSize(3, props_.get(i));
-            }
-            size += getUnknownFields().getSerializedSize();
-            memoizedSerializedSize = size;
-            return size;
-        }
-
-        private static final long serialVersionUID = 0L;
-
-        @java.lang.Override
-        protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-            return super.writeReplace();
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(com.google.protobuf.ByteString data)
-                                                                                                                               throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(com.google.protobuf.ByteString data,
-                                                                                           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                       throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(byte[] data)
-                                                                                                       throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(byte[] data,
-                                                                                           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                       throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(java.io.InputStream input)
-                                                                                                                     throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(java.io.InputStream input,
-                                                                                           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                       throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseDelimitedFrom(java.io.InputStream input)
-                                                                                                                              throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseDelimitedFrom(java.io.InputStream input,
-                                                                                                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                                throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(com.google.protobuf.CodedInputStream input)
-                                                                                                                                      throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parseFrom(com.google.protobuf.CodedInputStream input,
-                                                                                           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                       throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static Builder newBuilder() {
-            return Builder.create();
-        }
-
-        public Builder newBuilderForType() {
-            return newBuilder();
-        }
-
-        public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd prototype) {
-            return newBuilder().mergeFrom(prototype);
-        }
-
-        public Builder toBuilder() {
-            return newBuilder(this);
-        }
-
-        @java.lang.Override
-        protected Builder newBuilderForType(com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-            Builder builder = new Builder(parent);
-            return builder;
-        }
-
-        /**
-         * Protobuf type {@code com.alibaba.otter.canal.protocol.TransactionEnd}
-         *
-         * <pre>
-         * *结束事务的一些信息*
-         * </pre>
-         */
-        public static final class Builder extends com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:com.alibaba.otter.canal.protocol.TransactionEnd)
         com.alibaba.otter.canal.protocol.CanalEntry.TransactionEndOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor;
+      }
 
-            public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor;
-            }
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.class, com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.Builder.class);
+      }
 
-            protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.class,
-                    com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.Builder.class);
-            }
+      // Construct using com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
 
-            // Construct using
-            // com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.newBuilder()
-            private Builder(){
-                maybeForceBuilderInitialization();
-            }
-
-            private Builder(com.google.protobuf.GeneratedMessage.BuilderParent parent){
-                super(parent);
-                maybeForceBuilderInitialization();
-            }
-
-            private void maybeForceBuilderInitialization() {
-                if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-                    getPropsFieldBuilder();
-                }
-            }
-
-            private static Builder create() {
-                return new Builder();
-            }
-
-            public Builder clear() {
-                super.clear();
-                executeTime_ = 0L;
-                bitField0_ = (bitField0_ & ~0x00000001);
-                transactionId_ = "";
-                bitField0_ = (bitField0_ & ~0x00000002);
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000004);
-                } else {
-                    propsBuilder_.clear();
-                }
-                return this;
-            }
-
-            public Builder clone() {
-                return create().mergeFrom(buildPartial());
-            }
-
-            public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd getDefaultInstanceForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.getDefaultInstance();
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd build() {
-                com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd result = buildPartial();
-                if (!result.isInitialized()) {
-                    throw newUninitializedMessageException(result);
-                }
-                return result;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd buildPartial() {
-                com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd result = new com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd(this);
-                int from_bitField0_ = bitField0_;
-                int to_bitField0_ = 0;
-                if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-                    to_bitField0_ |= 0x00000001;
-                }
-                result.executeTime_ = executeTime_;
-                if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-                    to_bitField0_ |= 0x00000002;
-                }
-                result.transactionId_ = transactionId_;
-                if (propsBuilder_ == null) {
-                    if (((bitField0_ & 0x00000004) == 0x00000004)) {
-                        props_ = java.util.Collections.unmodifiableList(props_);
-                        bitField0_ = (bitField0_ & ~0x00000004);
-                    }
-                    result.props_ = props_;
-                } else {
-                    result.props_ = propsBuilder_.build();
-                }
-                result.bitField0_ = to_bitField0_;
-                onBuilt();
-                return result;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.Message other) {
-                if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd) {
-                    return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd) other);
-                } else {
-                    super.mergeFrom(other);
-                    return this;
-                }
-            }
-
-            public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd other) {
-                if (other == com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.getDefaultInstance()) return this;
-                if (other.hasExecuteTime()) {
-                    setExecuteTime(other.getExecuteTime());
-                }
-                if (other.hasTransactionId()) {
-                    bitField0_ |= 0x00000002;
-                    transactionId_ = other.transactionId_;
-                    onChanged();
-                }
-                if (propsBuilder_ == null) {
-                    if (!other.props_.isEmpty()) {
-                        if (props_.isEmpty()) {
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000004);
-                        } else {
-                            ensurePropsIsMutable();
-                            props_.addAll(other.props_);
-                        }
-                        onChanged();
-                    }
-                } else {
-                    if (!other.props_.isEmpty()) {
-                        if (propsBuilder_.isEmpty()) {
-                            propsBuilder_.dispose();
-                            propsBuilder_ = null;
-                            props_ = other.props_;
-                            bitField0_ = (bitField0_ & ~0x00000004);
-                            propsBuilder_ = com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ? getPropsFieldBuilder() : null;
-                        } else {
-                            propsBuilder_.addAllMessages(other.props_);
-                        }
-                    }
-                }
-                this.mergeUnknownFields(other.getUnknownFields());
-                return this;
-            }
-
-            public final boolean isInitialized() {
-                return true;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
-                                     com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                 throws java.io.IOException {
-                com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parsedMessage = null;
-                try {
-                    parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                    parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd) e.getUnfinishedMessage();
-                    throw e;
-                } finally {
-                    if (parsedMessage != null) {
-                        mergeFrom(parsedMessage);
-                    }
-                }
-                return this;
-            }
-
-            private int  bitField0_;
-
-            private long executeTime_;
-
-            /**
-             * <code>optional int64 executeTime = 1;</code>
-             *
-             * <pre>
-             * *已废弃，请使用header里的executeTime*
-             * </pre>
-             */
-            public boolean hasExecuteTime() {
-                return ((bitField0_ & 0x00000001) == 0x00000001);
-            }
-
-            /**
-             * <code>optional int64 executeTime = 1;</code>
-             *
-             * <pre>
-             * *已废弃，请使用header里的executeTime*
-             * </pre>
-             */
-            public long getExecuteTime() {
-                return executeTime_;
-            }
-
-            /**
-             * <code>optional int64 executeTime = 1;</code>
-             *
-             * <pre>
-             * *已废弃，请使用header里的executeTime*
-             * </pre>
-             */
-            public Builder setExecuteTime(long value) {
-                bitField0_ |= 0x00000001;
-                executeTime_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional int64 executeTime = 1;</code>
-             *
-             * <pre>
-             * *已废弃，请使用header里的executeTime*
-             * </pre>
-             */
-            public Builder clearExecuteTime() {
-                bitField0_ = (bitField0_ & ~0x00000001);
-                executeTime_ = 0L;
-                onChanged();
-                return this;
-            }
-
-            private java.lang.Object transactionId_ = "";
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *事务号*
-             * </pre>
-             */
-            public boolean hasTransactionId() {
-                return ((bitField0_ & 0x00000002) == 0x00000002);
-            }
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *事务号*
-             * </pre>
-             */
-            public java.lang.String getTransactionId() {
-                java.lang.Object ref = transactionId_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        transactionId_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *事务号*
-             * </pre>
-             */
-            public com.google.protobuf.ByteString getTransactionIdBytes() {
-                java.lang.Object ref = transactionId_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    transactionId_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *事务号*
-             * </pre>
-             */
-            public Builder setTransactionId(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000002;
-                transactionId_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *事务号*
-             * </pre>
-             */
-            public Builder clearTransactionId() {
-                bitField0_ = (bitField0_ & ~0x00000002);
-                transactionId_ = getDefaultInstance().getTransactionId();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string transactionId = 2;</code>
-             *
-             * <pre>
-             * *事务号*
-             * </pre>
-             */
-            public Builder setTransactionIdBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000002;
-                transactionId_ = value;
-                onChanged();
-                return this;
-            }
-
-            private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ = java.util.Collections.emptyList();
-
-            private void ensurePropsIsMutable() {
-                if (!((bitField0_ & 0x00000004) == 0x00000004)) {
-                    props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
-                    bitField0_ |= 0x00000004;
-                }
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
-                if (propsBuilder_ == null) {
-                    return java.util.Collections.unmodifiableList(props_);
-                } else {
-                    return propsBuilder_.getMessageList();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public int getPropsCount() {
-                if (propsBuilder_ == null) {
-                    return props_.size();
-                } else {
-                    return propsBuilder_.getCount();
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessage(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.set(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder setProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.set(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.setMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
-                if (propsBuilder_ == null) {
-                    if (value == null) {
-                        throw new NullPointerException();
-                    }
-                    ensurePropsIsMutable();
-                    props_.add(index, value);
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, value);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addProps(int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.add(index, builderForValue.build());
-                    onChanged();
-                } else {
-                    propsBuilder_.addMessage(index, builderForValue.build());
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder addAllProps(java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    com.google.protobuf.AbstractMessageLite.Builder.addAll(values, props_);
-                    onChanged();
-                } else {
-                    propsBuilder_.addAllMessages(values);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder clearProps() {
-                if (propsBuilder_ == null) {
-                    props_ = java.util.Collections.emptyList();
-                    bitField0_ = (bitField0_ & ~0x00000004);
-                    onChanged();
-                } else {
-                    propsBuilder_.clear();
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public Builder removeProps(int index) {
-                if (propsBuilder_ == null) {
-                    ensurePropsIsMutable();
-                    props_.remove(index);
-                    onChanged();
-                } else {
-                    propsBuilder_.remove(index);
-                }
-                return this;
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(int index) {
-                return getPropsFieldBuilder().getBuilder(index);
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(int index) {
-                if (propsBuilder_ == null) {
-                    return props_.get(index);
-                } else {
-                    return propsBuilder_.getMessageOrBuilder(index);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsOrBuilderList() {
-                if (propsBuilder_ != null) {
-                    return propsBuilder_.getMessageOrBuilderList();
-                } else {
-                    return java.util.Collections.unmodifiableList(props_);
-                }
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
-                return getPropsFieldBuilder().addBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(int index) {
-                return getPropsFieldBuilder().addBuilder(index,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
-            }
-
-            /**
-             * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
-             *
-             * <pre>
-             * *预留扩展*
-             * </pre>
-             */
-            public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> getPropsBuilderList() {
-                return getPropsFieldBuilder().getBuilderList();
-            }
-
-            private com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> getPropsFieldBuilder() {
-                if (propsBuilder_ == null) {
-                    propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(props_,
-                        ((bitField0_ & 0x00000004) == 0x00000004),
-                        getParentForChildren(),
-                        isClean());
-                    props_ = null;
-                }
-                return propsBuilder_;
-            }
-
-            // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.TransactionEnd)
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+          getPropsFieldBuilder();
         }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
 
-        static {
-            defaultInstance = new TransactionEnd(true);
-            defaultInstance.initFields();
+      public Builder clear() {
+        super.clear();
+        executeTime_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        transactionId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+        } else {
+          propsBuilder_.clear();
         }
+        return this;
+      }
 
-        // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.TransactionEnd)
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd getDefaultInstanceForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.getDefaultInstance();
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd build() {
+        com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd buildPartial() {
+        com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd result = new com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.executeTime_ = executeTime_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.transactionId_ = transactionId_;
+        if (propsBuilder_ == null) {
+          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+            props_ = java.util.Collections.unmodifiableList(props_);
+            bitField0_ = (bitField0_ & ~0x00000004);
+          }
+          result.props_ = props_;
+        } else {
+          result.props_ = propsBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd) {
+          return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd other) {
+        if (other == com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd.getDefaultInstance()) return this;
+        if (other.hasExecuteTime()) {
+          setExecuteTime(other.getExecuteTime());
+        }
+        if (other.hasTransactionId()) {
+          bitField0_ |= 0x00000002;
+          transactionId_ = other.transactionId_;
+          onChanged();
+        }
+        if (propsBuilder_ == null) {
+          if (!other.props_.isEmpty()) {
+            if (props_.isEmpty()) {
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+            } else {
+              ensurePropsIsMutable();
+              props_.addAll(other.props_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.props_.isEmpty()) {
+            if (propsBuilder_.isEmpty()) {
+              propsBuilder_.dispose();
+              propsBuilder_ = null;
+              props_ = other.props_;
+              bitField0_ = (bitField0_ & ~0x00000004);
+              propsBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getPropsFieldBuilder() : null;
+            } else {
+              propsBuilder_.addAllMessages(other.props_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.TransactionEnd) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private long executeTime_ ;
+      /**
+       * <code>optional int64 executeTime = 1;</code>
+       *
+       * <pre>
+       **已废弃，请使用header里的executeTime*
+       * </pre>
+       */
+      public boolean hasExecuteTime() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional int64 executeTime = 1;</code>
+       *
+       * <pre>
+       **已废弃，请使用header里的executeTime*
+       * </pre>
+       */
+      public long getExecuteTime() {
+        return executeTime_;
+      }
+      /**
+       * <code>optional int64 executeTime = 1;</code>
+       *
+       * <pre>
+       **已废弃，请使用header里的executeTime*
+       * </pre>
+       */
+      public Builder setExecuteTime(long value) {
+        bitField0_ |= 0x00000001;
+        executeTime_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 executeTime = 1;</code>
+       *
+       * <pre>
+       **已废弃，请使用header里的executeTime*
+       * </pre>
+       */
+      public Builder clearExecuteTime() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        executeTime_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object transactionId_ = "";
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **事务号*
+       * </pre>
+       */
+      public boolean hasTransactionId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **事务号*
+       * </pre>
+       */
+      public java.lang.String getTransactionId() {
+        java.lang.Object ref = transactionId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            transactionId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **事务号*
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getTransactionIdBytes() {
+        java.lang.Object ref = transactionId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          transactionId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **事务号*
+       * </pre>
+       */
+      public Builder setTransactionId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        transactionId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **事务号*
+       * </pre>
+       */
+      public Builder clearTransactionId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        transactionId_ = getDefaultInstance().getTransactionId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string transactionId = 2;</code>
+       *
+       * <pre>
+       **事务号*
+       * </pre>
+       */
+      public Builder setTransactionIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        transactionId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> props_ =
+        java.util.Collections.emptyList();
+      private void ensurePropsIsMutable() {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+          props_ = new java.util.ArrayList<com.alibaba.otter.canal.protocol.CanalEntry.Pair>(props_);
+          bitField0_ |= 0x00000004;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> propsBuilder_;
+
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair> getPropsList() {
+        if (propsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(props_);
+        } else {
+          return propsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public int getPropsCount() {
+        if (propsBuilder_ == null) {
+          return props_.size();
+        } else {
+          return propsBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair getProps(int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);
+        } else {
+          return propsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.set(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder setProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair value) {
+        if (propsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensurePropsIsMutable();
+          props_.add(index, value);
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addProps(
+          int index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder builderForValue) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          propsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder addAllProps(
+          java.lang.Iterable<? extends com.alibaba.otter.canal.protocol.CanalEntry.Pair> values) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, props_);
+          onChanged();
+        } else {
+          propsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder clearProps() {
+        if (propsBuilder_ == null) {
+          props_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000004);
+          onChanged();
+        } else {
+          propsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public Builder removeProps(int index) {
+        if (propsBuilder_ == null) {
+          ensurePropsIsMutable();
+          props_.remove(index);
+          onChanged();
+        } else {
+          propsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder getPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder getPropsOrBuilder(
+          int index) {
+        if (propsBuilder_ == null) {
+          return props_.get(index);  } else {
+          return propsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<? extends com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+           getPropsOrBuilderList() {
+        if (propsBuilder_ != null) {
+          return propsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(props_);
+        }
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder() {
+        return getPropsFieldBuilder().addBuilder(
+            com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder addPropsBuilder(
+          int index) {
+        return getPropsFieldBuilder().addBuilder(
+            index, com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .com.alibaba.otter.canal.protocol.Pair props = 3;</code>
+       *
+       * <pre>
+       **预留扩展*
+       * </pre>
+       */
+      public java.util.List<com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder> 
+           getPropsBuilderList() {
+        return getPropsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder> 
+          getPropsFieldBuilder() {
+        if (propsBuilder_ == null) {
+          propsBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              com.alibaba.otter.canal.protocol.CanalEntry.Pair, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder, com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder>(
+                  props_,
+                  ((bitField0_ & 0x00000004) == 0x00000004),
+                  getParentForChildren(),
+                  isClean());
+          props_ = null;
+        }
+        return propsBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.TransactionEnd)
     }
 
-    public interface PairOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.Pair)
-    com.google.protobuf.MessageOrBuilder {
-
-        /**
-         * <code>optional string key = 1;</code>
-         */
-        boolean hasKey();
-
-        /**
-         * <code>optional string key = 1;</code>
-         */
-        java.lang.String getKey();
-
-        /**
-         * <code>optional string key = 1;</code>
-         */
-        com.google.protobuf.ByteString getKeyBytes();
-
-        /**
-         * <code>optional string value = 2;</code>
-         */
-        boolean hasValue();
-
-        /**
-         * <code>optional string value = 2;</code>
-         */
-        java.lang.String getValue();
-
-        /**
-         * <code>optional string value = 2;</code>
-         */
-        com.google.protobuf.ByteString getValueBytes();
+    static {
+      defaultInstance = new TransactionEnd(true);
+      defaultInstance.initFields();
     }
 
+    // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.TransactionEnd)
+  }
+
+  public interface PairOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:com.alibaba.otter.canal.protocol.Pair)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional string key = 1;</code>
+     */
+    boolean hasKey();
+    /**
+     * <code>optional string key = 1;</code>
+     */
+    java.lang.String getKey();
+    /**
+     * <code>optional string key = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getKeyBytes();
+
+    /**
+     * <code>optional string value = 2;</code>
+     */
+    boolean hasValue();
+    /**
+     * <code>optional string value = 2;</code>
+     */
+    java.lang.String getValue();
+    /**
+     * <code>optional string value = 2;</code>
+     */
+    com.google.protobuf.ByteString
+        getValueBytes();
+  }
+  /**
+   * Protobuf type {@code com.alibaba.otter.canal.protocol.Pair}
+   *
+   * <pre>
+   **预留扩展*
+   * </pre>
+   */
+  public static final class Pair extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.Pair)
+      PairOrBuilder {
+    // Use Pair.newBuilder() to construct.
+    private Pair(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private Pair(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final Pair defaultInstance;
+    public static Pair getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public Pair getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private Pair(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              key_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              value_ = bs;
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Pair_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.alibaba.otter.canal.protocol.CanalEntry.Pair.class, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<Pair> PARSER =
+        new com.google.protobuf.AbstractParser<Pair>() {
+      public Pair parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new Pair(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<Pair> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    public static final int KEY_FIELD_NUMBER = 1;
+    private java.lang.Object key_;
+    /**
+     * <code>optional string key = 1;</code>
+     */
+    public boolean hasKey() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>optional string key = 1;</code>
+     */
+    public java.lang.String getKey() {
+      java.lang.Object ref = key_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          key_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string key = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getKeyBytes() {
+      java.lang.Object ref = key_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        key_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int VALUE_FIELD_NUMBER = 2;
+    private java.lang.Object value_;
+    /**
+     * <code>optional string value = 2;</code>
+     */
+    public boolean hasValue() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional string value = 2;</code>
+     */
+    public java.lang.String getValue() {
+      java.lang.Object ref = value_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          value_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>optional string value = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getValueBytes() {
+      java.lang.Object ref = value_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        value_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private void initFields() {
+      key_ = "";
+      value_ = "";
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeBytes(1, getKeyBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeBytes(2, getValueBytes());
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getKeyBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(2, getValueBytes());
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Pair prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
     /**
      * Protobuf type {@code com.alibaba.otter.canal.protocol.Pair}
      *
      * <pre>
-     * *预留扩展*
+     **预留扩展*
      * </pre>
      */
-    public static final class Pair extends com.google.protobuf.GeneratedMessage implements
-    // @@protoc_insertion_point(message_implements:com.alibaba.otter.canal.protocol.Pair)
-    PairOrBuilder {
-
-        // Use Pair.newBuilder() to construct.
-        private Pair(com.google.protobuf.GeneratedMessage.Builder<?> builder){
-            super(builder);
-            this.unknownFields = builder.getUnknownFields();
-        }
-
-        private Pair(boolean noInit){
-            this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance();
-        }
-
-        private static final Pair defaultInstance;
-
-        public static Pair getDefaultInstance() {
-            return defaultInstance;
-        }
-
-        public Pair getDefaultInstanceForType() {
-            return defaultInstance;
-        }
-
-        private final com.google.protobuf.UnknownFieldSet unknownFields;
-
-        @java.lang.Override
-        public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
-            return this.unknownFields;
-        }
-
-        private Pair(com.google.protobuf.CodedInputStream input,
-                     com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                 throws com.google.protobuf.InvalidProtocolBufferException{
-            initFields();
-            int mutable_bitField0_ = 0;
-            com.google.protobuf.UnknownFieldSet.Builder unknownFields = com.google.protobuf.UnknownFieldSet.newBuilder();
-            try {
-                boolean done = false;
-                while (!done) {
-                    int tag = input.readTag();
-                    switch (tag) {
-                        case 0:
-                            done = true;
-                            break;
-                        default: {
-                            if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
-                                done = true;
-                            }
-                            break;
-                        }
-                        case 10: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000001;
-                            key_ = bs;
-                            break;
-                        }
-                        case 18: {
-                            com.google.protobuf.ByteString bs = input.readBytes();
-                            bitField0_ |= 0x00000002;
-                            value_ = bs;
-                            break;
-                        }
-                    }
-                }
-            } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                throw e.setUnfinishedMessage(this);
-            } catch (java.io.IOException e) {
-                throw new com.google.protobuf.InvalidProtocolBufferException(e.getMessage()).setUnfinishedMessage(this);
-            } finally {
-                this.unknownFields = unknownFields.build();
-                makeExtensionsImmutable();
-            }
-        }
-
-        public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor;
-        }
-
-        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-            return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Pair_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.Pair.class,
-                com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder.class);
-        }
-
-        public static com.google.protobuf.Parser<Pair> PARSER = new com.google.protobuf.AbstractParser<Pair>() {
-
-                                                                  public Pair parsePartialFrom(com.google.protobuf.CodedInputStream input,
-                                                                                               com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                           throws com.google.protobuf.InvalidProtocolBufferException {
-                                                                      return new Pair(input, extensionRegistry);
-                                                                  }
-                                                              };
-
-        @java.lang.Override
-        public com.google.protobuf.Parser<Pair> getParserForType() {
-            return PARSER;
-        }
-
-        private int              bitField0_;
-        public static final int  KEY_FIELD_NUMBER = 1;
-        private java.lang.Object key_;
-
-        /**
-         * <code>optional string key = 1;</code>
-         */
-        public boolean hasKey() {
-            return ((bitField0_ & 0x00000001) == 0x00000001);
-        }
-
-        /**
-         * <code>optional string key = 1;</code>
-         */
-        public java.lang.String getKey() {
-            java.lang.Object ref = key_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    key_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string key = 1;</code>
-         */
-        public com.google.protobuf.ByteString getKeyBytes() {
-            java.lang.Object ref = key_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                key_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        public static final int  VALUE_FIELD_NUMBER = 2;
-        private java.lang.Object value_;
-
-        /**
-         * <code>optional string value = 2;</code>
-         */
-        public boolean hasValue() {
-            return ((bitField0_ & 0x00000002) == 0x00000002);
-        }
-
-        /**
-         * <code>optional string value = 2;</code>
-         */
-        public java.lang.String getValue() {
-            java.lang.Object ref = value_;
-            if (ref instanceof java.lang.String) {
-                return (java.lang.String) ref;
-            } else {
-                com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                java.lang.String s = bs.toStringUtf8();
-                if (bs.isValidUtf8()) {
-                    value_ = s;
-                }
-                return s;
-            }
-        }
-
-        /**
-         * <code>optional string value = 2;</code>
-         */
-        public com.google.protobuf.ByteString getValueBytes() {
-            java.lang.Object ref = value_;
-            if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                value_ = b;
-                return b;
-            } else {
-                return (com.google.protobuf.ByteString) ref;
-            }
-        }
-
-        private void initFields() {
-            key_ = "";
-            value_ = "";
-        }
-
-        private byte memoizedIsInitialized = -1;
-
-        public final boolean isInitialized() {
-            byte isInitialized = memoizedIsInitialized;
-            if (isInitialized == 1) return true;
-            if (isInitialized == 0) return false;
-
-            memoizedIsInitialized = 1;
-            return true;
-        }
-
-        public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
-            getSerializedSize();
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                output.writeBytes(1, getKeyBytes());
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                output.writeBytes(2, getValueBytes());
-            }
-            getUnknownFields().writeTo(output);
-        }
-
-        private int memoizedSerializedSize = -1;
-
-        public int getSerializedSize() {
-            int size = memoizedSerializedSize;
-            if (size != -1) return size;
-
-            size = 0;
-            if (((bitField0_ & 0x00000001) == 0x00000001)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(1, getKeyBytes());
-            }
-            if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                size += com.google.protobuf.CodedOutputStream.computeBytesSize(2, getValueBytes());
-            }
-            size += getUnknownFields().getSerializedSize();
-            memoizedSerializedSize = size;
-            return size;
-        }
-
-        private static final long serialVersionUID = 0L;
-
-        @java.lang.Override
-        protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-            return super.writeReplace();
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(com.google.protobuf.ByteString data)
-                                                                                                                     throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(com.google.protobuf.ByteString data,
-                                                                                 com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                             throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(byte[] data)
-                                                                                             throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(byte[] data,
-                                                                                 com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                             throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(java.io.InputStream input)
-                                                                                                           throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(java.io.InputStream input,
-                                                                                 com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                             throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseDelimitedFrom(java.io.InputStream input)
-                                                                                                                    throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseDelimitedFrom(java.io.InputStream input,
-                                                                                          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                                      throws java.io.IOException {
-            return PARSER.parseDelimitedFrom(input, extensionRegistry);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(com.google.protobuf.CodedInputStream input)
-                                                                                                                            throws java.io.IOException {
-            return PARSER.parseFrom(input);
-        }
-
-        public static com.alibaba.otter.canal.protocol.CanalEntry.Pair parseFrom(com.google.protobuf.CodedInputStream input,
-                                                                                 com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                                                             throws java.io.IOException {
-            return PARSER.parseFrom(input, extensionRegistry);
-        }
-
-        public static Builder newBuilder() {
-            return Builder.create();
-        }
-
-        public Builder newBuilderForType() {
-            return newBuilder();
-        }
-
-        public static Builder newBuilder(com.alibaba.otter.canal.protocol.CanalEntry.Pair prototype) {
-            return newBuilder().mergeFrom(prototype);
-        }
-
-        public Builder toBuilder() {
-            return newBuilder(this);
-        }
-
-        @java.lang.Override
-        protected Builder newBuilderForType(com.google.protobuf.GeneratedMessage.BuilderParent parent) {
-            Builder builder = new Builder(parent);
-            return builder;
-        }
-
-        /**
-         * Protobuf type {@code com.alibaba.otter.canal.protocol.Pair}
-         *
-         * <pre>
-         * *预留扩展*
-         * </pre>
-         */
-        public static final class Builder extends com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:com.alibaba.otter.canal.protocol.Pair)
         com.alibaba.otter.canal.protocol.CanalEntry.PairOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor;
+      }
 
-            public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor;
-            }
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Pair_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.alibaba.otter.canal.protocol.CanalEntry.Pair.class, com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder.class);
+      }
 
-            protected com.google.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Pair_fieldAccessorTable.ensureFieldAccessorsInitialized(com.alibaba.otter.canal.protocol.CanalEntry.Pair.class,
-                    com.alibaba.otter.canal.protocol.CanalEntry.Pair.Builder.class);
-            }
+      // Construct using com.alibaba.otter.canal.protocol.CanalEntry.Pair.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
 
-            // Construct using
-            // com.alibaba.otter.canal.protocol.CanalEntry.Pair.newBuilder()
-            private Builder(){
-                maybeForceBuilderInitialization();
-            }
-
-            private Builder(com.google.protobuf.GeneratedMessage.BuilderParent parent){
-                super(parent);
-                maybeForceBuilderInitialization();
-            }
-
-            private void maybeForceBuilderInitialization() {
-                if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-                }
-            }
-
-            private static Builder create() {
-                return new Builder();
-            }
-
-            public Builder clear() {
-                super.clear();
-                key_ = "";
-                bitField0_ = (bitField0_ & ~0x00000001);
-                value_ = "";
-                bitField0_ = (bitField0_ & ~0x00000002);
-                return this;
-            }
-
-            public Builder clone() {
-                return create().mergeFrom(buildPartial());
-            }
-
-            public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair getDefaultInstanceForType() {
-                return com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance();
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair build() {
-                com.alibaba.otter.canal.protocol.CanalEntry.Pair result = buildPartial();
-                if (!result.isInitialized()) {
-                    throw newUninitializedMessageException(result);
-                }
-                return result;
-            }
-
-            public com.alibaba.otter.canal.protocol.CanalEntry.Pair buildPartial() {
-                com.alibaba.otter.canal.protocol.CanalEntry.Pair result = new com.alibaba.otter.canal.protocol.CanalEntry.Pair(this);
-                int from_bitField0_ = bitField0_;
-                int to_bitField0_ = 0;
-                if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-                    to_bitField0_ |= 0x00000001;
-                }
-                result.key_ = key_;
-                if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-                    to_bitField0_ |= 0x00000002;
-                }
-                result.value_ = value_;
-                result.bitField0_ = to_bitField0_;
-                onBuilt();
-                return result;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.Message other) {
-                if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.Pair) {
-                    return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.Pair) other);
-                } else {
-                    super.mergeFrom(other);
-                    return this;
-                }
-            }
-
-            public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.Pair other) {
-                if (other == com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance()) return this;
-                if (other.hasKey()) {
-                    bitField0_ |= 0x00000001;
-                    key_ = other.key_;
-                    onChanged();
-                }
-                if (other.hasValue()) {
-                    bitField0_ |= 0x00000002;
-                    value_ = other.value_;
-                    onChanged();
-                }
-                this.mergeUnknownFields(other.getUnknownFields());
-                return this;
-            }
-
-            public final boolean isInitialized() {
-                return true;
-            }
-
-            public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
-                                     com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                                                                                                 throws java.io.IOException {
-                com.alibaba.otter.canal.protocol.CanalEntry.Pair parsedMessage = null;
-                try {
-                    parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                    parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.Pair) e.getUnfinishedMessage();
-                    throw e;
-                } finally {
-                    if (parsedMessage != null) {
-                        mergeFrom(parsedMessage);
-                    }
-                }
-                return this;
-            }
-
-            private int              bitField0_;
-
-            private java.lang.Object key_ = "";
-
-            /**
-             * <code>optional string key = 1;</code>
-             */
-            public boolean hasKey() {
-                return ((bitField0_ & 0x00000001) == 0x00000001);
-            }
-
-            /**
-             * <code>optional string key = 1;</code>
-             */
-            public java.lang.String getKey() {
-                java.lang.Object ref = key_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        key_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string key = 1;</code>
-             */
-            public com.google.protobuf.ByteString getKeyBytes() {
-                java.lang.Object ref = key_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    key_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string key = 1;</code>
-             */
-            public Builder setKey(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000001;
-                key_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string key = 1;</code>
-             */
-            public Builder clearKey() {
-                bitField0_ = (bitField0_ & ~0x00000001);
-                key_ = getDefaultInstance().getKey();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string key = 1;</code>
-             */
-            public Builder setKeyBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000001;
-                key_ = value;
-                onChanged();
-                return this;
-            }
-
-            private java.lang.Object value_ = "";
-
-            /**
-             * <code>optional string value = 2;</code>
-             */
-            public boolean hasValue() {
-                return ((bitField0_ & 0x00000002) == 0x00000002);
-            }
-
-            /**
-             * <code>optional string value = 2;</code>
-             */
-            public java.lang.String getValue() {
-                java.lang.Object ref = value_;
-                if (!(ref instanceof java.lang.String)) {
-                    com.google.protobuf.ByteString bs = (com.google.protobuf.ByteString) ref;
-                    java.lang.String s = bs.toStringUtf8();
-                    if (bs.isValidUtf8()) {
-                        value_ = s;
-                    }
-                    return s;
-                } else {
-                    return (java.lang.String) ref;
-                }
-            }
-
-            /**
-             * <code>optional string value = 2;</code>
-             */
-            public com.google.protobuf.ByteString getValueBytes() {
-                java.lang.Object ref = value_;
-                if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
-                    value_ = b;
-                    return b;
-                } else {
-                    return (com.google.protobuf.ByteString) ref;
-                }
-            }
-
-            /**
-             * <code>optional string value = 2;</code>
-             */
-            public Builder setValue(java.lang.String value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000002;
-                value_ = value;
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string value = 2;</code>
-             */
-            public Builder clearValue() {
-                bitField0_ = (bitField0_ & ~0x00000002);
-                value_ = getDefaultInstance().getValue();
-                onChanged();
-                return this;
-            }
-
-            /**
-             * <code>optional string value = 2;</code>
-             */
-            public Builder setValueBytes(com.google.protobuf.ByteString value) {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-                bitField0_ |= 0x00000002;
-                value_ = value;
-                onChanged();
-                return this;
-            }
-
-            // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.Pair)
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
         }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
 
-        static {
-            defaultInstance = new Pair(true);
-            defaultInstance.initFields();
+      public Builder clear() {
+        super.clear();
+        key_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        value_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor;
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair getDefaultInstanceForType() {
+        return com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance();
+      }
+
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair build() {
+        com.alibaba.otter.canal.protocol.CanalEntry.Pair result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
         }
+        return result;
+      }
 
-        // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.Pair)
+      public com.alibaba.otter.canal.protocol.CanalEntry.Pair buildPartial() {
+        com.alibaba.otter.canal.protocol.CanalEntry.Pair result = new com.alibaba.otter.canal.protocol.CanalEntry.Pair(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.key_ = key_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.value_ = value_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.alibaba.otter.canal.protocol.CanalEntry.Pair) {
+          return mergeFrom((com.alibaba.otter.canal.protocol.CanalEntry.Pair)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.alibaba.otter.canal.protocol.CanalEntry.Pair other) {
+        if (other == com.alibaba.otter.canal.protocol.CanalEntry.Pair.getDefaultInstance()) return this;
+        if (other.hasKey()) {
+          bitField0_ |= 0x00000001;
+          key_ = other.key_;
+          onChanged();
+        }
+        if (other.hasValue()) {
+          bitField0_ |= 0x00000002;
+          value_ = other.value_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.alibaba.otter.canal.protocol.CanalEntry.Pair parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.alibaba.otter.canal.protocol.CanalEntry.Pair) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object key_ = "";
+      /**
+       * <code>optional string key = 1;</code>
+       */
+      public boolean hasKey() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>optional string key = 1;</code>
+       */
+      public java.lang.String getKey() {
+        java.lang.Object ref = key_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            key_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string key = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getKeyBytes() {
+        java.lang.Object ref = key_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          key_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string key = 1;</code>
+       */
+      public Builder setKey(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        key_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string key = 1;</code>
+       */
+      public Builder clearKey() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        key_ = getDefaultInstance().getKey();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string key = 1;</code>
+       */
+      public Builder setKeyBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        key_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object value_ = "";
+      /**
+       * <code>optional string value = 2;</code>
+       */
+      public boolean hasValue() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional string value = 2;</code>
+       */
+      public java.lang.String getValue() {
+        java.lang.Object ref = value_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            value_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string value = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getValueBytes() {
+        java.lang.Object ref = value_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          value_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string value = 2;</code>
+       */
+      public Builder setValue(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        value_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string value = 2;</code>
+       */
+      public Builder clearValue() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        value_ = getDefaultInstance().getValue();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string value = 2;</code>
+       */
+      public Builder setValueBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        value_ = value;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:com.alibaba.otter.canal.protocol.Pair)
     }
 
-    private static final com.google.protobuf.Descriptors.Descriptor        internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor;
-    private static com.google.protobuf.GeneratedMessage.FieldAccessorTable internal_static_com_alibaba_otter_canal_protocol_Entry_fieldAccessorTable;
-    private static final com.google.protobuf.Descriptors.Descriptor        internal_static_com_alibaba_otter_canal_protocol_Header_descriptor;
-    private static com.google.protobuf.GeneratedMessage.FieldAccessorTable internal_static_com_alibaba_otter_canal_protocol_Header_fieldAccessorTable;
-    private static final com.google.protobuf.Descriptors.Descriptor        internal_static_com_alibaba_otter_canal_protocol_Column_descriptor;
-    private static com.google.protobuf.GeneratedMessage.FieldAccessorTable internal_static_com_alibaba_otter_canal_protocol_Column_fieldAccessorTable;
-    private static final com.google.protobuf.Descriptors.Descriptor        internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor;
-    private static com.google.protobuf.GeneratedMessage.FieldAccessorTable internal_static_com_alibaba_otter_canal_protocol_RowData_fieldAccessorTable;
-    private static final com.google.protobuf.Descriptors.Descriptor        internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor;
-    private static com.google.protobuf.GeneratedMessage.FieldAccessorTable internal_static_com_alibaba_otter_canal_protocol_RowChange_fieldAccessorTable;
-    private static final com.google.protobuf.Descriptors.Descriptor        internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor;
-    private static com.google.protobuf.GeneratedMessage.FieldAccessorTable internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_fieldAccessorTable;
-    private static final com.google.protobuf.Descriptors.Descriptor        internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor;
-    private static com.google.protobuf.GeneratedMessage.FieldAccessorTable internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_fieldAccessorTable;
-    private static final com.google.protobuf.Descriptors.Descriptor        internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor;
-    private static com.google.protobuf.GeneratedMessage.FieldAccessorTable internal_static_com_alibaba_otter_canal_protocol_Pair_fieldAccessorTable;
-
-    public static com.google.protobuf.Descriptors.FileDescriptor getDescriptor() {
-        return descriptor;
-    }
-
-    private static com.google.protobuf.Descriptors.FileDescriptor descriptor;
     static {
-        java.lang.String[] descriptorData = {
-            "\n\023EntryProtocol.proto\022 com.alibaba.otter"
-                    + ".canal.protocol\"\236\001\n\005Entry\0228\n\006header\030\001 \001("
-                    + "\0132(.com.alibaba.otter.canal.protocol.Hea"
-                    + "der\022G\n\tentryType\030\002 \001(\0162+.com.alibaba.ott"
-                    + "er.canal.protocol.EntryType:\007ROWDATA\022\022\n\n"
-                    + "storeValue\030\003 \001(\014\"\203\003\n\006Header\022\022\n\007version\030\001"
-                    + " \001(\005:\0011\022\023\n\013logfileName\030\002 \001(\t\022\025\n\rlogfileO"
-                    + "ffset\030\003 \001(\003\022\020\n\010serverId\030\004 \001(\003\022\024\n\014servere"
-                    + "nCode\030\005 \001(\t\022\023\n\013executeTime\030\006 \001(\003\022A\n\nsour"
-                    + "ceType\030\007 \001(\0162&.com.alibaba.otter.canal.p",
-            "rotocol.Type:\005MYSQL\022\022\n\nschemaName\030\010 \001(\t\022"
-                    + "\021\n\ttableName\030\t \001(\t\022\023\n\013eventLength\030\n \001(\003\022"
-                    + "F\n\teventType\030\013 \001(\0162+.com.alibaba.otter.c"
-                    + "anal.protocol.EventType:\006UPDATE\0225\n\005props"
-                    + "\030\014 \003(\0132&.com.alibaba.otter.canal.protoco"
-                    + "l.Pair\"\326\001\n\006Column\022\r\n\005index\030\001 \001(\005\022\017\n\007sqlT"
-                    + "ype\030\002 \001(\005\022\014\n\004name\030\003 \001(\t\022\r\n\005isKey\030\004 \001(\010\022\017"
-                    + "\n\007updated\030\005 \001(\010\022\025\n\006isNull\030\006 \001(\010:\005false\0225"
-                    + "\n\005props\030\007 \003(\0132&.com.alibaba.otter.canal."
-                    + "protocol.Pair\022\r\n\005value\030\010 \001(\t\022\016\n\006length\030\t",
-            " \001(\005\022\021\n\tmysqlType\030\n \001(\t\"\301\001\n\007RowData\022?\n\rb"
-                    + "eforeColumns\030\001 \003(\0132(.com.alibaba.otter.c"
-                    + "anal.protocol.Column\022>\n\014afterColumns\030\002 \003"
-                    + "(\0132(.com.alibaba.otter.canal.protocol.Co"
-                    + "lumn\0225\n\005props\030\003 \003(\0132&.com.alibaba.otter."
-                    + "canal.protocol.Pair\"\222\002\n\tRowChange\022\017\n\007tab"
-                    + "leId\030\001 \001(\003\022F\n\teventType\030\002 \001(\0162+.com.alib"
-                    + "aba.otter.canal.protocol.EventType:\006UPDA"
-                    + "TE\022\024\n\005isDdl\030\n \001(\010:\005false\022\013\n\003sql\030\013 \001(\t\022;\n"
-                    + "\010rowDatas\030\014 \003(\0132).com.alibaba.otter.cana",
-            "l.protocol.RowData\0225\n\005props\030\r \003(\0132&.com."
-                    + "alibaba.otter.canal.protocol.Pair\022\025\n\rddl"
-                    + "SchemaName\030\016 \001(\t\"\207\001\n\020TransactionBegin\022\023\n"
-                    + "\013executeTime\030\001 \001(\003\022\025\n\rtransactionId\030\002 \001("
-                    + "\t\0225\n\005props\030\003 \003(\0132&.com.alibaba.otter.can"
-                    + "al.protocol.Pair\022\020\n\010threadId\030\004 \001(\003\"s\n\016Tr"
-                    + "ansactionEnd\022\023\n\013executeTime\030\001 \001(\003\022\025\n\rtra"
-                    + "nsactionId\030\002 \001(\t\0225\n\005props\030\003 \003(\0132&.com.al"
-                    + "ibaba.otter.canal.protocol.Pair\"\"\n\004Pair\022"
-                    + "\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t*Q\n\tEntryType",
-            "\022\024\n\020TRANSACTIONBEGIN\020\001\022\013\n\007ROWDATA\020\002\022\022\n\016T"
-                    + "RANSACTIONEND\020\003\022\r\n\tHEARTBEAT\020\004*\216\001\n\tEvent"
-                    + "Type\022\n\n\006INSERT\020\001\022\n\n\006UPDATE\020\002\022\n\n\006DELETE\020\003"
-                    + "\022\n\n\006CREATE\020\004\022\t\n\005ALTER\020\005\022\t\n\005ERASE\020\006\022\t\n\005QU"
-                    + "ERY\020\007\022\014\n\010TRUNCATE\020\010\022\n\n\006RENAME\020\t\022\n\n\006CINDE"
-                    + "X\020\n\022\n\n\006DINDEX\020\013*(\n\004Type\022\n\n\006ORACLE\020\001\022\t\n\005M"
-                    + "YSQL\020\002\022\t\n\005PGSQL\020\003B0\n com.alibaba.otter.c"
-                    + "anal.protocolB\nCanalEntryH\001" };
-        com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner = new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
-
-            public com.google.protobuf.ExtensionRegistry assignDescriptors(com.google.protobuf.Descriptors.FileDescriptor root) {
-                descriptor = root;
-                return null;
-            }
-        };
-        com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(descriptorData,
-            new com.google.protobuf.Descriptors.FileDescriptor[] {},
-            assigner);
-        internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor = getDescriptor().getMessageTypes().get(0);
-        internal_static_com_alibaba_otter_canal_protocol_Entry_fieldAccessorTable = new com.google.protobuf.GeneratedMessage.FieldAccessorTable(internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor,
-            new java.lang.String[] { "Header", "EntryType", "StoreValue", });
-        internal_static_com_alibaba_otter_canal_protocol_Header_descriptor = getDescriptor().getMessageTypes().get(1);
-        internal_static_com_alibaba_otter_canal_protocol_Header_fieldAccessorTable = new com.google.protobuf.GeneratedMessage.FieldAccessorTable(internal_static_com_alibaba_otter_canal_protocol_Header_descriptor,
-            new java.lang.String[] { "Version", "LogfileName", "LogfileOffset", "ServerId", "ServerenCode",
-            "ExecuteTime", "SourceType", "SchemaName", "TableName", "EventLength", "EventType", "Props", });
-        internal_static_com_alibaba_otter_canal_protocol_Column_descriptor = getDescriptor().getMessageTypes().get(2);
-        internal_static_com_alibaba_otter_canal_protocol_Column_fieldAccessorTable = new com.google.protobuf.GeneratedMessage.FieldAccessorTable(internal_static_com_alibaba_otter_canal_protocol_Column_descriptor,
-            new java.lang.String[] { "Index", "SqlType", "Name", "IsKey", "Updated", "IsNull", "Props", "Value",
-            "Length", "MysqlType", });
-        internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor = getDescriptor().getMessageTypes().get(3);
-        internal_static_com_alibaba_otter_canal_protocol_RowData_fieldAccessorTable = new com.google.protobuf.GeneratedMessage.FieldAccessorTable(internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor,
-            new java.lang.String[] { "BeforeColumns", "AfterColumns", "Props", });
-        internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor = getDescriptor().getMessageTypes()
-            .get(4);
-        internal_static_com_alibaba_otter_canal_protocol_RowChange_fieldAccessorTable = new com.google.protobuf.GeneratedMessage.FieldAccessorTable(internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor,
-            new java.lang.String[] { "TableId", "EventType", "IsDdl", "Sql", "RowDatas", "Props", "DdlSchemaName", });
-        internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor = getDescriptor().getMessageTypes()
-            .get(5);
-        internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_fieldAccessorTable = new com.google.protobuf.GeneratedMessage.FieldAccessorTable(internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor,
-            new java.lang.String[] { "ExecuteTime", "TransactionId", "Props", "ThreadId", });
-        internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor = getDescriptor().getMessageTypes()
-            .get(6);
-        internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_fieldAccessorTable = new com.google.protobuf.GeneratedMessage.FieldAccessorTable(internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor,
-            new java.lang.String[] { "ExecuteTime", "TransactionId", "Props", });
-        internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor = getDescriptor().getMessageTypes().get(7);
-        internal_static_com_alibaba_otter_canal_protocol_Pair_fieldAccessorTable = new com.google.protobuf.GeneratedMessage.FieldAccessorTable(internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor,
-            new java.lang.String[] { "Key", "Value", });
+      defaultInstance = new Pair(true);
+      defaultInstance.initFields();
     }
 
-    // @@protoc_insertion_point(outer_class_scope)
+    // @@protoc_insertion_point(class_scope:com.alibaba.otter.canal.protocol.Pair)
+  }
+
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_alibaba_otter_canal_protocol_Entry_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_alibaba_otter_canal_protocol_Header_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_alibaba_otter_canal_protocol_Header_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_alibaba_otter_canal_protocol_Column_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_alibaba_otter_canal_protocol_Column_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_alibaba_otter_canal_protocol_RowData_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_alibaba_otter_canal_protocol_RowChange_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_com_alibaba_otter_canal_protocol_Pair_fieldAccessorTable;
+
+  public static com.google.protobuf.Descriptors.FileDescriptor
+      getDescriptor() {
+    return descriptor;
+  }
+  private static com.google.protobuf.Descriptors.FileDescriptor
+      descriptor;
+  static {
+    java.lang.String[] descriptorData = {
+      "\n\023EntryProtocol.proto\022 com.alibaba.otter" +
+      ".canal.protocol\"\236\001\n\005Entry\0228\n\006header\030\001 \001(" +
+      "\0132(.com.alibaba.otter.canal.protocol.Hea" +
+      "der\022G\n\tentryType\030\002 \001(\0162+.com.alibaba.ott" +
+      "er.canal.protocol.EntryType:\007ROWDATA\022\022\n\n" +
+      "storeValue\030\003 \001(\014\"\221\003\n\006Header\022\022\n\007version\030\001" +
+      " \001(\005:\0011\022\023\n\013logfileName\030\002 \001(\t\022\025\n\rlogfileO" +
+      "ffset\030\003 \001(\003\022\020\n\010serverId\030\004 \001(\003\022\024\n\014servere" +
+      "nCode\030\005 \001(\t\022\023\n\013executeTime\030\006 \001(\003\022A\n\nsour" +
+      "ceType\030\007 \001(\0162&.com.alibaba.otter.canal.p",
+      "rotocol.Type:\005MYSQL\022\022\n\nschemaName\030\010 \001(\t\022" +
+      "\021\n\ttableName\030\t \001(\t\022\023\n\013eventLength\030\n \001(\003\022" +
+      "F\n\teventType\030\013 \001(\0162+.com.alibaba.otter.c" +
+      "anal.protocol.EventType:\006UPDATE\0225\n\005props" +
+      "\030\014 \003(\0132&.com.alibaba.otter.canal.protoco" +
+      "l.Pair\022\014\n\004gtid\030\r \001(\t\"\326\001\n\006Column\022\r\n\005index" +
+      "\030\001 \001(\005\022\017\n\007sqlType\030\002 \001(\005\022\014\n\004name\030\003 \001(\t\022\r\n" +
+      "\005isKey\030\004 \001(\010\022\017\n\007updated\030\005 \001(\010\022\025\n\006isNull\030" +
+      "\006 \001(\010:\005false\0225\n\005props\030\007 \003(\0132&.com.alibab" +
+      "a.otter.canal.protocol.Pair\022\r\n\005value\030\010 \001",
+      "(\t\022\016\n\006length\030\t \001(\005\022\021\n\tmysqlType\030\n \001(\t\"\301\001" +
+      "\n\007RowData\022?\n\rbeforeColumns\030\001 \003(\0132(.com.a" +
+      "libaba.otter.canal.protocol.Column\022>\n\014af" +
+      "terColumns\030\002 \003(\0132(.com.alibaba.otter.can" +
+      "al.protocol.Column\0225\n\005props\030\003 \003(\0132&.com." +
+      "alibaba.otter.canal.protocol.Pair\"\222\002\n\tRo" +
+      "wChange\022\017\n\007tableId\030\001 \001(\003\022F\n\teventType\030\002 " +
+      "\001(\0162+.com.alibaba.otter.canal.protocol.E" +
+      "ventType:\006UPDATE\022\024\n\005isDdl\030\n \001(\010:\005false\022\013" +
+      "\n\003sql\030\013 \001(\t\022;\n\010rowDatas\030\014 \003(\0132).com.alib",
+      "aba.otter.canal.protocol.RowData\0225\n\005prop" +
+      "s\030\r \003(\0132&.com.alibaba.otter.canal.protoc" +
+      "ol.Pair\022\025\n\rddlSchemaName\030\016 \001(\t\"\207\001\n\020Trans" +
+      "actionBegin\022\023\n\013executeTime\030\001 \001(\003\022\025\n\rtran" +
+      "sactionId\030\002 \001(\t\0225\n\005props\030\003 \003(\0132&.com.ali" +
+      "baba.otter.canal.protocol.Pair\022\020\n\010thread" +
+      "Id\030\004 \001(\003\"s\n\016TransactionEnd\022\023\n\013executeTim" +
+      "e\030\001 \001(\003\022\025\n\rtransactionId\030\002 \001(\t\0225\n\005props\030" +
+      "\003 \003(\0132&.com.alibaba.otter.canal.protocol" +
+      ".Pair\"\"\n\004Pair\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(",
+      "\t*^\n\tEntryType\022\024\n\020TRANSACTIONBEGIN\020\001\022\013\n\007" +
+      "ROWDATA\020\002\022\022\n\016TRANSACTIONEND\020\003\022\r\n\tHEARTBE" +
+      "AT\020\004\022\013\n\007GTIDLOG\020\005*\230\001\n\tEventType\022\n\n\006INSER" +
+      "T\020\001\022\n\n\006UPDATE\020\002\022\n\n\006DELETE\020\003\022\n\n\006CREATE\020\004\022" +
+      "\t\n\005ALTER\020\005\022\t\n\005ERASE\020\006\022\t\n\005QUERY\020\007\022\014\n\010TRUN" +
+      "CATE\020\010\022\n\n\006RENAME\020\t\022\n\n\006CINDEX\020\n\022\n\n\006DINDEX" +
+      "\020\013\022\010\n\004GTID\020\014*(\n\004Type\022\n\n\006ORACLE\020\001\022\t\n\005MYSQ" +
+      "L\020\002\022\t\n\005PGSQL\020\003B0\n com.alibaba.otter.cana" +
+      "l.protocolB\nCanalEntryH\001"
+    };
+    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
+        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
+          public com.google.protobuf.ExtensionRegistry assignDescriptors(
+              com.google.protobuf.Descriptors.FileDescriptor root) {
+            descriptor = root;
+            return null;
+          }
+        };
+    com.google.protobuf.Descriptors.FileDescriptor
+      .internalBuildGeneratedFileFrom(descriptorData,
+        new com.google.protobuf.Descriptors.FileDescriptor[] {
+        }, assigner);
+    internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor =
+      getDescriptor().getMessageTypes().get(0);
+    internal_static_com_alibaba_otter_canal_protocol_Entry_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_alibaba_otter_canal_protocol_Entry_descriptor,
+        new java.lang.String[] { "Header", "EntryType", "StoreValue", });
+    internal_static_com_alibaba_otter_canal_protocol_Header_descriptor =
+      getDescriptor().getMessageTypes().get(1);
+    internal_static_com_alibaba_otter_canal_protocol_Header_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_alibaba_otter_canal_protocol_Header_descriptor,
+        new java.lang.String[] { "Version", "LogfileName", "LogfileOffset", "ServerId", "ServerenCode", "ExecuteTime", "SourceType", "SchemaName", "TableName", "EventLength", "EventType", "Props", "Gtid", });
+    internal_static_com_alibaba_otter_canal_protocol_Column_descriptor =
+      getDescriptor().getMessageTypes().get(2);
+    internal_static_com_alibaba_otter_canal_protocol_Column_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_alibaba_otter_canal_protocol_Column_descriptor,
+        new java.lang.String[] { "Index", "SqlType", "Name", "IsKey", "Updated", "IsNull", "Props", "Value", "Length", "MysqlType", });
+    internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor =
+      getDescriptor().getMessageTypes().get(3);
+    internal_static_com_alibaba_otter_canal_protocol_RowData_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_alibaba_otter_canal_protocol_RowData_descriptor,
+        new java.lang.String[] { "BeforeColumns", "AfterColumns", "Props", });
+    internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor =
+      getDescriptor().getMessageTypes().get(4);
+    internal_static_com_alibaba_otter_canal_protocol_RowChange_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_alibaba_otter_canal_protocol_RowChange_descriptor,
+        new java.lang.String[] { "TableId", "EventType", "IsDdl", "Sql", "RowDatas", "Props", "DdlSchemaName", });
+    internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor =
+      getDescriptor().getMessageTypes().get(5);
+    internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_alibaba_otter_canal_protocol_TransactionBegin_descriptor,
+        new java.lang.String[] { "ExecuteTime", "TransactionId", "Props", "ThreadId", });
+    internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor =
+      getDescriptor().getMessageTypes().get(6);
+    internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_alibaba_otter_canal_protocol_TransactionEnd_descriptor,
+        new java.lang.String[] { "ExecuteTime", "TransactionId", "Props", });
+    internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor =
+      getDescriptor().getMessageTypes().get(7);
+    internal_static_com_alibaba_otter_canal_protocol_Pair_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_com_alibaba_otter_canal_protocol_Pair_descriptor,
+        new java.lang.String[] { "Key", "Value", });
+  }
+
+  // @@protoc_insertion_point(outer_class_scope)
 }

--- a/protocol/src/main/java/com/alibaba/otter/canal/protocol/EntryProtocol.proto
+++ b/protocol/src/main/java/com/alibaba/otter/canal/protocol/EntryProtocol.proto
@@ -55,7 +55,10 @@ message Header {
 	optional EventType 				eventType			= 11 [default = UPDATE];
 	
 	/**预留扩展**/
-	repeated Pair					props				= 12;		
+	repeated Pair					props				= 12;
+
+    /**当前事务的gitd**/
+	optional string                 gtid                = 13;
 }
 
 /**每个字段的数据结构**/
@@ -169,7 +172,8 @@ enum EntryType{
 	ROWDATA					=		2;
 	TRANSACTIONEND			=		3;
 	/** 心跳类型，内部使用，外部暂不可见，可忽略 **/
-	HEARTBEAT				=		4; 
+	HEARTBEAT				=		4;
+	GTIDLOG                 =       5;
 }
 
 /** 事件类型 **/
@@ -186,6 +190,7 @@ enum EventType {
     /**CREATE INDEX**/
     CINDEX		= 		10;
     DINDEX 		= 		11;
+    GTID        =       12;
 }
 
 /**数据库类型**/

--- a/protocol/src/main/java/com/alibaba/otter/canal/protocol/position/EntryPosition.java
+++ b/protocol/src/main/java/com/alibaba/otter/canal/protocol/position/EntryPosition.java
@@ -18,6 +18,7 @@ public class EntryPosition extends TimePosition {
     private Long              position;
     // add by agapple at 2016-06-28
     private Long              serverId              = null;              // 记录一下位点对应的serverId
+    private String            gtid                  = null;
 
     public EntryPosition(){
         super(null);
@@ -72,6 +73,14 @@ public class EntryPosition extends TimePosition {
 
     public void setServerId(Long serverId) {
         this.serverId = serverId;
+    }
+
+    public String getGtid() {
+        return gtid;
+    }
+
+    public void setGtid(String gtid) {
+        this.gtid = gtid;
     }
 
     @Override

--- a/store/src/main/java/com/alibaba/otter/canal/store/helper/CanalEventUtils.java
+++ b/store/src/main/java/com/alibaba/otter/canal/store/helper/CanalEventUtils.java
@@ -54,6 +54,9 @@ public class CanalEventUtils {
         // add serverId at 2016-06-28
         position.setServerId(event.getEntry().getHeader().getServerId());
 
+        // add gtid
+        position.setGtid(event.getEntry().getHeader().getGtid());
+
         LogPosition logPosition = new LogPosition();
         logPosition.setPostion(position);
         logPosition.setIdentity(event.getLogIdentity());


### PR DESCRIPTION
1. 增加instance级配置`gtidon`，指示该instance是否启用GTID模式。
2. driver包增加GTID相关类：`GTIDSet`，`UUIDSet`是GTID表示，`BinlogDumpGTIDCommandPacket`是`COM_BINLOG_DUMP_GTID`命令。
3. 补全dbsync包下的`GtidLogEvent`事件的解析。
4. protocol包下，增加了`EntryType`枚举项`GTIDLOG`，是binlog流中的GTIDLOG事件；`Header`增加了字段`gtid`，这里后面单独段落详细说明。
5. parse包下，`ErosaConnection`增加根据GTID同步的dump方法。
6. parse包下，`AbstractEventParser.start内`，如果instance使用GTID模式，则发送`COM_BINLOG_DUMP_GTID`命令给mysql。