### PR TITLE
修复 FlatMessage  Hash 到不正确的分区的Bug。

### DIFF
--- a/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
+++ b/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
@@ -417,9 +417,9 @@ public class MQMessageUtils {
                         pkNames = flatMessage.getPkNames();
                     }
 
-                    int hashCode = table.hashCode();
                     int idx = 0;
                     for (Map<String, String> row : flatMessage.getData()) {
+                        int hashCode = table.hashCode();
                         if (!hashMode.tableHash) {
                             for (String pkName : pkNames) {
                                 String value = row.get(pkName);


### PR DESCRIPTION
修复当 canal.mq.flatMessage = true 时，MQMessageUtils::messagePartition 数据分区错误的 bug。

```
public static FlatMessage[] messagePartition(FlatMessage flatMessage, Integer partitionsNum, String pkHashConfigs)  
```
当 `flatMessage` 的 `data` 有多条数据时，没有初始化 `hashCode`。 
