### PR TITLE
kafka发送相同key 删除操作和其他操作分区不一致

### DIFF
--- a/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
+++ b/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
@@ -230,10 +230,25 @@ public class MQMessageUtils {
                                     }
                                 }
                             } else {
-                                for (CanalEntry.Column column : rowData.getAfterColumnsList()) {
-                                    if (checkPkNamesHasContain(hashMode.pkNames, column.getName())) {
-                                        hashCode = hashCode ^ column.getValue().hashCode();
+                                try {
+                                    CanalEntry.EventType eventType = RowChange.parseFrom(entry.getStoreValue()).getEventType();
+                                    if(eventType == CanalEntry.EventType.DELETE){
+                                        for (CanalEntry.Column column : rowData.getBeforeColumnsList()) {
+                                            if (checkPkNamesHasContain(hashMode.pkNames, column.getName())) {
+                                                hashCode = hashCode ^ column.getValue().hashCode();
+                                            }
+                                        }
                                     }
+                                    else {
+                                        for (CanalEntry.Column column : rowData.getAfterColumnsList()) {
+                                            if (checkPkNamesHasContain(hashMode.pkNames, column.getName())) {
+                                                hashCode = hashCode ^ column.getValue().hashCode();
+                                            }
+                                        }
+                                    }
+                                }
+                                catch (InvalidProtocolBufferException e) {
+                                    e.printStackTrace();
                                 }
                             }
 


### PR DESCRIPTION
删除操作计算hash值的情况没有考虑，导致删除时的分区和插入更新时的分区不一致