### PR TITLE
对齐h2database版本 align h2 version to 1.4.196

### DIFF
--- a/client-adapter/pom.xml
+++ b/client-adapter/pom.xml
@@ -143,7 +143,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.192</version>
+                <version>1.4.196</version>
             </dependency>
             <!-- 单独引入rocketmq依赖 -->
             <dependency>


### PR DESCRIPTION
对齐版本，避免API行为不一致。