### PR TITLE
升级spring 3.2.18.RELEASE -> 5.0.8.RELEASE, parse的tsdb操作去除orm SqlMapCli…

### DIFF
--- a/deployer/src/main/resources/spring/base-instance.xml
+++ b/deployer/src/main/resources/spring/base-instance.xml
@@ -3,11 +3,11 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:aop="http://www.springframework.org/schema/aop" xmlns:lang="http://www.springframework.org/schema/lang"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.0.xsd
-           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.0.xsd
-           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd
+           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
 	default-autowire="byName">
 
 	<!-- properties -->

--- a/deployer/src/main/resources/spring/default-instance.xml
+++ b/deployer/src/main/resources/spring/default-instance.xml
@@ -3,35 +3,23 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:aop="http://www.springframework.org/schema/aop" xmlns:lang="http://www.springframework.org/schema/lang"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.0.xsd
-           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.0.xsd
-           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd
+           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
 	default-autowire="byName">
 
 	<import resource="classpath:spring/base-instance.xml" />
 
 	<bean id="instance" class="com.alibaba.otter.canal.instance.spring.CanalInstanceWithSpring">
 		<property name="destination" value="${canal.instance.destination}" />
-		<property name="eventParser">
-			<ref local="eventParser" />
-		</property>
-		<property name="eventSink">
-			<ref local="eventSink" />
-		</property>
-		<property name="eventStore">
-			<ref local="eventStore" />
-		</property>
-		<property name="metaManager">
-			<ref local="metaManager" />
-		</property>
-		<property name="alarmHandler">
-			<ref local="alarmHandler" />
-		</property>
-        <property name="mqConfig">
-            <ref local="mqConfig" />
-        </property>
+		<property name="eventParser" ref="eventParser"/>
+		<property name="eventSink" ref="eventSink" />
+		<property name="eventStore" ref="eventStore" />
+		<property name="metaManager" ref="metaManager" />
+		<property name="alarmHandler" ref="alarmHandler" />
+		<property name="mqConfig" ref="mqConfig" />
 	</bean>
 
 	<!-- 报警处理类 -->

--- a/deployer/src/main/resources/spring/file-instance.xml
+++ b/deployer/src/main/resources/spring/file-instance.xml
@@ -3,35 +3,23 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:aop="http://www.springframework.org/schema/aop" xmlns:lang="http://www.springframework.org/schema/lang"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.0.xsd
-           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.0.xsd
-           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd
+           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
 	default-autowire="byName">
 
 	<import resource="classpath:spring/base-instance.xml" />
 
 	<bean id="instance" class="com.alibaba.otter.canal.instance.spring.CanalInstanceWithSpring">
 		<property name="destination" value="${canal.instance.destination}" />
-		<property name="eventParser">
-			<ref local="eventParser" />
-		</property>
-		<property name="eventSink">
-			<ref local="eventSink" />
-		</property>
-		<property name="eventStore">
-			<ref local="eventStore" />
-		</property>
-		<property name="metaManager">
-			<ref local="metaManager" />
-		</property>
-		<property name="alarmHandler">
-			<ref local="alarmHandler" />
-		</property>
-        <property name="mqConfig">
-            <ref local="mqConfig" />
-        </property>
+		<property name="eventParser" ref="eventParser"/>
+		<property name="eventSink" ref="eventSink" />
+		<property name="eventStore" ref="eventStore" />
+		<property name="metaManager" ref="metaManager" />
+		<property name="alarmHandler" ref="alarmHandler" />
+		<property name="mqConfig" ref="mqConfig" />
 	</bean>
 
 	<!-- 报警处理类 -->

--- a/deployer/src/main/resources/spring/group-instance.xml
+++ b/deployer/src/main/resources/spring/group-instance.xml
@@ -3,35 +3,23 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:aop="http://www.springframework.org/schema/aop" xmlns:lang="http://www.springframework.org/schema/lang"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.0.xsd
-           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.0.xsd
-           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd
+           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
 	default-autowire="byName">
 
 	<import resource="classpath:spring/base-instance.xml" />
 
 	<bean id="instance" class="com.alibaba.otter.canal.instance.spring.CanalInstanceWithSpring">
 		<property name="destination" value="${canal.instance.destination}" />
-		<property name="eventParser">
-			<ref local="eventParser" />
-		</property>
-		<property name="eventSink">
-			<ref local="eventSink" />
-		</property>
-		<property name="eventStore">
-			<ref local="eventStore" />
-		</property>
-		<property name="metaManager">
-			<ref local="metaManager" />
-		</property>
-		<property name="alarmHandler">
-			<ref local="alarmHandler" />
-		</property>
-		<property name="mqConfig">
-			<ref local="mqConfig" />
-		</property>
+		<property name="eventParser" ref="eventParser"/>
+		<property name="eventSink" ref="eventSink" />
+		<property name="eventStore" ref="eventStore" />
+		<property name="metaManager" ref="metaManager" />
+		<property name="alarmHandler" ref="alarmHandler" />
+		<property name="mqConfig" ref="mqConfig" />
 	</bean>
 
 	<!-- 报警处理类 -->

