### PR TITLE
CanalMessageDeserializer.deserializer 方法和FlatMessage.messageConverter 配合的问题

### DIFF
--- a/client/src/main/java/com/alibaba/otter/canal/client/CanalMessageDeserializer.java
+++ b/client/src/main/java/com/alibaba/otter/canal/client/CanalMessageDeserializer.java
@@ -32,10 +32,12 @@ public class CanalMessageDeserializer {
                         if (lazyParseEntry) {
                             // byteString
                             result.setRawEntries(messages.getMessagesList());
+                            result.setRaw(true);
                         } else {
                             for (ByteString byteString : messages.getMessagesList()) {
                                 result.addEntry(CanalEntry.Entry.parseFrom(byteString));
                             }
+                            result.setRaw(false);
                         }
                         return result;
                     }


### PR DESCRIPTION
## 目的： 
修复CanalMessageDeserializer.deserializer方法，在lazyParseEntry =  false 情况下，没有修改raw的值（因为raw默认值是true），导致后续如果用FlatMessage.messageConverter转换不出来的问题。

## 问题描述： 
CanalMessageDeserializer.deserializer(byte[]) 方法或者 CanalMessageDeserializer.deserializer(byte[], boolean) lazyParseEntry 传值false时，在解析的时候，实际已经解析过一遍了，没有把message的raw设置为false，那么后续配合FlatMessage.messageConverter使用时，会出现messageConverter 判断isRaw时，为默认的true，那么这时候就会继续去rawEntries里面拿数据解析，而这时候的rawEntries数据是空的，解析出来还是空，导致问题。

## 解决思路： 
不管mesaage的raw默认值是什么，如果已经解析过的，就把raw设置为false，没有解析过就设置为true，后面的场景就不会有冲突。
