### PR TITLE
Client QPS指标的datasource配置项由"Prometheus"改为取$datasource参数

### DIFF
--- a/deployer/src/main/resources/metrics/Canal_instances_tmpl.json
+++ b/deployer/src/main/resources/metrics/Canal_instances_tmpl.json
@@ -938,7 +938,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "$datasource",
       "description": "client 请求的GET与ACK包的QPS。",
       "fill": 1,
       "gridPos": {


### PR DESCRIPTION
升级Canal到1.1.0后配置了监控，在Grafana的监控页面中发现名为"Client QPS"的panel不可用，原因在于"Canal instances"面板的配置文件Canal_instances_tmpl.json中，名为"Client QPS"的panel的"datasource"配置项写成了固定值"Prometheus"，修改为取"$datasource"参数后，panel就可以正常显示了