### PR TITLE
resovle config/metrics as a destination folder

### DIFF
--- a/deployer/src/main/java/com/alibaba/otter/canal/deployer/CanalStater.java
+++ b/deployer/src/main/java/com/alibaba/otter/canal/deployer/CanalStater.java
@@ -65,7 +65,8 @@ public class CanalStater {
 
                         public boolean accept(File pathname) {
                             String filename = pathname.getName();
-                            return pathname.isDirectory() && !"spring".equalsIgnoreCase(filename);
+                            return pathname.isDirectory() && !"spring".equalsIgnoreCase(filename) &&
+                                    !"metrics".equalsIgnoreCase(filename);
                         }
                     });
                     if (instanceDirs != null && instanceDirs.length > 0) {


### PR DESCRIPTION
canal将conf/metrics认为是一个destination，启动时候会有错误信息。
`2019-04-09 14:58:52.414 [main] WARN  c.a.o.canal.parse.inbound.mysql.dbsync.LogEventConvert - --> init table filter : ^.*\..*$`
`2019-04-09 14:58:52.414 [main] WARN  c.a.o.canal.parse.inbound.mysql.dbsync.LogEventConvert - --> init table black filter :`
`2019-04-09 14:58:52.418 [destination = metrics , address = null , EventParser] ERROR c.a.o.c.p.inbound.mysql.rds.RdsBinlogEventParserProxy - parse events has an error
com.alibaba.otter.canal.parse.exception.CanalParseException: illegal connection is null`
`2019-04-09 14:58:52.425 [main] INFO  com.alibaba.otter.canal.deployer.CanalStater - ## the canal server is running now ......`
`2019-04-09 14:58:52.451 [canal-instance-scan-0] INFO  c.a.o.canal.deployer.monitor.SpringInstanceConfigMonitor - auto notify stop metrics successful.`
