### PR TITLE
fix_json_type_opaque_parse_err

### DIFF
--- a/dbsync/src/main/java/com/taobao/tddl/dbsync/binlog/JsonConversion.java
+++ b/dbsync/src/main/java/com/taobao/tddl/dbsync/binlog/JsonConversion.java
@@ -167,7 +167,7 @@ public class JsonConversion {
                 int type_byte = buffer.getUint8();
                 int position = buffer.position();
                 // Then there's the length of the value.
-                int q_max_bytes = (int) Math.min(len, 5);
+                int q_max_bytes = (int) Math.min(len - 1, 5);
                 long q_tlen = 0;
                 long q_str_len = 0;
                 long q_n = 0;


### PR DESCRIPTION
对于`JSONB_TYPE_OPAQUE`类型的解析计算`q_max_bytes`时，多算了`1`字节，在特定情况下（json的value为OPAQUE且为 `1字节type + 1字节len + 小于等于4字节数据`），解析失败