### PR TITLE
增加扁平Message用于kafka消息投递

### DIFF
--- a/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/CanalOuterAdapter.java
+++ b/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/CanalOuterAdapter.java
@@ -1,7 +1,9 @@
 package com.alibaba.otter.canal.client.adapter;
 
 import com.alibaba.otter.canal.client.adapter.support.CanalOuterAdapterConfiguration;
+import com.alibaba.otter.canal.client.adapter.support.Dml;
 import com.alibaba.otter.canal.client.adapter.support.SPI;
+import com.alibaba.otter.canal.protocol.FlatMessage;
 import com.alibaba.otter.canal.protocol.Message;
 
 /**
@@ -23,9 +25,11 @@ public interface CanalOuterAdapter {
     /**
      * 往适配器中写入数据
      *
-     * @param message message数据包
+     * @param dml 数据包
      */
-    void writeOut(Message message);
+    void writeOut(Dml dml);
+
+    // void writeOut(FlatMessage flatMessage);
 
     /**
      * 外部适配器销毁接口

--- a/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/CanalClientConfig.java
+++ b/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/CanalClientConfig.java
@@ -20,6 +20,8 @@ public class CanalClientConfig {
 
     private String              bootstrapServers;
 
+    private Boolean             flatMessage = true;
+
     private List<KafkaTopic>    kafkaTopics;
 
     private List<CanalInstance> canalInstances;
@@ -54,6 +56,14 @@ public class CanalClientConfig {
 
     public void setBootstrapServers(String bootstrapServers) {
         this.bootstrapServers = bootstrapServers;
+    }
+
+    public Boolean getFlatMessage() {
+        return flatMessage;
+    }
+
+    public void setFlatMessage(Boolean flatMessage) {
+        this.flatMessage = flatMessage;
     }
 
     public List<KafkaTopic> getKafkaTopics() {

--- a/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/JdbcTypeUtil.java
+++ b/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/JdbcTypeUtil.java
@@ -21,7 +21,7 @@ public class JdbcTypeUtil {
 
     private static Logger logger = LoggerFactory.getLogger(JdbcTypeUtil.class);
 
-    public static Object typeConvert(String tableName, String columnName, String value, int sqlType, String mysqlType) {
+    public static Object typeConvert(String columnName, String value, int sqlType, String mysqlType) {
         if (value == null || value.equals("")) {
             return null;
         }
@@ -96,7 +96,7 @@ public class JdbcTypeUtil {
             }
             return res;
         } catch (Exception e) {
-            logger.error("table: {} column: {}, failed convert type {} to {}", tableName, columnName, value, sqlType);
+            logger.error("table: {} column: {}, failed convert type {} to {}", columnName, value, sqlType);
             return value;
         }
     }

--- a/client-adapter/hbase/src/main/java/com/alibaba/otter/canal/client/adapter/hbase/HbaseAdapter.java
+++ b/client-adapter/hbase/src/main/java/com/alibaba/otter/canal/client/adapter/hbase/HbaseAdapter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.alibaba.otter.canal.protocol.FlatMessage;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -86,20 +87,14 @@ public class HbaseAdapter implements CanalOuterAdapter {
     }
 
     @Override
-    public void writeOut(Message message) {
-        MessageUtil.parse4Dml(message, new MessageUtil.Consumer<Dml>() {
-
-            @Override
-            public void accept(Dml dml) {
-                if (dml == null) {
-                    return;
-                }
-                String database = dml.getDatabase();
-                String table = dml.getTable();
-                MappingConfig config = mappingConfigCache.get(database + "-" + table);
-                hbaseSyncService.sync(config, dml);
-            }
-        });
+    public void writeOut(Dml dml) {
+        if (dml == null) {
+            return;
+        }
+        String database = dml.getDatabase();
+        String table = dml.getTable();
+        MappingConfig config = mappingConfigCache.get(database + "-" + table);
+        hbaseSyncService.sync(config, dml);
     }
 
     @Override

--- a/client-adapter/logger/src/main/java/com/alibaba/otter/canal/client/adapter/logger/LoggerAdapterExample.java
+++ b/client-adapter/logger/src/main/java/com/alibaba/otter/canal/client/adapter/logger/LoggerAdapterExample.java
@@ -6,9 +6,7 @@ import org.slf4j.LoggerFactory;
 import com.alibaba.otter.canal.client.adapter.CanalOuterAdapter;
 import com.alibaba.otter.canal.client.adapter.support.CanalOuterAdapterConfiguration;
 import com.alibaba.otter.canal.client.adapter.support.Dml;
-import com.alibaba.otter.canal.client.adapter.support.MessageUtil;
 import com.alibaba.otter.canal.client.adapter.support.SPI;
-import com.alibaba.otter.canal.protocol.Message;
 
 /**
  * 外部适配器示例
@@ -22,20 +20,13 @@ public class LoggerAdapterExample implements CanalOuterAdapter {
     private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Override
-    public void writeOut(Message message) {
-        // 直接输出日志信息
-        MessageUtil.parse4Dml(message, new MessageUtil.Consumer<Dml>() {
+    public void init(CanalOuterAdapterConfiguration configuration) {
 
-            @Override
-            public void accept(Dml dml) {
-                logger.info(dml.toString());
-            }
-        });
     }
 
     @Override
-    public void init(CanalOuterAdapterConfiguration configuration) {
-
+    public void writeOut(Dml dml) {
+        logger.info(dml.toString());
     }
 
     @Override

--- a/client-launcher/src/main/java/com/alibaba/otter/canal/client/adapter/loader/CanalAdapterLoader.java
+++ b/client-launcher/src/main/java/com/alibaba/otter/canal/client/adapter/loader/CanalAdapterLoader.java
@@ -59,6 +59,8 @@ public class CanalAdapterLoader {
         }
         String zkHosts = this.canalClientConfig.getZookeeperHosts();
 
+        boolean flatMessage = this.canalClientConfig.getFlatMessage();
+
         // if (zkHosts == null && sa == null) {
         // throw new RuntimeException("Blank config property: canalServerHost or
         // zookeeperHosts");
@@ -104,11 +106,12 @@ public class CanalAdapterLoader {
                     canalOuterAdapterGroups.add(canalOuterAdapters);
 
                     // String zkServers = canalClientConfig.getZookeeperHosts();
-                    CanalAdapterKafkaWorker canalKafkaWorker = new CanalAdapterKafkaWorker(zkHosts,
+                    CanalAdapterKafkaWorker canalKafkaWorker = new CanalAdapterKafkaWorker(
                         canalClientConfig.getBootstrapServers(),
                         kafkaTopic.getTopic(),
                         group.getGroupId(),
-                        canalOuterAdapterGroups);
+                        canalOuterAdapterGroups,
+                        flatMessage);
                     canalKafkaWorkers.put(kafkaTopic.getTopic() + "-" + group.getGroupId(), canalKafkaWorker);
                     canalKafkaWorker.start();
                     logger.info("Start adapter for canal-client kafka topic: {} succeed",

--- a/client-launcher/src/main/resources/canal-client.yml
+++ b/client-launcher/src/main/resources/canal-client.yml
@@ -1,21 +1,22 @@
-canalServerHost: 127.0.0.1:11111
+#canalServerHost: 127.0.0.1:11111
 #zookeeperHosts: slave1:2181
-#bootstrapServers: slave1:6667,slave2:6667
+bootstrapServers: slave1:6667,slave2:6667
+flatMessage: true
 
-canalInstances:
-- instance: example
-  adapterGroups:
-  - outAdapters:
-    - name: logger
-    - name: hbase
-      hosts: slave1:2181
-      properties: {znodeParent: "/hbase-unsecure"}
-#kafkaTopics:
-#- topic: example
-#  groups:
-#  - groupId: example_g1
-#    outAdapters:
+#canalInstances:
+#- instance: example
+#  adapterGroups:
+#  - outAdapters:
 #    - name: logger
+#    - name: hbase
+#      hosts: slave1:2181
+#      properties: {znodeParent: "/hbase-unsecure"}
+kafkaTopics:
+- topic: example
+  groups:
+  - groupId: egroup
+    outAdapters:
+    - name: logger
 #    - name: hbase
 #      hosts: slave1:2181
 #      properties: {znodeParent: "/hbase-unsecure"}

--- a/client/src/main/java/com/alibaba/otter/canal/client/kafka/KafkaCanalConnector.java
+++ b/client/src/main/java/com/alibaba/otter/canal/client/kafka/KafkaCanalConnector.java
@@ -1,19 +1,20 @@
 package com.alibaba.otter.canal.client.kafka;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
-import com.alibaba.otter.canal.client.kafka.running.ClientRunningData;
-import com.alibaba.otter.canal.common.utils.AddressUtils;
-import com.alibaba.otter.canal.common.zookeeper.ZkClientx;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.otter.canal.protocol.FlatMessage;
 import com.alibaba.otter.canal.protocol.Message;
-import com.alibaba.otter.canal.protocol.exception.CanalClientException;
 
 /**
  * canal kafka 数据操作客户端
@@ -24,18 +25,19 @@ import com.alibaba.otter.canal.protocol.exception.CanalClientException;
 public class KafkaCanalConnector {
 
     private KafkaConsumer<String, Message> kafkaConsumer;
+    private KafkaConsumer<String, String>  kafkaConsumer2;   // 用于扁平message的数据消费
     private String                         topic;
     private Integer                        partition;
     private Properties                     properties;
-    // private ClientRunningMonitor runningMonitor; // 运行控制
-    // private BooleanMutex mutex = new BooleanMutex(false);
-    private ZkClientx                      zkClientx;
     private volatile boolean               connected = false;
     private volatile boolean               running   = false;
+    private boolean                        flatMessage;
 
-    public KafkaCanalConnector(String zkServers, String servers, String topic, Integer partition, String groupId){
+    public KafkaCanalConnector(String servers, String topic, Integer partition, String groupId,
+                               boolean flatMessage){
         this.topic = topic;
         this.partition = partition;
+        this.flatMessage = flatMessage;
 
         properties = new Properties();
         properties.put("bootstrap.servers", servers);
@@ -45,32 +47,13 @@ public class KafkaCanalConnector {
         properties.put("auto.offset.reset", "latest"); // 如果没有offset则从最后的offset开始读
         properties.put("request.timeout.ms", "40000"); // 必须大于session.timeout.ms的设置
         properties.put("session.timeout.ms", "30000"); // 默认为30秒
-        properties.put("max.poll.records", "1"); // 一次只取一条message数据
+        properties.put("max.poll.records", "100");
         properties.put("key.deserializer", StringDeserializer.class.getName());
-        properties.put("value.deserializer", MessageDeserializer.class.getName());
-
-        if (zkServers != null) {
-            zkClientx = new ZkClientx(zkServers);
-
-            ClientRunningData clientData = new ClientRunningData();
-            clientData.setGroupId(groupId);
-            clientData.setAddress(AddressUtils.getHostIp());
-
-            // runningMonitor = new ClientRunningMonitor();
-            // runningMonitor.setTopic(topic);
-            // runningMonitor.setZkClient(zkClientx);
-            // runningMonitor.setClientData(clientData);
-            // runningMonitor.setListener(new ClientRunningListener() {
-            // public void processActiveEnter() {
-            // mutex.set(true);
-            // }
-            //
-            // public void processActiveExit() {
-            // mutex.set(false);
-            // }
-            // });
+        if (!flatMessage) {
+            properties.put("value.deserializer", MessageDeserializer.class.getName());
+        } else {
+            properties.put("value.deserializer", StringDeserializer.class.getName());
         }
-
     }
 
     /**
@@ -93,57 +76,36 @@ public class KafkaCanalConnector {
             return;
         }
 
-        // if (runningMonitor != null) {
-        // if (!runningMonitor.isStart()) {
-        // runningMonitor.start();
-        // }
-        // }
-
         connected = true;
 
-        if (kafkaConsumer == null) {
+        if (kafkaConsumer == null && !flatMessage) {
             kafkaConsumer = new KafkaConsumer<String, Message>(properties);
+        }
+        if (kafkaConsumer2 == null && flatMessage) {
+            kafkaConsumer2 = new KafkaConsumer<String, String>(properties);
         }
     }
 
     /**
      * 关闭链接
      */
