### PR TITLE
filter views when dumpTableMeta

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/DatabaseTableMeta.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/DatabaseTableMeta.java
@@ -203,9 +203,13 @@ public class DatabaseTableMeta implements TableMetaTSDB {
             }
 
             for (String schema : schemas) {
-                packet = connection.query("show tables from `" + schema + "`");
+                // filter views
+                packet = connection.query("show full tables from `" + schema + "` where Table_type = 'BASE TABLE'");
                 List<String> tables = new ArrayList<String>();
                 for (String table : packet.getFieldValues()) {
+                    if("BASE TABLE".equalsIgnoreCase(table)){
+                       continue; 
+                    }
                     String fullName = schema + "." + table;
                     if (blackFilter == null || !blackFilter.filter(fullName)) {
                         if (filter == null || filter.filter(fullName)) {


### PR DESCRIPTION
show tables from schema会把当前schema下所有的view也查询出来，正常来说我可能拥有schema所有表的select权限，对表执行show create table xxx是没问题的，但是如果是view的话，就会出现`SHOW VIEW command denied to user 'xxx'@'yyy'`，最终就会导致MysqlEventParser#start一直失败