### PR TITLE
Set a specific validationQuery while testWhileIdle is true in h2-tsdb.xml

### DIFF
--- a/deployer/src/main/resources/spring/tsdb/h2-tsdb.xml
+++ b/deployer/src/main/resources/spring/tsdb/h2-tsdb.xml
@@ -43,6 +43,7 @@
         <property name="testOnBorrow" value="false" />
         <property name="testOnReturn" value="false" />
         <property name="useUnfairLock" value="true" />
+        <property name="validationQuery" value="SELECT 1" />
 	</bean>
 
     <bean id="sqlMapClient" class="org.springframework.orm.ibatis.SqlMapClientFactoryBean">


### PR DESCRIPTION
hi，在用默认的`h2-tsdb.xml`做tsdb meta info的配置文件时会有如下的错误日志产生
```
ERROR com.alibaba.druid.pool.DruidDataSource - testWhileIdle is true, validationQuery not set
```
我添加了`<property name="validationQuery" value="SELECT 1" />`来避免这个问题