-    public void disconnnect() {
-        kafkaConsumer.close();
+    public void disconnect() {
+        if (kafkaConsumer != null) {
+            kafkaConsumer.close();
+        }
+        if (kafkaConsumer2 != null) {
+            kafkaConsumer2.close();
+        }
 
         connected = false;
-        // if (runningMonitor.isStart()) {
-        // runningMonitor.stop();
-        // }
     }
 
     private void waitClientRunning() {
-        try {
-            if (zkClientx != null) {
-                if (!connected) {// 未调用connect
-                    throw new CanalClientException("should connect first");
-                }
-
-                running = true;
-                // mutex.get();// 阻塞等待
-            } else {
-                // 单机模式直接设置为running
-                running = true;
-            }
-        } catch (Exception e) {
-            Thread.currentThread().interrupt();
-            throw new CanalClientException(e);
-        }
+        running = true;
     }
 
     public boolean checkValid() {
-        if (zkClientx != null) {
-            // return mutex.state();
-            return true;
-        } else {
-            return true;// 默认都放过
-        }
+        return true;// 默认都放过
     }
 
     /**
@@ -156,10 +118,20 @@ public class KafkaCanalConnector {
         }
 
         if (partition == null) {
-            kafkaConsumer.subscribe(Collections.singletonList(topic));
+            if (kafkaConsumer != null) {
+                kafkaConsumer.subscribe(Collections.singletonList(topic));
+            }
+            if (kafkaConsumer2 != null) {
+                kafkaConsumer2.subscribe(Collections.singletonList(topic));
+            }
         } else {
             TopicPartition topicPartition = new TopicPartition(topic, partition);
-            kafkaConsumer.assign(Collections.singletonList(topicPartition));
+            if (kafkaConsumer != null) {
+                kafkaConsumer.assign(Collections.singletonList(topicPartition));
+            }
+            if (kafkaConsumer2 != null) {
+                kafkaConsumer2.assign(Collections.singletonList(topicPartition));
+            }
         }
     }
 
@@ -172,7 +144,12 @@ public class KafkaCanalConnector {
             return;
         }
 
-        kafkaConsumer.unsubscribe();
+        if (kafkaConsumer != null) {
+            kafkaConsumer.unsubscribe();
+        }
+        if (kafkaConsumer2 != null) {
+            kafkaConsumer2.unsubscribe();
+        }
     }
 
     /**
@@ -180,22 +157,22 @@ public class KafkaCanalConnector {
      *
      * @return
      */
-    public Message get() {
+    public List<Message> get() {
         return get(100L, TimeUnit.MILLISECONDS);
     }
 
-    public Message get(Long timeout, TimeUnit unit) {
+    public List<Message> get(Long timeout, TimeUnit unit) {
         waitClientRunning();
         if (!running) {
             return null;
         }
 
-        Message message = getWithoutAck(timeout, unit);
+        List<Message> messages = getWithoutAck(timeout, unit);
         this.ack();
-        return message;
+        return messages;
     }
 
-    public Message getWithoutAck() {
+    public List<Message> getWithoutAck() {
         return getWithoutAck(100L, TimeUnit.MILLISECONDS);
     }
 
@@ -204,7 +181,7 @@ public class KafkaCanalConnector {
      *
      * @return
      */
-    public Message getWithoutAck(Long timeout, TimeUnit unit) {
+    public List<Message> getWithoutAck(Long timeout, TimeUnit unit) {
         waitClientRunning();
         if (!running) {
             return null;
@@ -213,7 +190,33 @@ public class KafkaCanalConnector {
         ConsumerRecords<String, Message> records = kafkaConsumer.poll(unit.toMillis(timeout)); // 基于配置，最多只能poll到一条数据
 
         if (!records.isEmpty()) {
-            return records.iterator().next().value();
+            // return records.iterator().next().value();
+            List<Message> messages = new ArrayList<>();
+            for (ConsumerRecord<String, Message> record : records) {
+                messages.add(record.value());
+            }
+            return messages;
+        }
+        return null;
+    }
+
+    public List<FlatMessage> getFlatMessageWithoutAck(Long timeout, TimeUnit unit) {
+        waitClientRunning();
+        if (!running) {
+            return null;
+        }
+
+        ConsumerRecords<String, String> records = kafkaConsumer2.poll(unit.toMillis(timeout));
+
+        if (!records.isEmpty()) {
+            List<FlatMessage> flatMessages = new ArrayList<>();
+            for (ConsumerRecord<String, String> record : records) {
+                String flatMessageJson = record.value();
+                FlatMessage flatMessage = JSON.parseObject(flatMessageJson, FlatMessage.class);
+                flatMessages.add(flatMessage);
+            }
+
+            return flatMessages;
         }
         return null;
     }
@@ -227,7 +230,12 @@ public class KafkaCanalConnector {
             return;
         }
 
-        kafkaConsumer.commitSync();
+        if (kafkaConsumer != null) {
+            kafkaConsumer.commitSync();
+        }
+        if (kafkaConsumer2 != null) {
+            kafkaConsumer2.commitAsync();
+        }
     }
 
     public void stopRunning() {

--- a/client/src/main/java/com/alibaba/otter/canal/client/kafka/KafkaCanalConnectors.java
+++ b/client/src/main/java/com/alibaba/otter/canal/client/kafka/KafkaCanalConnectors.java
@@ -17,8 +17,9 @@ public class KafkaCanalConnectors {
      * @param groupId
      * @return
      */
-    public static KafkaCanalConnector newKafkaConnector(String servers, String topic, Integer partition, String groupId) {
-        return new KafkaCanalConnector(null, servers, topic, partition, groupId);
+    public static KafkaCanalConnector newKafkaConnector(String servers, String topic, Integer partition,
+                                                        String groupId) {
+        return new KafkaCanalConnector(servers, topic, partition, groupId, false);
     }
 
     /**
@@ -30,33 +31,21 @@ public class KafkaCanalConnectors {
      * @return
      */
     public static KafkaCanalConnector newKafkaConnector(String servers, String topic, String groupId) {
-        return new KafkaCanalConnector(null, servers, topic, null, groupId);
+        return new KafkaCanalConnector(servers, topic, null, groupId, false);
     }
 
     /**
      * 创建kafka客户端链接
      *
-     * @param zkServers
      * @param servers
      * @param topic
      * @param partition
      * @param groupId
+     * @param flatMessage
      * @return
      */
-    public static KafkaCanalConnector newKafkaConnector(String zkServers, String servers, String topic, Integer partition, String groupId) {
-        return new KafkaCanalConnector(zkServers, servers, topic, partition, groupId);
-    }
-
-    /**
-     * 创建kafka客户端链接
-     *
-     * @param zkServers
-     * @param servers
-     * @param topic
-     * @param groupId
-     * @return
-     */
-    public static KafkaCanalConnector newKafkaConnector(String zkServers, String servers, String topic, String groupId) {
-        return new KafkaCanalConnector(zkServers, servers, topic, null, groupId);
+    public static KafkaCanalConnector newKafkaConnector( String servers, String topic,
+                                                        Integer partition, String groupId,boolean flatMessage) {
+        return new KafkaCanalConnector(servers, topic, partition, groupId, flatMessage);
     }
 }

--- a/client/src/test/java/com/alibaba/otter/canal/client/running/kafka/KafkaClientRunningTest.java
+++ b/client/src/test/java/com/alibaba/otter/canal/client/running/kafka/KafkaClientRunningTest.java
@@ -1,5 +1,6 @@
 package com.alibaba.otter.canal.client.running.kafka;
 
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -39,9 +40,9 @@ public class KafkaClientRunningTest extends AbstractKafkaTest {
                 connector.subscribe();
                 while (running) {
                     try {
-                        Message message = connector.getWithoutAck(3L, TimeUnit.SECONDS);
-                        if (message != null) {
-                            System.out.println(message);
+                        List<Message> messages = connector.getWithoutAck(3L, TimeUnit.SECONDS);
+                        if (messages != null) {
+                            System.out.println(messages);
                         }
                         connector.ack();
                     } catch (WakeupException e) {
@@ -49,7 +50,7 @@ public class KafkaClientRunningTest extends AbstractKafkaTest {
                     }
                 }
                 connector.unsubscribe();
-                connector.disconnnect();
+                connector.disconnect();
             }
         });
 

--- a/deployer/src/main/resources/kafka.yml
+++ b/deployer/src/main/resources/kafka.yml
@@ -8,8 +8,11 @@ bufferMemory: 33554432
 canalBatchSize: 50
 # Canal get数据的超时时间, 单位: 毫秒, 空为不限超时
 canalGetTimeout: 100
+flatMessage: true
 
 canalDestinations:
   - canalDestination: example
     topic: example
     partition:
+
+

--- a/protocol/src/main/java/com/alibaba/otter/canal/protocol/FlatMessage.java
+++ b/protocol/src/main/java/com/alibaba/otter/canal/protocol/FlatMessage.java
@@ -1,0 +1,286 @@
+package com.alibaba.otter.canal.protocol;
+
+import java.io.Serializable;
+import java.util.*;
+
+import com.google.common.collect.Table;
+import com.google.protobuf.ByteString;
+
+/**
+ * @author machengyuan 2018-9-13 下午10:31:14
+ * @version 1.0.0
+ */
+public class FlatMessage implements Serializable {
+
+    private static final long         serialVersionUID = -3386650678735860050L;
+
+    private long                      id;
+    private String                    database;
+    private String                    table;
+    private Boolean                   isDdl;
+    private String                    type;
+    private Long                      ts;
+    private String                    sql;
+    private Map<String, Integer>      sqlType;
+    private Map<String, String>       mysqlType;
+    private List<Map<String, String>> data;
+    private List<Map<String, String>> old;
+
+    public FlatMessage() {
+    }
+
+    public FlatMessage(long id){
+        this.id = id;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public void setTable(String table) {
+        this.table = table;
+    }
+
+    public Boolean getIsDdl() {
+        return isDdl;
+    }
+
+    public void setIsDdl(Boolean isDdl) {
+        this.isDdl = isDdl;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Long getTs() {
+        return ts;
+    }
+
+    public void setTs(Long ts) {
+        this.ts = ts;
+    }
+
+    public String getSql() {
+        return sql;
+    }
+
+    public void setSql(String sql) {
+        this.sql = sql;
+    }
+
+    public Map<String, Integer> getSqlType() {
+        return sqlType;
+    }
+
+    public void setSqlType(Map<String, Integer> sqlType) {
+        this.sqlType = sqlType;
+    }
+
+    public Map<String, String> getMysqlType() {
+        return mysqlType;
+    }
+
+    public void setMysqlType(Map<String, String> mysqlType) {
+        this.mysqlType = mysqlType;
+    }
+
+    public List<Map<String, String>> getData() {
+        return data;
+    }
+
+    public void setData(List<Map<String, String>> data) {
+        this.data = data;
+    }
+
+    public List<Map<String, String>> getOld() {
+        return old;
+    }
+
+    public void setOld(List<Map<String, String>> old) {
+        this.old = old;
+    }
+
+    public static List<FlatMessage> messageConverter(Message message) {
+        try {
+            if (message == null) {
+                return null;
+            }
+
+            List<FlatMessage> flatMessages = new ArrayList<>();
+
+            List<ByteString> rawEntries = message.getRawEntries();
+
+            for (ByteString byteString : rawEntries) {
+                CanalEntry.Entry entry = CanalEntry.Entry.parseFrom(byteString);
+                if (entry.getEntryType() == CanalEntry.EntryType.TRANSACTIONBEGIN
+                    || entry.getEntryType() == CanalEntry.EntryType.TRANSACTIONEND) {
+                    continue;
+                }
+
+                CanalEntry.RowChange rowChange;
+                try {
+                    rowChange = CanalEntry.RowChange.parseFrom(entry.getStoreValue());
+                } catch (Exception e) {
+                    throw new RuntimeException(
+                        "ERROR ## parser of eromanga-event has an error , data:" + entry.toString(),
+                        e);
+                }
+
+                CanalEntry.EventType eventType = rowChange.getEventType();
+
+                FlatMessage flatMessage = new FlatMessage(message.getId());
+                flatMessages.add(flatMessage);
+                flatMessage.setDatabase(entry.getHeader().getSchemaName());
+                flatMessage.setTable(entry.getHeader().getTableName());
+                flatMessage.setIsDdl(rowChange.getIsDdl());
+                flatMessage.setType(eventType.toString());
+                flatMessage.setTs(System.currentTimeMillis());
+                flatMessage.setSql(rowChange.getSql());
+
+                if (!rowChange.getIsDdl()) {
+                    Map<String, Integer> sqlType = new LinkedHashMap<>();
+                    Map<String, String> mysqlType = new LinkedHashMap<>();
+                    List<Map<String, String>> data = new ArrayList<>();
+                    List<Map<String, String>> old = new ArrayList<>();
+
+                    Set<String> updateSet = new HashSet<>();
+                    for (CanalEntry.RowData rowData : rowChange.getRowDatasList()) {
+                        if (eventType != CanalEntry.EventType.INSERT && eventType != CanalEntry.EventType.UPDATE
+                            && eventType != CanalEntry.EventType.DELETE) {
+                            continue;
+                        }
+
+                        Map<String, String> row = new LinkedHashMap<>();
+                        List<CanalEntry.Column> columns;
+
+                        if (eventType == CanalEntry.EventType.DELETE) {
+                            columns = rowData.getBeforeColumnsList();
+                        } else {
+                            columns = rowData.getAfterColumnsList();
+                        }
+
+                        for (CanalEntry.Column column : columns) {
+                            sqlType.put(column.getName(), column.getSqlType());
+                            mysqlType.put(column.getName(), column.getMysqlType());
+                            row.put(column.getName(), column.getValue());
+                            // 获取update为true的字段
+                            if (column.getUpdated()) {
+                                updateSet.add(column.getName());
+                            }
+                        }
+                        if (!row.isEmpty()) {
+                            data.add(row);
+                        }
+
+                        if (eventType == CanalEntry.EventType.UPDATE) {
+                            Map<String, String> rowOld = new LinkedHashMap<>();
+                            for (CanalEntry.Column column : rowData.getBeforeColumnsList()) {
+                                if (updateSet.contains(column.getName())) {
+                                    rowOld.put(column.getName(), column.getValue());
+                                }
+                            }
+                            // update操作将记录修改前的值
+                            if (!rowOld.isEmpty()) {
+                                old.add(rowOld);
+                            }
+                        }
+                    }
+                    if (!sqlType.isEmpty()) {
+                        flatMessage.setSqlType(sqlType);
+                    }
+                    if (!mysqlType.isEmpty()) {
+                        flatMessage.setMysqlType(mysqlType);
+                    }
+                    if (!data.isEmpty()) {
+                        flatMessage.setData(data);
+                    }
+                    if (!old.isEmpty()) {
+                        flatMessage.setOld(old);
+                    }
+                }
+            }
+            return flatMessages;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static FlatMessage[] messagePartition(FlatMessage flatMessage, Integer partitionsNum,
+                                                 Table<String, String, String> pkHashConfig) {
+        FlatMessage[] partitionMessages = new FlatMessage[partitionsNum];
+
+        String pk = pkHashConfig.get(flatMessage.getDatabase(), flatMessage.getTable());
+        if (pk == null || flatMessage.getIsDdl()) {
+            partitionMessages[0] = flatMessage;
+        } else {
+            if (flatMessage.getData() != null) {
+                int idx = 0;
+                for (Map<String, String> row : flatMessage.getData()) {
+                    String value = row.get(pk);
+                    if (value == null) {
+                        value = "";
+                    }
+                    int hash = value.hashCode();
+                    int pkHash = Math.abs(hash) % partitionsNum;
+
+                    FlatMessage flatMessageTmp = partitionMessages[pkHash];
+                    if (flatMessageTmp == null) {
+                        flatMessageTmp = new FlatMessage(flatMessage.getId());
+                        partitionMessages[pkHash] = flatMessageTmp;
+                        flatMessageTmp.setDatabase(flatMessage.getDatabase());
+                        flatMessageTmp.setTable(flatMessage.getTable());
+                        flatMessageTmp.setIsDdl(flatMessage.getIsDdl());
+                        flatMessageTmp.setType(flatMessage.getType());
+                        flatMessageTmp.setSql(flatMessage.getSql());
+                        flatMessageTmp.setSqlType(flatMessage.getSqlType());
+                        flatMessageTmp.setMysqlType(flatMessage.getMysqlType());
+                    }
+                    List<Map<String, String>> data = flatMessageTmp.getData();
+                    if (data == null) {
+                        data = new ArrayList<>();
+                        flatMessageTmp.setData(data);
+                    }
+                    data.add(row);
+                    if (flatMessage.getOld() != null && !flatMessage.getOld().isEmpty()) {
+                        List<Map<String, String>> old = flatMessageTmp.getOld();
+                        if (old == null) {
+                            old = new ArrayList<>();
+                            flatMessageTmp.setOld(old);
+                        }
+                        old.add(flatMessage.getOld().get(idx));
+                    }
+                    idx++;
+                }
+            }
+        }
+        return partitionMessages;
+    }
+
+    @Override
+    public String toString() {
+        return "FlatMessage{" + "id=" + id + ", database='" + database + '\'' + ", table='" + table + '\'' + ", isDdl="
+               + isDdl + ", type='" + type + '\'' + ", ts=" + ts + ", sql='" + sql + '\'' + ", sqlType=" + sqlType
+               + ", mysqlType=" + mysqlType + ", data=" + data + ", old=" + old + '}';
+    }
+}

--- a/server/src/main/java/com/alibaba/otter/canal/kafka/CanalKafkaProducer.java
+++ b/server/src/main/java/com/alibaba/otter/canal/kafka/CanalKafkaProducer.java
@@ -1,5 +1,6 @@
 package com.alibaba.otter.canal.kafka;
 
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Future;
 
@@ -11,6 +12,8 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.alibaba.fastjson.JSON;
+import com.alibaba.otter.canal.protocol.FlatMessage;
 import com.alibaba.otter.canal.protocol.Message;
 
 /**
@@ -25,7 +28,12 @@ public class CanalKafkaProducer {
 
     private Producer<String, Message> producer;
 
+    private Producer<String, String>  producer2;                                                 // 用于扁平message的数据投递
+
+    private KafkaProperties           kafkaProperties;
+
     public void init(KafkaProperties kafkaProperties) {
+        this.kafkaProperties = kafkaProperties;
         Properties properties = new Properties();
         properties.put("bootstrap.servers", kafkaProperties.getServers());
         properties.put("acks", "all");
@@ -34,15 +42,26 @@ public class CanalKafkaProducer {
         properties.put("linger.ms", kafkaProperties.getLingerMs());
         properties.put("buffer.memory", kafkaProperties.getBufferMemory());
         properties.put("key.serializer", StringSerializer.class.getName());
-        properties.put("value.serializer", MessageSerializer.class.getName());
-        producer = new KafkaProducer<String, Message>(properties);
+        if (!kafkaProperties.getFlatMessage()) {
+            properties.put("value.serializer", MessageSerializer.class.getName());
+            producer = new KafkaProducer<String, Message>(properties);
+        } else {
+            properties.put("value.serializer", StringSerializer.class.getName());
+            producer2 = new KafkaProducer<String, String>(properties);
+        }
+
         // producer.initTransactions();
     }
 
     public void stop() {
         try {
             logger.info("## stop the kafka producer");
-            producer.close();
+            if (producer != null) {
+                producer.close();
+            }
+            if (producer2 != null) {
+                producer2.close();
+            }
         } catch (Throwable e) {
             logger.warn("##something goes wrong when stopping kafka producer:", e);
         } finally {
@@ -53,14 +72,27 @@ public class CanalKafkaProducer {
     public void send(KafkaProperties.Topic topic, Message message, Callback callback) {
         try {
             // producer.beginTransaction();
-            ProducerRecord<String, Message> record;
-            if (topic.getPartition() != null) {
-                record = new ProducerRecord<String, Message>(topic.getTopic(), topic.getPartition(), null, message);
+            if (!kafkaProperties.getFlatMessage()) {
+                ProducerRecord<String, Message> record;
+                if (topic.getPartition() != null) {
+                    record = new ProducerRecord<String, Message>(topic.getTopic(), topic.getPartition(), null, message);
+                } else {
+                    record = new ProducerRecord<String, Message>(topic.getTopic(), message);
+                }
+                Future<RecordMetadata> future = producer.send(record);
+                future.get();
             } else {
-                record = new ProducerRecord<String, Message>(topic.getTopic(), message);
+                // 发送扁平数据json
+                List<FlatMessage> flatMessages = FlatMessage.messageConverter(message);
+                if (flatMessages != null) {
+                    for (FlatMessage flatMessage : flatMessages) {
+                        ProducerRecord<String, String> record = new ProducerRecord<String, String>(topic.getTopic(),
+                            JSON.toJSONString(flatMessage));
+                        producer2.send(record);
+                    }
+                }
             }
-            Future<RecordMetadata> future = producer.send(record);
-            future.get();
+
             // producer.commitTransaction();
             callback.commit();
             if (logger.isDebugEnabled()) {

--- a/server/src/main/java/com/alibaba/otter/canal/kafka/CanalKafkaStarter.java
+++ b/server/src/main/java/com/alibaba/otter/canal/kafka/CanalKafkaStarter.java
@@ -149,7 +149,7 @@ public class CanalKafkaStarter implements CanalServerStarter {
                             }); // 发送message到topic
                         } else {
                             try {
-                                Thread.sleep(1000);
+                                Thread.sleep(100);
                             } catch (InterruptedException e) {
                                 // ignore
                             }

--- a/server/src/main/java/com/alibaba/otter/canal/kafka/KafkaProperties.java
+++ b/server/src/main/java/com/alibaba/otter/canal/kafka/KafkaProperties.java
@@ -21,6 +21,7 @@ public class KafkaProperties {
     private boolean                filterTransactionEntry = true;
     private int                    canalBatchSize         = 50;
     private Long                   canalGetTimeout;
+    private boolean                flatMessage            = true;
 
     private List<CanalDestination> canalDestinations      = new ArrayList<CanalDestination>();
 
@@ -158,6 +159,14 @@ public class KafkaProperties {
 
     public void setCanalGetTimeout(Long canalGetTimeout) {
         this.canalGetTimeout = canalGetTimeout;
+    }
+
+    public boolean getFlatMessage() {
+        return flatMessage;
+    }
+
+    public void setFlatMessage(boolean flatMessage) {
+        this.flatMessage = flatMessage;
     }
 
     public List<CanalDestination> getCanalDestinations() {

--- a/server/src/main/java/com/alibaba/otter/canal/server/embedded/CanalServerWithEmbedded.java
+++ b/server/src/main/java/com/alibaba/otter/canal/server/embedded/CanalServerWithEmbedded.java
@@ -311,9 +311,10 @@ public class CanalServerWithEmbedded extends AbstractCanalLifeCycle implements C
             }
 
             if (CollectionUtils.isEmpty(events.getEvents())) {
-                logger.debug("getWithoutAck successfully, clientId:{} batchSize:{} but result is null",
-                    clientIdentity.getClientId(),
-                    batchSize);
+                // logger.debug("getWithoutAck successfully, clientId:{} batchSize:{} but result
+                // is null",
+                // clientIdentity.getClientId(),
+                // batchSize);
                 return new Message(-1, true, new ArrayList()); // 返回空包，避免生成batchId，浪费性能
             } else {
                 // 记录到流式信息


### PR DESCRIPTION
增加FlatMessage类，用于kafka的消息投递，Message的每个Entry会被拆分成对应FlatMessage，使用json序列化发送至kafka消费。
原生Message数据通过kafka投递发现有吞吐量底的问题（5000行/s左右），将Message拆分为多个FlatMessage后吞吐量实测在3w行/s左右。
后续将实现对FlatMessage按pk hash 和 partition进行拆分的需求

**增加配置**
server端：
conf/kafka.yml 增加新属性：
flatMessage: true  true：代表使用FlatMessage消息投递，false：代表使用原生Message消息投递

client端：
canal_client/conf/canal-client.yml 增加属性：
flatMessage: true true：代表使用FlatMessage消息投递，false：代表使用原生Message消息投递

**注：**
FlatMessage只对kafka消息投递有效，不影响tcp的原生Message消息传输