### PR TITLE
[ISSUE#1158]Fix NPE when messages size is 0

### DIFF
--- a/client/src/test/java/com/alibaba/otter/canal/client/running/rocketmq/CanalRocketMQClientExample.java
+++ b/client/src/test/java/com/alibaba/otter/canal/client/running/rocketmq/CanalRocketMQClientExample.java
@@ -105,6 +105,11 @@ public class CanalRocketMQClientExample extends AbstractRocektMQTest {
                 connector.subscribe();
                 while (running) {
                     List<Message> messages = connector.getListWithoutAck(100L, TimeUnit.MILLISECONDS); // 获取message
+
+                    if(messages.size() == 0){
+                        continue;
+                    }
+
                     for (Message message : messages) {
                         long batchId = message.getId();
                         int size = message.getEntries().size();


### PR DESCRIPTION
CanalRocketMQClientExample#process中，如果connector.getListWithoutAck()第一次返回的messages大小为0，则RocketMQCanalConnector中的lastGetBatchMessage仍未null，后续调用connector.ack()时会抛空指针。