### PR TITLE
支持不同topic指定专属partitionNum

### DIFF
--- a/deployer/src/main/resources/example/instance.properties
+++ b/deployer/src/main/resources/example/instance.properties
@@ -54,4 +54,5 @@ canal.mq.partition=0
 # hash partition config
 #canal.mq.partitionsNum=3
 #canal.mq.partitionHash=test.table:id^name,.*\\..*
+#canal.mq.dynamicTopicPartitionNum=test.*:4,mycanal:6
 #################################################

--- a/deployer/src/main/resources/spring/default-instance.xml
+++ b/deployer/src/main/resources/spring/default-instance.xml
@@ -200,5 +200,6 @@
 		<property name="partition" value="${canal.mq.partition}" />
 		<property name="partitionsNum" value="${canal.mq.partitionsNum}" />
 		<property name="partitionHash" value="${canal.mq.partitionHash}" />
+		<property name="dynamicTopicPartitionNum" value="${canal.mq.dynamicTopicPartitionNum}" />
 	</bean>
 </beans>

--- a/deployer/src/main/resources/spring/file-instance.xml
+++ b/deployer/src/main/resources/spring/file-instance.xml
@@ -186,5 +186,6 @@
         <property name="partition" value="${canal.mq.partition}" />
         <property name="partitionsNum" value="${canal.mq.partitionsNum}" />
         <property name="partitionHash" value="${canal.mq.partitionHash}" />
+        <property name="dynamicTopicPartitionNum" value="${canal.mq.dynamicTopicPartitionNum}" />
 	</bean>
 </beans>

--- a/deployer/src/main/resources/spring/group-instance.xml
+++ b/deployer/src/main/resources/spring/group-instance.xml
@@ -276,5 +276,6 @@
         <property name="partition" value="${canal.mq.partition}" />
         <property name="partitionsNum" value="${canal.mq.partitionsNum}" />
         <property name="partitionHash" value="${canal.mq.partitionHash}" />
+        <property name="dynamicTopicPartitionNum" value="${canal.mq.dynamicTopicPartitionNum}" />
     </bean>
 </beans>

--- a/deployer/src/main/resources/spring/memory-instance.xml
+++ b/deployer/src/main/resources/spring/memory-instance.xml
@@ -174,5 +174,6 @@
 		<property name="partition" value="${canal.mq.partition}" />
 		<property name="partitionsNum" value="${canal.mq.partitionsNum}" />
 		<property name="partitionHash" value="${canal.mq.partitionHash}" />
+		<property name="dynamicTopicPartitionNum" value="${canal.mq.dynamicTopicPartitionNum}" />
 	</bean>
 </beans>

--- a/instance/core/src/main/java/com/alibaba/otter/canal/instance/core/CanalMQConfig.java
+++ b/instance/core/src/main/java/com/alibaba/otter/canal/instance/core/CanalMQConfig.java
@@ -7,6 +7,7 @@ public class CanalMQConfig {
     private Integer partitionsNum;
     private String  partitionHash;
     private String  dynamicTopic;
+    private String  dynamicTopicPartitionNum;
 
     public String getTopic() {
         return topic;
@@ -46,5 +47,13 @@ public class CanalMQConfig {
 
     public void setDynamicTopic(String dynamicTopic) {
         this.dynamicTopic = dynamicTopic;
+    }
+
+    public String getDynamicTopicPartitionNum() {
+        return dynamicTopicPartitionNum;
+    }
+
+    public void setDynamicTopicPartitionNum(String dynamicTopicPartitionNum) {
+        this.dynamicTopicPartitionNum = dynamicTopicPartitionNum;
     }
 }

--- a/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
+++ b/server/src/main/java/com/alibaba/otter/canal/common/MQMessageUtils.java
@@ -109,6 +109,39 @@ public class MQMessageUtils {
                                                                                  }
                                                                              });
 
