### PR TITLE
Update AddressUtils.java

### DIFF
--- a/common/src/main/java/com/alibaba/otter/canal/common/utils/AddressUtils.java
+++ b/common/src/main/java/com/alibaba/otter/canal/common/utils/AddressUtils.java
@@ -55,15 +55,6 @@ public class AddressUtils {
     public static InetAddress getHostAddress() {
         InetAddress localAddress = null;
         try {
-            localAddress = InetAddress.getLocalHost();
-            if (isValidHostAddress(localAddress)) {
-                return localAddress;
-            }
-        } catch (Throwable e) {
-            logger.warn("Failed to retriving local host ip address, try scan network card ip address. cause: "
-                        + e.getMessage());
-        }
-        try {
             Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
             if (interfaces != null) {
                 while (interfaces.hasMoreElements()) {


### PR DESCRIPTION
由于服务器的k8s 划分了 虚拟网络，导致读取ip不准确。windows装了虚拟也有同样的问题，读取到了虚拟机的vm8的虚拟网址。