### PR TITLE
bugfix mysql >= 8.0,  缓存层移除，EbeanServer 运行 Fail，Unknown system variable 'query_cache_size'

### DIFF
--- a/canal-admin/pom.xml
+++ b/canal-admin/pom.xml
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.40</version>
+                <version>8.0.17</version>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
bugfix mysql >= 8.0,  缓存层移除，EbeanServer 运行 Fail，Unknown system variable  query_cache_size error！

threw exception; nested exception is javax.persistence.PersistenceException: java.sql.SQLException: Unknown system variable 'query_cache_size'