--- a/deployer/src/main/resources/spring/memory-instance.xml
+++ b/deployer/src/main/resources/spring/memory-instance.xml
@@ -3,35 +3,23 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:aop="http://www.springframework.org/schema/aop" xmlns:lang="http://www.springframework.org/schema/lang"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.0.xsd
-           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.0.xsd
-           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd
+           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
 	default-autowire="byName">
 
 	<import resource="classpath:spring/base-instance.xml" />
 
 	<bean id="instance" class="com.alibaba.otter.canal.instance.spring.CanalInstanceWithSpring">
 		<property name="destination" value="${canal.instance.destination}" />
-		<property name="eventParser">
-			<ref local="eventParser" />
-		</property>
-		<property name="eventSink">
-			<ref local="eventSink" />
-		</property>
-		<property name="eventStore">
-			<ref local="eventStore" />
-		</property>
-		<property name="metaManager">
-			<ref local="metaManager" />
-		</property>
-		<property name="alarmHandler">
-			<ref local="alarmHandler" />
-		</property>
-        <property name="mqConfig">
-            <ref local="mqConfig" />
-        </property>
+		<property name="eventParser" ref="eventParser"/>
+		<property name="eventSink" ref="eventSink" />
+		<property name="eventStore" ref="eventStore" />
+		<property name="metaManager" ref="metaManager" />
+		<property name="alarmHandler" ref="alarmHandler" />
+		<property name="mqConfig" ref="mqConfig" />
 	</bean>
 
 	<!-- 报警处理类 -->

--- a/deployer/src/main/resources/spring/tsdb/h2-tsdb.xml
+++ b/deployer/src/main/resources/spring/tsdb/h2-tsdb.xml
@@ -45,16 +45,17 @@
         <property name="useUnfairLock" value="true" />
 	</bean>
 
-    <bean id="sqlMapClient" class="org.springframework.orm.ibatis.SqlMapClientFactoryBean">
+    <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
         <property name="dataSource" ref="dataSource"/>
-        <property name="configLocation" value="classpath:spring/tsdb/sql-map/sqlmap-config.xml"/>
+        <property name="configLocation" value="classpath:tsdb/sql-map/sqlmap-config.xml"/>
     </bean>
 
     <bean id="metaHistoryDAO" class="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDAO">
-        <property name="sqlMapClient" ref="sqlMapClient"/>
+        <property name="sqlSessionFactory" ref="sqlSessionFactory"/>
     </bean>
 
     <bean id="metaSnapshotDAO" class="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDAO">
-        <property name="sqlMapClient" ref="sqlMapClient"/>
+        <property name="sqlSessionFactory" ref="sqlSessionFactory"/>
+<!--        <property name="sqlMapClient" ref="sqlMapClient"/>-->
     </bean>
 </beans>

--- a/deployer/src/main/resources/spring/tsdb/mysql-tsdb.xml
+++ b/deployer/src/main/resources/spring/tsdb/mysql-tsdb.xml
@@ -48,16 +48,16 @@
         <property name="useUnfairLock" value="true" />
 	</bean>
 
-    <bean id="sqlMapClient" class="org.springframework.orm.ibatis.SqlMapClientFactoryBean">
+    <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
         <property name="dataSource" ref="dataSource"/>
-        <property name="configLocation" value="classpath:spring/tsdb/sql-map/sqlmap-config.xml"/>
+        <property name="configLocation" value="classpath:tsdb/sql-map/sqlmap-config.xml"/>
     </bean>
 
     <bean id="metaHistoryDAO" class="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDAO">
-        <property name="sqlMapClient" ref="sqlMapClient"/>
+        <property name="sqlSessionFactory" ref="sqlSessionFactory"/>
     </bean>
 
     <bean id="metaSnapshotDAO" class="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDAO">
-        <property name="sqlMapClient" ref="sqlMapClient"/>
+        <property name="sqlSessionFactory" ref="sqlSessionFactory"/>
     </bean>
 </beans>

--- a/deployer/src/main/resources/spring/tsdb/sql-map/sqlmap-config.xml
+++ b/deployer/src/main/resources/spring/tsdb/sql-map/sqlmap-config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE sqlMapConfig PUBLIC "-//iBATIS.com//DTD SQL Map Config 2.0//EN"
-        "http://www.ibatis.com/dtd/sql-map-config-2.dtd">
-<sqlMapConfig>
-    <settings useStatementNamespaces="true"/>
-    <sqlMap resource="spring/tsdb/sql-map/sqlmap_history.xml"/>
-    <sqlMap resource="spring/tsdb/sql-map/sqlmap_snapshot.xml"/>
-</sqlMapConfig>
+<!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN" "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+    <mappers>
+        <mapper resource="tsdb/sql-map/sqlmap_history.xml"/>
+        <mapper resource="tsdb/sql-map/sqlmap_snapshot.xml"/>
+    </mappers>
+</configuration>

