### PR TITLE
fix: mem leak of the MemoryEventStoreWithBuffer

### DIFF
--- a/store/src/main/java/com/alibaba/otter/canal/store/memory/MemoryEventStoreWithBuffer.java
+++ b/store/src/main/java/com/alibaba/otter/canal/store/memory/MemoryEventStoreWithBuffer.java
@@ -439,7 +439,7 @@ public class MemoryEventStoreWithBuffer extends AbstractCanalStoreScavenge imple
                     if (batchMode.isMemSize()) {
                         ackMemSize.addAndGet(memsize);
                         // 尝试清空buffer中的内存，将ack之前的内存全部释放掉
-                        for (long index = sequence + 1; index < next; index++) {
+                        for (long index = sequence + 1; index <= next; index++) {
                             entries[getIndex(index)] = null;// 设置为null
                         }
                     }


### PR DESCRIPTION
Every time when the func `cleanUntil(Position position)` be called, the event match `position` which is `next` will not be set to `null`. Then the `ackSequence` be set to `next`，the `position(next)` will never be GC, unless the next cycle put other event into this position, if the event is very big, may be result to OOM. 