### PR TITLE
always check whether ringbuffer has an exception in event processor

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/MysqlMultiStageCoprocessor.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/MysqlMultiStageCoprocessor.java
@@ -190,17 +190,17 @@ public class MysqlMultiStageCoprocessor extends AbstractCanalLifeCycle implement
             return false;
         }
 
-        /**
-         * 由于改为processor仅终止自身stage而不是stop，那么需要由incident标识coprocessor是否正常工作。
-         * 让dump线程能够及时感知
-         */
-        if (exception != null) {
-            throw exception;
-        }
         boolean interupted = false;
         long blockingStart = 0L;
         int fullTimes = 0;
         do {
+            /**
+             * 由于改为processor仅终止自身stage而不是stop，那么需要由incident标识coprocessor是否正常工作。
+             * 让dump线程能够及时感知
+             */
+            if (exception != null) {
+                throw exception;
+            }
             try {
                 long next = disruptorMsgBuffer.tryNext();
                 MessageEvent data = disruptorMsgBuffer.get(next);


### PR DESCRIPTION
when mysql connection dump binlog and try to publish an event to RingBuffer, there is an situtation that RingBuffer is already full and SimpleParseStage or DmlParseStage has an exception after that, then the dump thread will block in publish because in the publish loop doesn't check the exception again. The SimplePareStage may has a retryable exception, but can't retry due to connection thread blocked in RingBuffer.