### PR TITLE
fix: hbase etl sql syntax error in some case

### DIFF
--- a/client-adapter/hbase/src/main/java/com/alibaba/otter/canal/client/adapter/hbase/service/HbaseEtlService.java
+++ b/client-adapter/hbase/src/main/java/com/alibaba/otter/canal/client/adapter/hbase/service/HbaseEtlService.java
@@ -79,7 +79,7 @@ public class HbaseEtlService extends AbstractEtlService {
             createTable();
 
             // 拼接sql
-            String sql = "SELECT * FROM " + config.getHbaseMapping().getDatabase() + "." + hbaseMapping.getTable();
+            String sql = "SELECT * FROM `" + config.getHbaseMapping().getDatabase() + "`.`" + hbaseMapping.getTable() + "`";
 
             return super.importData(sql, params);
         } catch (Exception e) {


### PR DESCRIPTION
select * from a-b.tableName;  // SQL syntax error

select * from `a-b`.`tableName`;  // fix above error