### PR TITLE
查询数据过长变成byte数组转化为json解决

### DIFF
--- a/client-adapter/elasticsearch/src/main/java/com/alibaba/otter/canal/client/adapter/es/support/ESSyncUtil.java
+++ b/client-adapter/elasticsearch/src/main/java/com/alibaba/otter/canal/client/adapter/es/support/ESSyncUtil.java
@@ -44,7 +44,10 @@ public class ESSyncUtil {
             String[] values = val.toString().split(separator);
             return Arrays.asList(values);
         } else if (fieldInfo.startsWith("object")) {
-            return JSON.parse(val.toString());
+            if (val instanceof String){
+                return JSON.parse(val.toString());
+            }
+            return JSON.parse(new String((byte[])val));
         }
         return null;
     }


### PR DESCRIPTION
Caused by: com.alibaba.fastjson.JSONException: syntax error, pos 2, json : [B@406b7f2 #2089