### PR TITLE
 修改canal.mq.partitionHash散列规则，使其支持同库下的不同表hash至相同分区

### DIFF
--- a/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
+++ b/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
@@ -230,6 +230,7 @@ public class MQMessageUtils {
                                     }
                                 }
                             } else {
+                            	hashCode = database.hashCode();
                                 for (CanalEntry.Column column : rowData.getAfterColumnsList()) {
                                     if (checkPkNamesHasContain(hashMode.pkNames, column.getName())) {
                                         hashCode = hashCode ^ column.getValue().hashCode();


### PR DESCRIPTION
当指明pk级做分区（schema.table:pk1^pk2）时，
由table.hashCode()^column.getValue().hashCode()改database.hashCode()^column.getValue().hashCode()，从而支持同库下不同表hash至相同分区 
