### PR TITLE
make canal.admin.port canal.admin.user canal.admin.passwd can be override by system env properties

### DIFF
--- a/canal-admin/canal-admin-server/src/main/java/com/alibaba/otter/canal/admin/connector/SimpleAdminConnectors.java
+++ b/canal-admin/canal-admin-server/src/main/java/com/alibaba/otter/canal/admin/connector/SimpleAdminConnectors.java
@@ -25,6 +25,7 @@ public class SimpleAdminConnectors {
             connector.connect();
             return function.apply(connector);
         } catch (Exception e) {
+            logger.error("connect to ip:{},port:{},user:{},password:{}, failed", ip, port, user,passwd);
             logger.error(e.getMessage());
         } finally {
             connector.disconnect();

--- a/deployer/src/main/java/com/alibaba/otter/canal/deployer/CanalStarter.java
+++ b/deployer/src/main/java/com/alibaba/otter/canal/deployer/CanalStarter.java
@@ -106,15 +106,18 @@ public class CanalStarter {
         }
 
         // start canalAdmin
-        String port = properties.getProperty(CanalConstants.CANAL_ADMIN_PORT);
+        String port = CanalController.getProperty(properties, CanalConstants.CANAL_ADMIN_PORT);
         if (canalAdmin == null && StringUtils.isNotEmpty(port)) {
-            String user = properties.getProperty(CanalConstants.CANAL_ADMIN_USER);
-            String passwd = properties.getProperty(CanalConstants.CANAL_ADMIN_PASSWD);
+            String user = CanalController.getProperty(properties, CanalConstants.CANAL_ADMIN_USER);
+            String passwd = CanalController.getProperty(properties, CanalConstants.CANAL_ADMIN_PASSWD);
             CanalAdminController canalAdmin = new CanalAdminController(this);
             canalAdmin.setUser(user);
             canalAdmin.setPasswd(passwd);
 
-            String ip = properties.getProperty(CanalConstants.CANAL_IP);
+            String ip = CanalController.getProperty(properties, CanalConstants.CANAL_IP);
+
+            logger.debug("canal admin port:{}, canal admin user:{}, canal admin password: {}, canal ip:{}", port, user, passwd, ip);
+
             CanalAdminWithNetty canalAdminWithNetty = CanalAdminWithNetty.instance();
             canalAdminWithNetty.setCanalAdmin(canalAdmin);
             canalAdminWithNetty.setPort(Integer.valueOf(port));


### PR DESCRIPTION
Because the CanalStarter did not use CanalController.getProperty when setting up CanalAdminWithNetty so the canal.admin.port, canal.admin.user, canal.admin.passwd can't be override from the system env properties。 As a result when I deploy use docker and if I want a different port， I have to build more then one image with different canal_local.properties.