### PR TITLE
Fix issue #795 Canal has compatibility issues with guava 20, guava 18 MapMaker.makeComputingMap method is obsolete

### DIFF
--- a/common/src/main/java/com/google/common/collect/MigrateMap.java
+++ b/common/src/main/java/com/google/common/collect/MigrateMap.java
@@ -1,19 +1,133 @@
 package com.google.common.collect;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 
 import com.google.common.base.Function;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 
 public class MigrateMap {
 
-    @SuppressWarnings("deprecation")
-    public static <K, V> ConcurrentMap<K, V> makeComputingMap(MapMaker maker,
+    public static <K, V> ConcurrentMap<K, V> makeComputingMap(CacheBuilder<Object, Object> builder,
                                                               Function<? super K, ? extends V> computingFunction) {
-        return maker.makeComputingMap(computingFunction);
+        final Function<? super K, ? extends V> function = computingFunction;
+        LoadingCache<K, V> computingCache = builder.build(new CacheLoader<K, V>() {
+            @Override
+            public V load(K key) throws Exception {
+                return function.apply(key);
+            }
+        });
+
+        return new MigrateConcurrentMap<K, V>(computingCache);
     }
 
-    @SuppressWarnings("deprecation")
     public static <K, V> ConcurrentMap<K, V> makeComputingMap(Function<? super K, ? extends V> computingFunction) {
-        return new MapMaker().makeComputingMap(computingFunction);
+        return makeComputingMap(CacheBuilder.newBuilder(), computingFunction);
+    }
+
+    final static class MigrateConcurrentMap<K, V> implements ConcurrentMap<K, V> {
+
+        private final LoadingCache<K, V> computingCache;
+
+        private final ConcurrentMap<K, V> cacheView;
+
+        MigrateConcurrentMap(LoadingCache<K, V> computingCache) {
+            this.computingCache = computingCache;
+            this.cacheView = computingCache.asMap();
+        }
+
+        @Override
+        public int size() {
+            return cacheView.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return cacheView.isEmpty();
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return cacheView.containsKey(key);
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+            return cacheView.containsValue(value);
+        }
+
+        @Override
+        public V get(Object key) {
+            try {
+                return computingCache.get((K) key);
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public V put(K key, V value) {
+            return cacheView.put(key, value);
+        }
+
+        @Override
+        public V remove(Object key) {
+            return cacheView.remove(key);
+        }
+
+        @Override
+        public void putAll(Map<? extends K, ? extends V> m) {
+            cacheView.putAll(m);
+        }
+
+        @Override
+        public void clear() {
+            cacheView.clear();
+        }
+
+        @Override
+        public Set<K> keySet() {
+            return cacheView.keySet();
+        }
+
+        @Override
+        public Collection<V> values() {
+            return cacheView.values();
+        }
+
+        @Override
+        public Set<Entry<K, V>> entrySet() {
+            return cacheView.entrySet();
+        }
+
+        @Override
+        public V putIfAbsent(K key, V value) {
+            return cacheView.putIfAbsent(key, value);
+        }
+
+        @Override
+        public boolean remove(Object key, Object value) {
+            return cacheView.remove(key, value);
+        }
+
+        @Override
+        public boolean replace(K key, V oldValue, V newValue) {
+            return cacheView.replace(key, oldValue, newValue);
+        }
+
+        @Override
+        public V replace(K key, V value) {
+            return cacheView.replace(key, value);
+        }
+
+        @Override
+        public String toString() {
+            return cacheView.toString();
+        }
     }
 }

--- a/filter/src/main/java/com/alibaba/otter/canal/filter/PatternUtils.java
+++ b/filter/src/main/java/com/alibaba/otter/canal/filter/PatternUtils.java
@@ -8,13 +8,13 @@ import org.apache.oro.text.regex.PatternCompiler;
 import org.apache.oro.text.regex.Perl5Compiler;
 
 import com.google.common.base.Function;
-import com.google.common.collect.MapMaker;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.MigrateMap;
 
 public class PatternUtils {
 
     @SuppressWarnings("deprecation")
-    private static Map<String, Pattern> patterns = MigrateMap.makeComputingMap(new MapMaker().softValues(),
+    private static Map<String, Pattern> patterns = MigrateMap.makeComputingMap(CacheBuilder.newBuilder().softValues(),
                                                      new Function<String, Pattern>() {
 
                                                          public Pattern apply(String pattern) {

--- a/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
+++ b/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
@@ -18,7 +18,7 @@ import com.alibaba.otter.canal.protocol.FlatMessage;
 import com.alibaba.otter.canal.protocol.Message;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
-import com.google.common.collect.MapMaker;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.MigrateMap;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -31,7 +31,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 public class MQMessageUtils {
 
     @SuppressWarnings("deprecation")
-    private static Map<String, List<PartitionData>>    partitionDatas    = MigrateMap.makeComputingMap(new MapMaker().softValues(),
+    private static Map<String, List<PartitionData>>    partitionDatas    = MigrateMap.makeComputingMap(CacheBuilder.newBuilder().softValues(),
                                                                              new Function<String, List<PartitionData>>() {
 
                                                                                  public List<PartitionData> apply(String pkHashConfigs) {
@@ -73,7 +73,7 @@ public class MQMessageUtils {
                                                                              });
 
     @SuppressWarnings("deprecation")
-    private static Map<String, List<DynamicTopicData>> dynamicTopicDatas = MigrateMap.makeComputingMap(new MapMaker().softValues(),
+    private static Map<String, List<DynamicTopicData>> dynamicTopicDatas = MigrateMap.makeComputingMap(CacheBuilder.newBuilder().softValues(),
                                                                              new Function<String, List<DynamicTopicData>>() {
 
                                                                                  public List<DynamicTopicData> apply(String pkHashConfigs) {


### PR DESCRIPTION
MigrateMap使用的MapMaker#makeComputingMap和MapMaker#softValues方法在guava20后的版本被删除，嵌入式方式使用Canal会和高版本Guava API冲突，用guava推荐的CacheBuilder替代