### PR TITLE
fix issue 1532

### DIFF
--- a/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
+++ b/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
@@ -499,7 +499,7 @@ public class MQMessageUtils {
                     topics.add(topic);
                 }
             } else if (matchDynamicTopic(name, item)) {
-                topics.add(name);
+                topics.add(name.toLowerCase());
             }
         }
         return topics.isEmpty() ? null : topics;


### PR DESCRIPTION
因为binlog日志同表名大小写的原因导致kafka的日志恢复并resize，报错之后引起集群崩溃
现在修改为投递消息的topic不区分表名大小写