--- a/deployer/src/main/resources/spring/tsdb/sql-map/sqlmap_history.xml
+++ b/deployer/src/main/resources/spring/tsdb/sql-map/sqlmap_history.xml
@@ -1,45 +1,68 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE sqlMap PUBLIC "-//ibatis.apache.org//DTD SQL Map 2.0//EN" "http://ibatis.apache.org/dtd/sql-map-2.dtd" >
-<sqlMap namespace="meta_history">
-    <typeAlias alias="metaHistoryDO" type="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDO"/>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="meta_history">
+    <resultMap id="metaHistoryDO" type="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDO"/>
     <sql id="allColumns">
         <![CDATA[
-		gmt_create,gmt_modified,destination,binlog_file,binlog_offest,binlog_master_id,binlog_timestamp,use_schema,sql_schema,sql_table,sql_text,sql_type,extra
+		gmt_create,
+		gmt_modified,
+		destination,
+		binlog_file,
+		binlog_offest,
+		binlog_master_id,
+		binlog_timestamp,
+		use_schema,
+		sql_schema,
+		sql_table,
+		sql_text,
+		sql_type,
+		extra
         ]]>
     </sql>
     <sql id="allVOColumns">
         <![CDATA[
-		a.id as id,a.gmt_create as gmtCreate,a.gmt_modified as gmtModified,
-		a.destination as destination,a.binlog_file as binlogFile,a.binlog_offest as binlogOffest,a.binlog_master_id as binlogMasterId,a.binlog_timestamp as binlogTimestamp,
-		a.use_schema as useSchema,a.sql_schema as sqlSchema,a.sql_table as sqlTable,a.sql_text as sqlText,a.sql_type as sqlType,a.extra as extra
+		a.id as id,
+		a.gmt_create as gmtCreate,
+		a.gmt_modified as gmtModified,
+		a.destination as destination,
+		a.binlog_file as binlogFile,
+		a.binlog_offest as binlogOffest,
+		a.binlog_master_id as binlogMasterId,
+		a.binlog_timestamp as binlogTimestamp,
+		a.use_schema as useSchema,
+		a.sql_schema as sqlSchema,
+		a.sql_table as sqlTable,
+		a.sql_text as sqlText,
+		a.sql_type as sqlType,
+		a.extra as extra
         ]]>
     </sql>
 
-    <select id="findByTimestamp" parameterClass="java.util.Map" resultClass="metaHistoryDO">
+    <select id="findByTimestamp" parameterType="java.util.Map" resultType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDO">
         select
         <include refid="allVOColumns"/>
         from meta_history a
         <![CDATA[
-        where destination = #destination# and binlog_timestamp >= #snapshotTimestamp# and binlog_timestamp <= #timestamp#
+        where destination = #{destination} and binlog_timestamp >= #{snapshotTimestamp} and binlog_timestamp <= #{timestamp}
         order by binlog_timestamp asc,id asc
         ]]>
     </select>
 
-    <insert id="insert" parameterClass="metaHistoryDO">
+    <insert id="insert" parameterType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDO">
         insert into meta_history (<include refid="allColumns"/>)
