### PR TITLE
添加目标表不区分大小写的支持，并可开关（默认为区分大小写）

### DIFF
--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/MappingConfig.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/MappingConfig.java
@@ -92,21 +92,21 @@ public class MappingConfig implements AdapterConfig {
 
     public static class DbMapping implements AdapterMapping {
 
-        private boolean             mirrorDb    = false;                 // 是否镜像库
-        private String              database;                            // 数据库名或schema名
-        private String              table;                               // 表名
-        private Map<String, String> targetPk    = new LinkedHashMap<>(); // 目标表主键字段
-        private boolean             mapAll      = false;                 // 映射所有字段
-        private String              targetDb;                            // 目标库名
-        private String              targetTable;                         // 目标表名
-        private Map<String, String> targetColumns;                       // 目标表字段映射
+        private boolean             mirrorDb        = false;                 // 是否镜像库
+        private String              database;                                // 数据库名或schema名
+        private String              table;                                   // 表名
+        private Map<String, String> targetPk        = new LinkedHashMap<>(); // 目标表主键字段
+        private boolean             mapAll          = false;                 // 映射所有字段
+        private String              targetDb;                                // 目标库名
+        private String              targetTable;                             // 目标表名
+        private Map<String, String> targetColumns;                           // 目标表字段映射
 
-        private boolean caseInsensitive = false;             //目标表不区分大小写，默认是否
+        private boolean             caseInsensitive = false;                 // 目标表不区分大小写，默认是否
 
-        private String              etlCondition;                        // etl条件sql
+        private String              etlCondition;                            // etl条件sql
 
-        private int                 readBatch   = 5000;
-        private int                 commitBatch = 5000;                  // etl等批量提交大小
+        private int                 readBatch       = 5000;
+        private int                 commitBatch     = 5000;                  // etl等批量提交大小
 
         private Map<String, String> allMapColumns;
 

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/MappingConfig.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/MappingConfig.java
@@ -101,6 +101,8 @@ public class MappingConfig implements AdapterConfig {
         private String              targetTable;                         // 目标表名
         private Map<String, String> targetColumns;                       // 目标表字段映射
 
+        private boolean caseInsensitive = false;             //目标表不区分大小写，默认是否
+
         private String              etlCondition;                        // etl条件sql
 
         private int                 readBatch   = 5000;
@@ -177,6 +179,14 @@ public class MappingConfig implements AdapterConfig {
 
         public void setTargetColumns(Map<String, String> targetColumns) {
             this.targetColumns = targetColumns;
+        }
+
+        public boolean isCaseInsensitive() {
+            return caseInsensitive;
+        }
+
+        public void setCaseInsensitive(boolean caseInsensitive) {
+            this.caseInsensitive = caseInsensitive;
         }
 
         public String getEtlCondition() {

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbMirrorDbSyncService.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbMirrorDbSyncService.java
@@ -91,10 +91,10 @@ public class RdbMirrorDbSyncService {
                 if (config == null) {
                     return false;
                 }
-                //是否区分大小写
+                // 是否区分大小写
                 boolean caseInsensitive = config.getDbMapping().isCaseInsensitive();
                 if (config.getConcurrent()) {
-                    List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml,caseInsensitive);
+                    List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml, caseInsensitive);
                     singleDmls.forEach(singleDml -> {
                         int hash = rdbSyncService.pkHash(config.getDbMapping(), singleDml.getData());
                         RdbSyncService.SyncItem syncItem = new RdbSyncService.SyncItem(config, singleDml);
@@ -102,7 +102,7 @@ public class RdbMirrorDbSyncService {
                     });
                 } else {
                     int hash = 0;
-                    List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml,caseInsensitive);
+                    List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml, caseInsensitive);
                     singleDmls.forEach(singleDml -> {
                         RdbSyncService.SyncItem syncItem = new RdbSyncService.SyncItem(config, singleDml);
                         rdbSyncService.getDmlsPartition()[hash].add(syncItem);

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbMirrorDbSyncService.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbMirrorDbSyncService.java
@@ -91,9 +91,10 @@ public class RdbMirrorDbSyncService {
                 if (config == null) {
                     return false;
                 }
-
+                //是否区分大小写
+                boolean caseInsensitive = config.getDbMapping().isCaseInsensitive();
                 if (config.getConcurrent()) {
-                    List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml);
+                    List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml,caseInsensitive);
                     singleDmls.forEach(singleDml -> {
                         int hash = rdbSyncService.pkHash(config.getDbMapping(), singleDml.getData());
                         RdbSyncService.SyncItem syncItem = new RdbSyncService.SyncItem(config, singleDml);
@@ -101,7 +102,7 @@ public class RdbMirrorDbSyncService {
                     });
                 } else {
                     int hash = 0;
-                    List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml);
+                    List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml,caseInsensitive);
                     singleDmls.forEach(singleDml -> {
                         RdbSyncService.SyncItem syncItem = new RdbSyncService.SyncItem(config, singleDml);
                         rdbSyncService.getDmlsPartition()[hash].add(syncItem);

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbSyncService.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbSyncService.java
@@ -112,9 +112,8 @@ public class RdbSyncService {
 
                     futures.add(executorThreads[i].submit(() -> {
                         try {
-                            dmlsPartition[j].forEach(syncItem -> sync(batchExecutors[j],
-                                    syncItem.config,
-                                    syncItem.singleDml));
+                            dmlsPartition[j]
+                                .forEach(syncItem -> sync(batchExecutors[j], syncItem.config, syncItem.singleDml));
                             dmlsPartition[j].clear();
                             batchExecutors[j].commit();
                             return true;
@@ -178,7 +177,7 @@ public class RdbSyncService {
                 for (MappingConfig config : configMap.values()) {
                     boolean caseInsensitive = config.getDbMapping().isCaseInsensitive();
                     if (config.getConcurrent()) {
-                        List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml,caseInsensitive);
+                        List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml, caseInsensitive);
                         singleDmls.forEach(singleDml -> {
                             int hash = pkHash(config.getDbMapping(), singleDml.getData());
                             SyncItem syncItem = new SyncItem(config, singleDml);
@@ -186,7 +185,7 @@ public class RdbSyncService {
                         });
                     } else {
                         int hash = 0;
-                        List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml,caseInsensitive);
+                        List<SingleDml> singleDmls = SingleDml.dml2SingleDmls(dml, caseInsensitive);
                         singleDmls.forEach(singleDml -> {
                             SyncItem syncItem = new SyncItem(config, singleDml);
                             dmlsPartition[hash].add(syncItem);
@@ -195,7 +194,7 @@ public class RdbSyncService {
                 }
                 return true;
             }
-        }   );
+        });
     }
 
     /**
@@ -278,7 +277,7 @@ public class RdbSyncService {
             batchExecutor.execute(insertSql.toString(), values);
         } catch (SQLException e) {
             if (skipDupException
-                    && (e.getMessage().contains("Duplicate entry") || e.getMessage().startsWith("ORA-00001:"))) {
+                && (e.getMessage().contains("Duplicate entry") || e.getMessage().startsWith("ORA-00001:"))) {
                 // ignore
                 // TODO 增加更多关系数据库的主键冲突的错误码
             } else {

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SingleDml.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SingleDml.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.alibaba.otter.canal.client.adapter.support.Dml;
+import org.springframework.util.LinkedCaseInsensitiveMap;
 
 public class SingleDml {
 
@@ -63,7 +64,7 @@ public class SingleDml {
         this.old = old;
     }
 
-    public static List<SingleDml> dml2SingleDmls(Dml dml) {
+    public static List<SingleDml> dml2SingleDmls(Dml dml, boolean caseInsensitive) {
         List<SingleDml> singleDmls = new ArrayList<>();
         if (dml.getData() != null) {
             int size = dml.getData().size();
@@ -73,9 +74,17 @@ public class SingleDml {
                 singleDml.setDatabase(dml.getDatabase());
                 singleDml.setTable(dml.getTable());
                 singleDml.setType(dml.getType());
-                singleDml.setData(dml.getData().get(i));
+                Map<String,Object> data = dml.getData().get(i);
+                if(caseInsensitive){
+                    data = toCaseInsensitiveMap(data);
+                }
+                singleDml.setData(data);
                 if (dml.getOld() != null) {
-                    singleDml.setOld(dml.getOld().get(i));
+                    Map<String,Object> oldData = dml.getOld().get(i);
+                    if(caseInsensitive){
+                        oldData = toCaseInsensitiveMap(oldData);
+                    }
+                    singleDml.setOld(oldData);
                 }
                 singleDmls.add(singleDml);
             }
@@ -88,5 +97,15 @@ public class SingleDml {
             singleDmls.add(singleDml);
         }
         return singleDmls;
+    }
+
+    public static List<SingleDml> dml2SingleDmls(Dml dml) {
+        return dml2SingleDmls(dml,false);
+    }
+
+    private static <V> LinkedCaseInsensitiveMap<V> toCaseInsensitiveMap(Map<String,V> data) {
+        LinkedCaseInsensitiveMap map = new LinkedCaseInsensitiveMap();
+        map.putAll(data);
+        return map;
     }
 }

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SingleDml.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SingleDml.java
@@ -74,14 +74,14 @@ public class SingleDml {
                 singleDml.setDatabase(dml.getDatabase());
                 singleDml.setTable(dml.getTable());
                 singleDml.setType(dml.getType());
-                Map<String,Object> data = dml.getData().get(i);
-                if(caseInsensitive){
+                Map<String, Object> data = dml.getData().get(i);
+                if (caseInsensitive) {
                     data = toCaseInsensitiveMap(data);
                 }
                 singleDml.setData(data);
                 if (dml.getOld() != null) {
-                    Map<String,Object> oldData = dml.getOld().get(i);
-                    if(caseInsensitive){
+                    Map<String, Object> oldData = dml.getOld().get(i);
+                    if (caseInsensitive) {
                         oldData = toCaseInsensitiveMap(oldData);
                     }
                     singleDml.setOld(oldData);
@@ -100,10 +100,10 @@ public class SingleDml {
     }
 
     public static List<SingleDml> dml2SingleDmls(Dml dml) {
-        return dml2SingleDmls(dml,false);
+        return dml2SingleDmls(dml, false);
     }
 
-    private static <V> LinkedCaseInsensitiveMap<V> toCaseInsensitiveMap(Map<String,V> data) {
+    private static <V> LinkedCaseInsensitiveMap<V> toCaseInsensitiveMap(Map<String, V> data) {
         LinkedCaseInsensitiveMap map = new LinkedCaseInsensitiveMap();
         map.putAll(data);
         return map;


### PR DESCRIPTION
Mqsql数据库设置为字段不区分大小写，对端为pg，也设置为不区分大小写。可是pg设置为不区分大小写，它的字段名就全部是小写的。造成了源端和对端字段类型之一，名称不一致的情况。因此添加支持字段不区分大小写的开关