+    @SuppressWarnings("deprecation")
+    private static Map<String, List<TopicPartitionData>> topicPartitionDatas = MigrateMap.makeComputingMap(new MapMaker().softValues(),
+                                                                                    new Function<String, List<TopicPartitionData>>() {
+
+                                                                                        public List<TopicPartitionData> apply(String tPConfigs) {
+                                                                                            List<TopicPartitionData> datas = Lists.newArrayList();
+                                                                                            String[] tPArray = StringUtils.split(StringUtils.replace(tPConfigs,
+                                                                                                    ",",
+                                                                                                    ";"),
+                                                                                                    ";");
+                                                                                            for (String tPConfig : tPArray) {
+                                                                                                TopicPartitionData data = new TopicPartitionData();
+                                                                                                int i = tPConfig.lastIndexOf(":");
+                                                                                                if (i > 0) {
+                                                                                                    String tStr = tPConfig.substring(0, i);
+                                                                                                    String pStr = tPConfig.substring(i + 1);
+                                                                                                    if (!isWildCard(tStr)) {
+                                                                                                        data.simpleName = tStr;
+                                                                                                    } else {
+                                                                                                        data.regexFilter = new AviaterRegexFilter(tStr);
+                                                                                                    }
+                                                                                                    if (!StringUtils.isEmpty(pStr) && StringUtils.isNumeric(pStr)) {
+                                                                                                        data.partitionNum = Integer.valueOf(pStr);
+                                                                                                    }
+                                                                                                    datas.add(data);
+                                                                                                }
+                                                                                            }
+
+                                                                                            return datas;
+                                                                                        }
+                                                                                    });
+
+
     /**
      * 按 schema 或者 schema+table 将 message 分配到对应topic
      *
@@ -625,6 +658,24 @@ public class MQMessageUtils {
         return false;
     }
 
+    public static Integer parseDynamicTopicPartition(String name, String tPConfigs) {
+        if (!StringUtils.isEmpty(tPConfigs)) {
+            List<TopicPartitionData> datas = topicPartitionDatas.get(tPConfigs);
+            for (TopicPartitionData data : datas) {
+                if (data.simpleName != null) {
+                    if (data.simpleName.equalsIgnoreCase(name)) {
+                        return data.partitionNum;
+                    }
+                } else {
+                    if (data.regexFilter.filter(name)) {
+                        return data.partitionNum;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     private static boolean isWildCard(String value) {
         // not contaiins '.' ?
         return StringUtils.containsAny(value, new char[] { '*', '?', '+', '|', '(', ')', '{', '}', '[', ']', '\\', '$',
@@ -660,6 +711,13 @@ public class MQMessageUtils {
         public String             simpleName;
         public AviaterRegexFilter schemaRegexFilter;
         public AviaterRegexFilter tableRegexFilter;
+    }
+
+    public static class TopicPartitionData {
+
+        public String             simpleName;
+        public AviaterRegexFilter regexFilter;
+        public Integer            partitionNum;
     }
 
     public static class EntryRowData {

--- a/server/src/main/java/com/alibaba/otter/canal/common/MQProperties.java
+++ b/server/src/main/java/com/alibaba/otter/canal/common/MQProperties.java
@@ -59,6 +59,7 @@ public class MQProperties {
         private Integer partitionsNum;
         private String  partitionHash;
         private String  dynamicTopic;
+        private String dynamicTopicPartitionNum;
 
         public String getCanalDestination() {
             return canalDestination;
@@ -106,6 +107,14 @@ public class MQProperties {
 
         public void setDynamicTopic(String dynamicTopic) {
             this.dynamicTopic = dynamicTopic;
+        }
+
+        public String getDynamicTopicPartitionNum() {
+            return dynamicTopicPartitionNum;
+        }
+
+        public void setDynamicTopicPartitionNum(String dynamicTopicPartitionNum) {
+            this.dynamicTopicPartitionNum = dynamicTopicPartitionNum;
         }
     }
 

--- a/server/src/main/java/com/alibaba/otter/canal/kafka/CanalKafkaProducer.java
+++ b/server/src/main/java/com/alibaba/otter/canal/kafka/CanalKafkaProducer.java
@@ -164,6 +164,11 @@ public class CanalKafkaProducer extends AbstractMQProducer implements CanalMQPro
     private List<Future> send(MQProperties.CanalDestination canalDestination, String topicName, Message message,
                               boolean flat) throws Exception {
         List<ProducerRecord<String, byte[]>> records = new ArrayList<ProducerRecord<String, byte[]>>();
+        // 获取当前topic的分区数
+        Integer partitionNum = MQMessageUtils.parseDynamicTopicPartition(topicName, canalDestination.getDynamicTopicPartitionNum());
+        if (partitionNum == null) {
+            partitionNum = canalDestination.getPartitionsNum();
+        }
         if (!flat) {
             if (canalDestination.getPartitionHash() != null && !canalDestination.getPartitionHash().isEmpty()) {
                 // 并发构造
@@ -171,7 +176,7 @@ public class CanalKafkaProducer extends AbstractMQProducer implements CanalMQPro
                 // 串行分区
                 Message[] messages = MQMessageUtils.messagePartition(datas,
                     message.getId(),
-                    canalDestination.getPartitionsNum(),
+                        partitionNum,
                     canalDestination.getPartitionHash(),
                     kafkaProperties.getDatabaseHash());
                 int length = messages.length;
@@ -201,7 +206,7 @@ public class CanalKafkaProducer extends AbstractMQProducer implements CanalMQPro
             for (FlatMessage flatMessage : flatMessages) {
                 if (canalDestination.getPartitionHash() != null && !canalDestination.getPartitionHash().isEmpty()) {
                     FlatMessage[] partitionFlatMessage = MQMessageUtils.messagePartition(flatMessage,
-                        canalDestination.getPartitionsNum(),
+                            partitionNum,
                         canalDestination.getPartitionHash(),
                         kafkaProperties.getDatabaseHash());
                     int length = partitionFlatMessage.length;

--- a/server/src/main/java/com/alibaba/otter/canal/rocketmq/CanalRocketMQProducer.java
+++ b/server/src/main/java/com/alibaba/otter/canal/rocketmq/CanalRocketMQProducer.java
@@ -117,6 +117,11 @@ public class CanalRocketMQProducer extends AbstractMQProducer implements CanalMQ
 
     public void send(final MQProperties.CanalDestination destination, String topicName,
                      com.alibaba.otter.canal.protocol.Message message) throws Exception {
+        // 获取当前topic的分区数
+        Integer partitionNum = MQMessageUtils.parseDynamicTopicPartition(topicName, destination.getDynamicTopicPartitionNum());
+        if (partitionNum == null) {
+            partitionNum = destination.getPartitionsNum();
+        }
         if (!mqProperties.getFlatMessage()) {
             if (destination.getPartitionHash() != null && !destination.getPartitionHash().isEmpty()) {
                 // 并发构造
@@ -124,7 +129,7 @@ public class CanalRocketMQProducer extends AbstractMQProducer implements CanalMQ
                 // 串行分区
                 com.alibaba.otter.canal.protocol.Message[] messages = MQMessageUtils.messagePartition(datas,
                     message.getId(),
-                    destination.getPartitionsNum(),
+                        partitionNum,
                     destination.getPartitionHash(),
                     mqProperties.getDatabaseHash());
                 int length = messages.length;
@@ -168,7 +173,7 @@ public class CanalRocketMQProducer extends AbstractMQProducer implements CanalMQ
 
                     for (FlatMessage flatMessage : flatMessages) {
                         FlatMessage[] partitionFlatMessage = MQMessageUtils.messagePartition(flatMessage,
-                            destination.getPartitionsNum(),
+                                partitionNum,
                             destination.getPartitionHash(),
                             mqProperties.getDatabaseHash());
                         int length = partitionFlatMessage.length;

--- a/server/src/main/java/com/alibaba/otter/canal/server/CanalMQStarter.java
+++ b/server/src/main/java/com/alibaba/otter/canal/server/CanalMQStarter.java
@@ -159,6 +159,7 @@ public class CanalMQStarter {
                 canalDestination.setDynamicTopic(mqConfig.getDynamicTopic());
                 canalDestination.setPartitionsNum(mqConfig.getPartitionsNum());
                 canalDestination.setPartitionHash(mqConfig.getPartitionHash());
+                canalDestination.setDynamicTopicPartitionNum(mqConfig.getDynamicTopicPartitionNum());
 
                 canalServer.subscribe(clientIdentity);
                 logger.info("## the MQ producer: {} is running now ......", destination);


### PR DESCRIPTION
issue: [https://github.com/alibaba/canal/issues/2173](url)
canal 向 mq 发送消息时，可以根据不同的 topic 配置相应的 partitionNum

在 instance.properties 配置文件中新增如下配置项：

`#canal.mq.dynamicTopicPartitionNum=test.*:4,mycanal:6`

支持以正则表达式的方式，为不同的 topic 指定专属 partitionNum
一条规则中，分号前是 topic 或者 topic 的正则表达式，分号后是 partitionNum
多条规则以逗号分隔
大家可以结合自己的业务需求，设置匹配规则，多条匹配规则之间是按照顺序进行匹配(命中一条规则就返回)

例子1: test.*:4,mycanal:6 前缀为test的topic分区数是4，topic mycanal指定分区数为6
例子2: test1|mycanal:6 指定 topic test1 或者 topic mycanal 分区数为6
例子3: 匹配规则啥都不写，或者未匹配上，则 topic 的默认分区数是 canal.mq.partitionsNum