-        values(CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,#destination#,#binlogFile#,#binlogOffest#,#binlogMasterId#,#binlogTimestamp#,#useSchema#,#sqlSchema#,#sqlTable#,#sqlText#,#sqlType#,#extra#)
+        values(CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,#{destination},#{binlogFile},#{binlogOffest},#{binlogMasterId},#{binlogTimestamp},#{useSchema},#{sqlSchema},#{sqlTable},#{sqlText},#{sqlType},#{extra})
     </insert>
     
-    <delete id="deleteByName" parameterClass="java.util.Map">
+    <delete id="deleteByName" parameterType="java.util.Map">
         delete from meta_history 
-        where destination=#destination#
+        where destination=#{destination}
     </delete>
 
 
-    <delete id="deleteByTimestamp" parameterClass="java.util.Map">
+    <delete id="deleteByTimestamp" parameterType="java.util.Map">
         <![CDATA[
 		delete from meta_history
-		where destination=#destination# and binlog_timestamp < #timestamp#
+		where destination=#{destination} and binlog_timestamp < #{timestamp}
         ]]>
     </delete>
-</sqlMap>
+</mapper>

--- a/deployer/src/main/resources/spring/tsdb/sql-map/sqlmap_snapshot.xml
+++ b/deployer/src/main/resources/spring/tsdb/sql-map/sqlmap_snapshot.xml
@@ -1,51 +1,78 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE sqlMap PUBLIC "-//ibatis.apache.org//DTD SQL Map 2.0//EN" "http://ibatis.apache.org/dtd/sql-map-2.dtd" >
-<sqlMap namespace="meta_snapshot">
-    <typeAlias alias="metaSnapshotDO" type="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO"/>
-    <typeAlias alias="tableMetaSnapshotDO"
-               type="com.alibaba.middleware.jingwei.biz.dataobject.CanalTableMetaSnapshotDO"/>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="meta_snapshot">
+    <resultMap id="metaSnapshotDO" type="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO"/>
+<!--    <resultMap id="tableMetaSnapshotDO" type="com.alibaba.middleware.jingwei.biz.dataobject.CanalTableMetaSnapshotDO"/>-->
     <sql id="allColumns">
         <![CDATA[
-		gmt_create,gmt_modified,destination,binlog_file,binlog_offest,binlog_master_id,binlog_timestamp,data,extra
+		gmt_create,
+		gmt_modified,
+		destination,
+		binlog_file,
+		binlog_offest,
+		binlog_master_id,
+		binlog_timestamp,
+		data,
+		extra
         ]]>
     </sql>
     <sql id="allVOColumns">
         <![CDATA[
-		a.id as id,a.gmt_create as gmtCreate,a.gmt_modified as gmtModified,
-		a.destination as destination,a.binlog_file as binlogFile,a.binlog_offest as binlogOffest,a.binlog_master_id as binlogMasterId,a.binlog_timestamp as binlogTimestamp,a.data as data,a.extra as extra
+		a.id as id,
+		a.gmt_create as gmtCreate,
+		a.gmt_modified as gmtModified,
+		a.destination as destination,
+		a.binlog_file as binlogFile,
+		a.binlog_offest as binlogOffest,
+		a.binlog_master_id as binlogMasterId,
+		a.binlog_timestamp as binlogTimestamp,
+		a.data as data,
+		a.extra as extra
         ]]>
     </sql>
 
-    <select id="findByTimestamp" parameterClass="java.util.Map" resultClass="metaSnapshotDO">
+    <select id="findByTimestamp" parameterType="java.util.Map" resultType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO">
     	select <include refid="allVOColumns"/>
     	<![CDATA[
         from meta_snapshot a
-        where destination = #destination# and binlog_timestamp < #timestamp#
+        where destination = #{destination} and binlog_timestamp < #{timestamp}
         order by binlog_timestamp desc,id desc
         limit 1
         ]]>
     </select>
     
-    <insert id="insert" parameterClass="metaSnapshotDO">
+     <select id="findByTimestampOnDerby" parameterType="java.util.Map" resultType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO">
+   		select * FROM ( 
+   		select ROW_NUMBER() OVER() AS rownum, <include refid="allVOColumns"/>
+   		<![CDATA[ 
+   		from meta_snapshot a
+   		where destination = #{destination} and binlog_timestamp < #{timestamp}
+        order by binlog_timestamp desc,id desc
+		) AS tmp 
+		WHERE rownum <= 5
+		]]>
+    </select>
+
+    <insert id="insert" parameterType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO">
         insert into meta_snapshot (<include refid="allColumns"/>)
-        values(CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,#destination#,#binlogFile#,#binlogOffest#,#binlogMasterId#,#binlogTimestamp#,#data#,#extra#)
+        values(CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,#{destination},#{binlogFile},#{binlogOffest},#{binlogMasterId},#{binlogTimestamp},#{data},#{extra})
     </insert>
 
-    <update id="update" parameterClass="metaSnapshotDO">
+    <update id="update" parameterType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO">
         update meta_snapshot set gmt_modified=now(),
-        binlog_file=#binlogFile#,binlog_offest=#binlogOffest#,binlog_master_id=#binlogMasterId#,binlog_timestamp=#binlogTimestamp#,data=#data#,extra=#extra#
-        where destination=#destination# and binlog_timestamp=0
+        binlog_file=#{binlogFile},binlog_offest=#{binlogOffest},binlog_master_id=#{binlogMasterId},binlog_timestamp=#{binlogTimestamp},data=#{data},extra=#{extra}
+        where destination=#{destination} and binlog_timestamp=0
     </update>
 
- 	<delete id="deleteByName" parameterClass="java.util.Map">
+ 	<delete id="deleteByName" parameterType="java.util.Map">
         delete from meta_snapshot 
-        where destination=#destination#
+        where destination=#{destination}
     </delete>
 
-    <delete id="deleteByTimestamp" parameterClass="java.util.Map">
+    <delete id="deleteByTimestamp" parameterType="java.util.Map">
         <![CDATA[
 		delete from meta_snapshot
-		where destination=#destination# and binlog_timestamp < #timestamp# and binlog_timestamp > 0
+		where destination=#{destination} and binlog_timestamp < #{timestamp} and binlog_timestamp > 0
         ]]>
     </delete>
-</sqlMap>
+</mapper>

--- a/parse/pom.xml
+++ b/parse/pom.xml
@@ -66,6 +66,14 @@
 			<artifactId>h2</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.mybatis</groupId>
+			<artifactId>mybatis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mybatis</groupId>
+			<artifactId>mybatis-spring</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 		</dependency>

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/dao/MetaBaseDAO.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/dao/MetaBaseDAO.java
@@ -5,18 +5,19 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import javax.sql.DataSource;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.orm.ibatis.support.SqlMapClientDaoSupport;
+import org.mybatis.spring.support.SqlSessionDaoSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author agapple 2017年10月14日 上午1:05:22
  * @since 1.0.25
  */
-@SuppressWarnings("deprecation")
-public class MetaBaseDAO extends SqlMapClientDaoSupport {
+public class MetaBaseDAO extends SqlSessionDaoSupport {
+
+    private static final Logger log = LoggerFactory.getLogger(MetaBaseDAO.class);
 
     protected boolean isH2 = false;
 
@@ -24,8 +25,8 @@ public class MetaBaseDAO extends SqlMapClientDaoSupport {
         Connection conn = null;
         InputStream input = null;
         try {
-            DataSource dataSource = getDataSource();
-            conn = dataSource.getConnection();
+//            DataSource dataSource = getDataSource();
+            conn = super.getSqlSessionFactory().openSession().getConnection();
             String name = "mysql";
             isH2 = isH2(conn);
             if (isH2) {
@@ -43,7 +44,7 @@ public class MetaBaseDAO extends SqlMapClientDaoSupport {
             stmt.execute(sql);
             stmt.close();
         } catch (Throwable e) {
-            logger.warn("init " + tableName + " failed", e);
+            log.warn("init " + tableName + " failed", e);
         } finally {
             IOUtils.closeQuietly(input);
             if (conn != null) {

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/dao/MetaHistoryDAO.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/dao/MetaHistoryDAO.java
@@ -11,11 +11,10 @@ import com.google.common.collect.Maps;
  * @author wanshao 2017年7月27日 下午10:51:55
  * @since 3.2.5
  */
-@SuppressWarnings("deprecation")
 public class MetaHistoryDAO extends MetaBaseDAO {
 
-    public Long insert(MetaHistoryDO metaDO) {
-        return (Long) getSqlMapClientTemplate().insert("meta_history.insert", metaDO);
+    public Integer insert(MetaHistoryDO metaDO) {
+        return getSqlSessionTemplate().insert("meta_history.insert", metaDO);
     }
 
     public List<MetaHistoryDO> findByTimestamp(String destination, Long snapshotTimestamp, Long timestamp) {
@@ -23,13 +22,13 @@ public class MetaHistoryDAO extends MetaBaseDAO {
         params.put("destination", destination);
         params.put("snapshotTimestamp", snapshotTimestamp == null ? 0L : snapshotTimestamp);
         params.put("timestamp", timestamp == null ? 0L : timestamp);
-        return (List<MetaHistoryDO>) getSqlMapClientTemplate().queryForList("meta_history.findByTimestamp", params);
+        return getSqlSessionTemplate().<MetaHistoryDO>selectList("meta_history.findByTimestamp", params);
     }
 
     public Integer deleteByName(String destination) {
         HashMap params = Maps.newHashMapWithExpectedSize(2);
         params.put("destination", destination);
-        return getSqlMapClientTemplate().delete("meta_history.deleteByName", params);
+        return getSqlSessionTemplate().delete("meta_history.deleteByName", params);
     }
 
     /**
@@ -40,7 +39,7 @@ public class MetaHistoryDAO extends MetaBaseDAO {
         long timestamp = System.currentTimeMillis() - interval * 1000;
         params.put("timestamp", timestamp);
         params.put("destination", destination);
-        return getSqlMapClientTemplate().delete("meta_history.deleteByTimestamp", params);
+        return getSqlSessionTemplate().delete("meta_history.deleteByTimestamp", params);
     }
 
     protected void initDao() throws Exception {

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/dao/MetaSnapshotDAO.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/dao/MetaSnapshotDAO.java
@@ -10,15 +10,14 @@ import com.google.common.collect.Maps;
  * @author wanshao 2017年7月27日 下午10:51:55
  * @since 3.2.5
  */
-@SuppressWarnings("deprecation")
 public class MetaSnapshotDAO extends MetaBaseDAO {
 
-    public Long insert(MetaSnapshotDO snapshotDO) {
-        return (Long) getSqlMapClientTemplate().insert("meta_snapshot.insert", snapshotDO);
+    public Integer insert(MetaSnapshotDO snapshotDO) {
+        return getSqlSessionTemplate().insert("meta_snapshot.insert", snapshotDO);
     }
 
-    public Long update(MetaSnapshotDO snapshotDO) {
-        return (Long) getSqlMapClientTemplate().insert("meta_snapshot.update", snapshotDO);
+    public Integer update(MetaSnapshotDO snapshotDO) {
+        return getSqlSessionTemplate().insert("meta_snapshot.update", snapshotDO);
     }
 
     public MetaSnapshotDO findByTimestamp(String destination, Long timestamp) {
@@ -26,13 +25,13 @@ public class MetaSnapshotDAO extends MetaBaseDAO {
         params.put("timestamp", timestamp == null ? 0L : timestamp);
         params.put("destination", destination);
 
-        return (MetaSnapshotDO) getSqlMapClientTemplate().queryForObject("meta_snapshot.findByTimestamp", params);
+        return (MetaSnapshotDO) getSqlSessionTemplate().selectOne("meta_snapshot.findByTimestamp", params);
     }
 
     public Integer deleteByName(String destination) {
         HashMap params = Maps.newHashMapWithExpectedSize(2);
         params.put("destination", destination);
-        return getSqlMapClientTemplate().delete("meta_snapshot.deleteByName", params);
+        return getSqlSessionTemplate().delete("meta_snapshot.deleteByName", params);
     }
 
     /**
@@ -43,7 +42,7 @@ public class MetaSnapshotDAO extends MetaBaseDAO {
         long timestamp = System.currentTimeMillis() - interval * 1000;
         params.put("timestamp", timestamp);
         params.put("destination", destination);
-        return getSqlMapClientTemplate().delete("meta_snapshot.deleteByTimestamp", params);
+        return getSqlSessionTemplate().delete("meta_snapshot.deleteByTimestamp", params);
     }
 
     protected void initDao() throws Exception {

--- a/parse/src/test/resources/tsdb/derby-tsdb.xml
+++ b/parse/src/test/resources/tsdb/derby-tsdb.xml
@@ -29,16 +29,16 @@
         <property name="useUnfairLock" value="true" />
 	</bean>
 
-    <bean id="sqlMapClient" class="org.springframework.orm.ibatis.SqlMapClientFactoryBean">
+    <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
         <property name="dataSource" ref="dataSource"/>
         <property name="configLocation" value="classpath:tsdb/sql-map/sqlmap-config.xml"/>
     </bean>
 
     <bean id="metaHistoryDAO" class="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDAO">
-        <property name="sqlMapClient" ref="sqlMapClient"/>
+        <property name="sqlSessionFactory" ref="sqlSessionFactory"/>
     </bean>
 
     <bean id="metaSnapshotDAO" class="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDAO">
-        <property name="sqlMapClient" ref="sqlMapClient"/>
+        <property name="sqlSessionFactory" ref="sqlSessionFactory"/>
     </bean>
 </beans>

--- a/parse/src/test/resources/tsdb/h2-tsdb.xml
+++ b/parse/src/test/resources/tsdb/h2-tsdb.xml
@@ -29,16 +29,17 @@
         <property name="useUnfairLock" value="true" />
 	</bean>
 
-    <bean id="sqlMapClient" class="org.springframework.orm.ibatis.SqlMapClientFactoryBean">
+    <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
         <property name="dataSource" ref="dataSource"/>
         <property name="configLocation" value="classpath:tsdb/sql-map/sqlmap-config.xml"/>
     </bean>
 
     <bean id="metaHistoryDAO" class="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDAO">
-        <property name="sqlMapClient" ref="sqlMapClient"/>
+        <property name="sqlSessionFactory" ref="sqlSessionFactory"/>
     </bean>
 
     <bean id="metaSnapshotDAO" class="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDAO">
-        <property name="sqlMapClient" ref="sqlMapClient"/>
+        <property name="sqlSessionFactory" ref="sqlSessionFactory"/>
+<!--        <property name="sqlMapClient" ref="sqlMapClient"/>-->
     </bean>
 </beans>

--- a/parse/src/test/resources/tsdb/mysql-tsdb.xml
+++ b/parse/src/test/resources/tsdb/mysql-tsdb.xml
@@ -3,7 +3,7 @@
        xmlns="http://www.springframework.org/schema/beans" xmlns:tx="http://www.springframework.org/schema/tx"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 	http://www.springframework.org/schema/tx
-    http://www.springframework.org/schema/tx/spring-tx-2.0.xsd"
+    http://www.springframework.org/schema/tx/spring-tx.xsd"
        default-autowire="byName">
 	
 	<!-- 基于db的实现 -->
@@ -32,16 +32,16 @@
         <property name="useUnfairLock" value="true" />
 	</bean>
 
-    <bean id="sqlMapClient" class="org.springframework.orm.ibatis.SqlMapClientFactoryBean">
+    <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
         <property name="dataSource" ref="dataSource"/>
         <property name="configLocation" value="classpath:tsdb/sql-map/sqlmap-config.xml"/>
     </bean>
 
     <bean id="metaHistoryDAO" class="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDAO">
-        <property name="sqlMapClient" ref="sqlMapClient"/>
+        <property name="sqlSessionFactory" ref="sqlSessionFactory"/>
     </bean>
 
     <bean id="metaSnapshotDAO" class="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDAO">
-        <property name="sqlMapClient" ref="sqlMapClient"/>
+        <property name="sqlSessionFactory" ref="sqlSessionFactory"/>
     </bean>
 </beans>

--- a/parse/src/test/resources/tsdb/sql-map/sqlmap-config.xml
+++ b/parse/src/test/resources/tsdb/sql-map/sqlmap-config.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE sqlMapConfig PUBLIC "-//iBATIS.com//DTD SQL Map Config 2.0//EN"
-        "http://www.ibatis.com/dtd/sql-map-config-2.dtd">
-<sqlMapConfig>
-    <settings useStatementNamespaces="true"/>
-    <sqlMap resource="tsdb/sql-map/sqlmap_history.xml"/>
-    <sqlMap resource="tsdb/sql-map/sqlmap_snapshot.xml"/>
-</sqlMapConfig>
+<!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN" "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+    <mappers>
+        <mapper resource="tsdb/sql-map/sqlmap_history.xml"/>
+        <mapper resource="tsdb/sql-map/sqlmap_snapshot.xml"/>
+    </mappers>
+</configuration>

--- a/parse/src/test/resources/tsdb/sql-map/sqlmap_history.xml
+++ b/parse/src/test/resources/tsdb/sql-map/sqlmap_history.xml
@@ -1,45 +1,68 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE sqlMap PUBLIC "-//ibatis.apache.org//DTD SQL Map 2.0//EN" "http://ibatis.apache.org/dtd/sql-map-2.dtd" >
-<sqlMap namespace="meta_history">
-    <typeAlias alias="metaHistoryDO" type="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDO"/>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="meta_history">
+    <resultMap id="metaHistoryDO" type="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDO"/>
     <sql id="allColumns">
         <![CDATA[
-		gmt_create,gmt_modified,destination,binlog_file,binlog_offest,binlog_master_id,binlog_timestamp,use_schema,sql_schema,sql_table,sql_text,sql_type,extra
+		gmt_create,
+		gmt_modified,
+		destination,
+		binlog_file,
+		binlog_offest,
+		binlog_master_id,
+		binlog_timestamp,
+		use_schema,
+		sql_schema,
+		sql_table,
+		sql_text,
+		sql_type,
+		extra
         ]]>
     </sql>
     <sql id="allVOColumns">
         <![CDATA[
-		a.id as id,a.gmt_create as gmtCreate,a.gmt_modified as gmtModified,
-		a.destination as destination,a.binlog_file as binlogFile,a.binlog_offest as binlogOffest,a.binlog_master_id as binlogMasterId,a.binlog_timestamp as binlogTimestamp,
-		a.use_schema as useSchema,a.sql_schema as sqlSchema,a.sql_table as sqlTable,a.sql_text as sqlText,a.sql_type as sqlType,a.extra as extra
+		a.id as id,
+		a.gmt_create as gmtCreate,
+		a.gmt_modified as gmtModified,
+		a.destination as destination,
+		a.binlog_file as binlogFile,
+		a.binlog_offest as binlogOffest,
+		a.binlog_master_id as binlogMasterId,
+		a.binlog_timestamp as binlogTimestamp,
+		a.use_schema as useSchema,
+		a.sql_schema as sqlSchema,
+		a.sql_table as sqlTable,
+		a.sql_text as sqlText,
+		a.sql_type as sqlType,
+		a.extra as extra
         ]]>
     </sql>
 
-    <select id="findByTimestamp" parameterClass="java.util.Map" resultClass="metaHistoryDO">
+    <select id="findByTimestamp" parameterType="java.util.Map" resultType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDO">
         select
         <include refid="allVOColumns"/>
         from meta_history a
         <![CDATA[
-        where destination = #destination# and binlog_timestamp >= #snapshotTimestamp# and binlog_timestamp <= #timestamp#
+        where destination = #{destination} and binlog_timestamp >= #{snapshotTimestamp} and binlog_timestamp <= #{timestamp}
         order by binlog_timestamp asc,id asc
         ]]>
     </select>
 
-    <insert id="insert" parameterClass="metaHistoryDO">
+    <insert id="insert" parameterType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaHistoryDO">
         insert into meta_history (<include refid="allColumns"/>)
-        values(CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,#destination#,#binlogFile#,#binlogOffest#,#binlogMasterId#,#binlogTimestamp#,#useSchema#,#sqlSchema#,#sqlTable#,#sqlText#,#sqlType#,#extra#)
+        values(CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,#{destination},#{binlogFile},#{binlogOffest},#{binlogMasterId},#{binlogTimestamp},#{useSchema},#{sqlSchema},#{sqlTable},#{sqlText},#{sqlType},#{extra})
     </insert>
     
-    <delete id="deleteByName" parameterClass="java.util.Map">
+    <delete id="deleteByName" parameterType="java.util.Map">
         delete from meta_history 
-        where destination=#destination#
+        where destination=#{destination}
     </delete>
 
 
-    <delete id="deleteByTimestamp" parameterClass="java.util.Map">
+    <delete id="deleteByTimestamp" parameterType="java.util.Map">
         <![CDATA[
 		delete from meta_history
-		where destination=#destination# and binlog_timestamp < #timestamp#
+		where destination=#{destination} and binlog_timestamp < #{timestamp}
         ]]>
     </delete>
-</sqlMap>
+</mapper>

--- a/parse/src/test/resources/tsdb/sql-map/sqlmap_snapshot.xml
+++ b/parse/src/test/resources/tsdb/sql-map/sqlmap_snapshot.xml
@@ -1,63 +1,78 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE sqlMap PUBLIC "-//ibatis.apache.org//DTD SQL Map 2.0//EN" "http://ibatis.apache.org/dtd/sql-map-2.dtd" >
-<sqlMap namespace="meta_snapshot">
-    <typeAlias alias="metaSnapshotDO" type="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO"/>
-    <typeAlias alias="tableMetaSnapshotDO"
-               type="com.alibaba.middleware.jingwei.biz.dataobject.CanalTableMetaSnapshotDO"/>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="meta_snapshot">
+    <resultMap id="metaSnapshotDO" type="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO"/>
+<!--    <resultMap id="tableMetaSnapshotDO" type="com.alibaba.middleware.jingwei.biz.dataobject.CanalTableMetaSnapshotDO"/>-->
     <sql id="allColumns">
         <![CDATA[
-		gmt_create,gmt_modified,destination,binlog_file,binlog_offest,binlog_master_id,binlog_timestamp,data,extra
+		gmt_create,
+		gmt_modified,
+		destination,
+		binlog_file,
+		binlog_offest,
+		binlog_master_id,
+		binlog_timestamp,
+		data,
+		extra
         ]]>
     </sql>
     <sql id="allVOColumns">
         <![CDATA[
-		a.id as id,a.gmt_create as gmtCreate,a.gmt_modified as gmtModified,
-		a.destination as destination,a.binlog_file as binlogFile,a.binlog_offest as binlogOffest,a.binlog_master_id as binlogMasterId,a.binlog_timestamp as binlogTimestamp,a.data as data,a.extra as extra
+		a.id as id,
+		a.gmt_create as gmtCreate,
+		a.gmt_modified as gmtModified,
+		a.destination as destination,
+		a.binlog_file as binlogFile,
+		a.binlog_offest as binlogOffest,
+		a.binlog_master_id as binlogMasterId,
+		a.binlog_timestamp as binlogTimestamp,
+		a.data as data,
+		a.extra as extra
         ]]>
     </sql>
 
-    <select id="findByTimestamp" parameterClass="java.util.Map" resultClass="metaSnapshotDO">
+    <select id="findByTimestamp" parameterType="java.util.Map" resultType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO">
     	select <include refid="allVOColumns"/>
     	<![CDATA[
         from meta_snapshot a
-        where destination = #destination# and binlog_timestamp < #timestamp#
+        where destination = #{destination} and binlog_timestamp < #{timestamp}
         order by binlog_timestamp desc,id desc
         limit 1
         ]]>
     </select>
     
-     <select id="findByTimestampOnDerby" parameterClass="java.util.Map" resultClass="metaSnapshotDO">
+     <select id="findByTimestampOnDerby" parameterType="java.util.Map" resultType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO">
    		select * FROM ( 
    		select ROW_NUMBER() OVER() AS rownum, <include refid="allVOColumns"/>
    		<![CDATA[ 
    		from meta_snapshot a
-   		where destination = #destination# and binlog_timestamp < #timestamp#
+   		where destination = #{destination} and binlog_timestamp < #{timestamp}
         order by binlog_timestamp desc,id desc
 		) AS tmp 
 		WHERE rownum <= 5
 		]]>
     </select>
 
-    <insert id="insert" parameterClass="metaSnapshotDO">
+    <insert id="insert" parameterType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO">
         insert into meta_snapshot (<include refid="allColumns"/>)
-        values(CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,#destination#,#binlogFile#,#binlogOffest#,#binlogMasterId#,#binlogTimestamp#,#data#,#extra#)
+        values(CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,#{destination},#{binlogFile},#{binlogOffest},#{binlogMasterId},#{binlogTimestamp},#{data},#{extra})
     </insert>
 
-    <update id="update" parameterClass="metaSnapshotDO">
+    <update id="update" parameterType="com.alibaba.otter.canal.parse.inbound.mysql.tsdb.dao.MetaSnapshotDO">
         update meta_snapshot set gmt_modified=now(),
-        binlog_file=#binlogFile#,binlog_offest=#binlogOffest#,binlog_master_id=#binlogMasterId#,binlog_timestamp=#binlogTimestamp#,data=#data#,extra=#extra#
-        where destination=#destination# and binlog_timestamp=0
+        binlog_file=#{binlogFile},binlog_offest=#{binlogOffest},binlog_master_id=#{binlogMasterId},binlog_timestamp=#{binlogTimestamp},data=#{data},extra=#{extra}
+        where destination=#{destination} and binlog_timestamp=0
     </update>
 
- 	<delete id="deleteByName" parameterClass="java.util.Map">
+ 	<delete id="deleteByName" parameterType="java.util.Map">
         delete from meta_snapshot 
-        where destination=#destination#
+        where destination=#{destination}
     </delete>
 
-    <delete id="deleteByTimestamp" parameterClass="java.util.Map">
+    <delete id="deleteByTimestamp" parameterType="java.util.Map">
         <![CDATA[
 		delete from meta_snapshot
-		where destination=#destination# and binlog_timestamp < #timestamp# and binlog_timestamp > 0
+		where destination=#{destination} and binlog_timestamp < #{timestamp} and binlog_timestamp > 0
         ]]>
     </delete>
-</sqlMap>
+</mapper>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <java_source_version>1.8</java_source_version>
         <java_target_version>1.8</java_target_version>
         <file_encoding>UTF-8</file_encoding>
-        <spring_version>3.2.18.RELEASE</spring_version>
+        <spring_version>5.0.8.RELEASE</spring_version>
         <maven-jacoco-plugin.version>0.8.3</maven-jacoco-plugin.version>
         <maven-surefire.version>2.22.1</maven-surefire.version>
         <argline>-server -Xms512m -Xmx1024m -Dfile.encoding=UTF-8
@@ -289,6 +289,16 @@
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>1.4.196</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mybatis</groupId>
+                <artifactId>mybatis</artifactId>
+                <version>3.5.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mybatis</groupId>
+                <artifactId>mybatis-spring</artifactId>
+                <version>2.0.1</version>
             </dependency>
             <!-- test dependency -->
             <dependency>


### PR DESCRIPTION
+ 升级Spring 3.2.18.RELEASE -> 5.0.8.RELEASE
+ parse Module中的`tsdb`操作  
  去除老版本 **spring-orm** `org.springframework.orm.ibatis.support.SqlMapClientDaoSupport` 
  使用 **mybatis-spring** `org.mybatis.spring.support.SqlSessionDaoSupport`