### PR TITLE
解决在数据库重装或者在数据库中执行了reset master导致binlog后缀变成000001后,自动切换的问题.

### DIFF
--- a/deployer/src/main/resources/canal.properties
+++ b/deployer/src/main/resources/canal.properties
@@ -62,6 +62,10 @@ canal.instance.parser.parallel = true
 ## disruptor ringbuffer size, must be power of 2
 canal.instance.parser.parallelBufferSize = 256
 
+# position error config
+canal.instance.position.error.check = false
+canal.instance.position.error.check.time = 5
+
 # table meta tsdb info
 canal.instance.tsdb.enable=true
 canal.instance.tsdb.dir=${canal.file.data.dir:../conf}/${canal.instance.destination:}

--- a/deployer/src/main/resources/spring/default-instance.xml
+++ b/deployer/src/main/resources/spring/default-instance.xml
@@ -179,5 +179,10 @@
 		<property name="parallel" value="${canal.instance.parser.parallel:true}" />
 		<property name="parallelThreadSize" value="${canal.instance.parser.parallelThreadSize}" />
 		<property name="parallelBufferSize" value="${canal.instance.parser.parallelBufferSize:256}" />
+		
+		<!-- position error config -->
+		<property name="positionErrorEnable" value="${canal.instance.position.error.check:false}" />
+		<property name="positionErrorTime" value="${canal.instance.position.error.check.time:5}" />
+		
 	</bean>
 </beans>

--- a/deployer/src/main/resources/spring/file-instance.xml
+++ b/deployer/src/main/resources/spring/file-instance.xml
@@ -164,5 +164,10 @@
 		<property name="parallel" value="${canal.instance.parser.parallel:true}" />
 		<property name="parallelThreadSize" value="${canal.instance.parser.parallelThreadSize}" />
 		<property name="parallelBufferSize" value="${canal.instance.parser.parallelBufferSize:256}" />
+		
+				
+		<!-- position error config -->
+		<property name="positionErrorEnable" value="${canal.instance.position.error.check:false}" />
+		<property name="positionErrorTime" value="${canal.instance.position.error.check.time:5}" />
 	</bean>
 </beans>

--- a/deployer/src/main/resources/spring/group-instance.xml
+++ b/deployer/src/main/resources/spring/group-instance.xml
@@ -252,5 +252,10 @@
 		<property name="parallel" value="${canal.instance.parser.parallel:true}" />
 		<property name="parallelThreadSize" value="${canal.instance.parser.parallelThreadSize}" />
 		<property name="parallelBufferSize" value="${canal.instance.parser.parallelBufferSize:256}" />
+		
+				
+		<!-- position error config -->
+		<property name="positionErrorEnable" value="${canal.instance.position.error.check:false}" />
+		<property name="positionErrorTime" value="${canal.instance.position.error.check.time:5}" />
 	</bean>
 </beans>

--- a/deployer/src/main/resources/spring/memory-instance.xml
+++ b/deployer/src/main/resources/spring/memory-instance.xml
@@ -152,5 +152,9 @@
 		<property name="parallel" value="${canal.instance.parser.parallel:true}" />
 		<property name="parallelThreadSize" value="${canal.instance.parser.parallelThreadSize}" />
 		<property name="parallelBufferSize" value="${canal.instance.parser.parallelBufferSize:256}" />
+		
+		<!-- position error config -->
+		<property name="positionErrorEnable" value="${canal.instance.position.error.check:false}" />
+		<property name="positionErrorTime" value="${canal.instance.position.error.check.time:5}" />
 	</bean>
 </beans>

--- a/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/CanalInstanceWithManager.java
+++ b/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/CanalInstanceWithManager.java
@@ -273,6 +273,8 @@ public class CanalInstanceWithManager extends AbstractCanalInstance {
             mysqlEventParser.setFallbackIntervalInSeconds(parameters.getFallbackIntervalInSeconds());
             mysqlEventParser.setProfilingEnabled(false);
             mysqlEventParser.setFilterTableError(parameters.getFilterTableError());
+            mysqlEventParser.setPositionErrorEnable(parameters.isPositionErrorEnable());
+            mysqlEventParser.setPositionErrorTime(parameters.getPositionErrorTime());
             eventParser = mysqlEventParser;
         } else if (type.isLocalBinlog()) {
             LocalBinlogEventParser localBinlogEventParser = new LocalBinlogEventParser();

--- a/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/model/CanalParameter.java
+++ b/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/model/CanalParameter.java
@@ -111,6 +111,8 @@ public class CanalParameter implements Serializable {
     private String                   standbyLogfileName                 = null;                      // standby起始位置
     private Long                     standbyLogfileOffest               = null;
     private Long                     standbyTimestamp                   = null;
+    private boolean                  positionErrorEnable                = false;                                   // 默认关闭
+    private int                      positionErrorTime                  = 5;  
 
     public static enum RunMode {
 
@@ -922,4 +924,20 @@ public class CanalParameter implements Serializable {
     public String toString() {
         return ToStringBuilder.reflectionToString(this, CanalToStringStyle.DEFAULT_STYLE);
     }
+
+	public boolean isPositionErrorEnable() {
+		return positionErrorEnable;
+	}
+
+	public void setPositionErrorEnable(boolean positionErrorEnable) {
+		this.positionErrorEnable = positionErrorEnable;
+	}
+
+	public int getPositionErrorTime() {
+		return positionErrorTime;
+	}
+
+	public void setPositionErrorTime(int positionErrorTime) {
+		this.positionErrorTime = positionErrorTime;
+	}
 }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/exception/PositionErrorException.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/exception/PositionErrorException.java
@@ -1,0 +1,15 @@
+package com.alibaba.otter.canal.parse.exception;
+
+import java.io.IOException;
+
+/**
+ * @author lulin on 2018/9/14 下午4:54
+ * @since 1.1.0
+ */
+
+public class PositionErrorException extends IOException {
+	private static final long serialVersionUID = -5989982973281276473L;
+	public PositionErrorException(String message) {
+		super(message);
+	}
+}

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/DirectLogFetcher.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/DirectLogFetcher.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.alibaba.otter.canal.parse.driver.mysql.socket.SocketChannel;
+import com.alibaba.otter.canal.parse.exception.PositionErrorException;
 import com.taobao.tddl.dbsync.binlog.LogFetcher;
 
 /**
@@ -99,7 +100,7 @@ public class DirectLogFetcher extends LogFetcher {
                     final int errno = getInt16();
                     String sqlstate = forward(1).getFixString(SQLSTATE_LENGTH);
                     String errmsg = getFixString(limit - position);
-                    throw new IOException("Received error packet:" + " errno = " + errno + ", sqlstate = " + sqlstate
+                    throw new PositionErrorException("Received error packet:" + " errno = " + errno + ", sqlstate = " + sqlstate
                                           + " errmsg = " + errmsg);
                 } else if (mark == 254) {
                     // Indicates end of stream. It's not clear when this would


### PR DESCRIPTION
投产中发现，当canal连接的数据库被重新安装或者执行reset master 后，canal会一致通过zk过去位置，然后去mysql中寻找这个位置的点，但是mysql已经不存在这个点了，于是一致循环报错，除非人为干预。
对于该问题，添加了一个位置解析错误的异常，在发生异常时，做了一个次数的判断，默认是5次，如果连续5次都是位置解析错误，那么重新设置新位置：mysql-bin.000001的154offset处，开始同步数据。可以自动切换。
默认改功能不开启。