### PR TITLE
fastjson1.2.28有安全问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>fastjson</artifactId>
-                <version>1.2.28</version>
+                <version>1.2.58</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
更新方法
https://github.com/alibaba/fastjson/wiki/update_faq_20190722
如果1.2.58遇到兼容问题可改为1.2.29.sec04版本
![image](https://user-images.githubusercontent.com/42863611/61425523-c8517880-a949-11e9-8ab1-a053b261cf8f.png)
