### PR TITLE
es同步数据增强: 支持限制bulk每次提交字节大小、objFields对象字段支持写子表sql

### DIFF
--- a/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/ES6xAdapter.java
+++ b/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/ES6xAdapter.java
@@ -1,14 +1,5 @@
 package com.alibaba.otter.canal.client.adapter.es6x;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
-import javax.sql.DataSource;
-
-import org.elasticsearch.action.search.SearchResponse;
-
 import com.alibaba.otter.canal.client.adapter.es.core.ESAdapter;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig;
 import com.alibaba.otter.canal.client.adapter.es6x.etl.ESEtlService;
@@ -18,6 +9,13 @@ import com.alibaba.otter.canal.client.adapter.support.DatasourceConfig;
 import com.alibaba.otter.canal.client.adapter.support.EtlResult;
 import com.alibaba.otter.canal.client.adapter.support.OuterAdapterConfig;
 import com.alibaba.otter.canal.client.adapter.support.SPI;
+import org.elasticsearch.action.search.SearchResponse;
+
+import javax.sql.DataSource;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * ES 6.x 外部适配器
@@ -75,7 +73,7 @@ public class ES6xAdapter extends ESAdapter {
         ESSyncConfig config = esSyncConfig.get(task);
         if (config != null) {
             DataSource dataSource = DatasourceConfig.DATA_SOURCES.get(config.getDataSourceKey());
-            ESEtlService esEtlService = new ESEtlService(esConnection, config);
+            ESEtlService esEtlService = new ESEtlService(esConnection, config, esSyncService);
             if (dataSource != null) {
                 return esEtlService.importData(params);
             } else {
@@ -89,7 +87,7 @@ public class ES6xAdapter extends ESAdapter {
             for (ESSyncConfig configTmp : esSyncConfig.values()) {
                 // 取所有的destination为task的配置
                 if (configTmp.getDestination().equals(task)) {
-                    ESEtlService esEtlService = new ESEtlService(esConnection, configTmp);
+                    ESEtlService esEtlService = new ESEtlService(esConnection, configTmp, esSyncService);
                     EtlResult etlRes = esEtlService.importData(params);
                     if (!etlRes.getSucceeded()) {
                         resSuccess = false;

--- a/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/etl/ESEtlService.java
+++ b/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/etl/ESEtlService.java
@@ -1,19 +1,6 @@
 package com.alibaba.otter.canal.client.adapter.es6x.etl;
 
-import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
-
-import javax.sql.DataSource;
-
-import org.apache.commons.lang.StringUtils;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.SearchHit;
-
+import com.alibaba.fastjson.JSON;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig.ESMapping;
 import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.FieldItem;
@@ -21,6 +8,7 @@ import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest;
 import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest.ESBulkResponse;
 import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest.ESIndexRequest;
 import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest.ESUpdateRequest;
+import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest.IESRequest;
 import com.alibaba.otter.canal.client.adapter.es.core.support.ESTemplate;
 import com.alibaba.otter.canal.client.adapter.es6x.support.ES6xTemplate;
 import com.alibaba.otter.canal.client.adapter.es6x.support.ESConnection;
@@ -29,6 +17,18 @@ import com.alibaba.otter.canal.client.adapter.support.AbstractEtlService;
 import com.alibaba.otter.canal.client.adapter.support.AdapterConfig;
 import com.alibaba.otter.canal.client.adapter.support.EtlResult;
 import com.alibaba.otter.canal.client.adapter.support.Util;
+import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * ES ETL Service
@@ -78,123 +78,152 @@ public class ESEtlService extends AbstractEtlService {
                             }
 
                             // 如果是主键字段则不插入
-                if (fieldItem.getFieldName().equals(mapping.get_id())) {
-                    idVal = esTemplate.getValFromRS(mapping, rs, fieldName, fieldName);
-                } else {
-                    Object val = esTemplate.getValFromRS(mapping, rs, fieldName, fieldName);
-                    esFieldData.put(Util.cleanColumn(fieldName), val);
-                }
-
-            }
-
-            if (!mapping.getRelations().isEmpty()) {
-                mapping.getRelations().forEach((relationField, relationMapping) -> {
-                    Map<String, Object> relations = new HashMap<>();
-                    relations.put("name", relationMapping.getName());
-                    if (StringUtils.isNotEmpty(relationMapping.getParent())) {
-                        FieldItem parentFieldItem = mapping.getSchemaItem()
-                            .getSelectFields()
-                            .get(relationMapping.getParent());
-                        Object parentVal;
-                        try {
-                            parentVal = esTemplate.getValFromRS(mapping,
-                                rs,
-                                parentFieldItem.getFieldName(),
-                                parentFieldItem.getFieldName());
-                        } catch (SQLException e) {
-                            throw new RuntimeException(e);
-                        }
-                        if (parentVal != null) {
-                            relations.put("parent", parentVal.toString());
-                            esFieldData.put("$parent_routing", parentVal.toString());
+                            if (fieldItem.getFieldName().equals(mapping.get_id())) {
+                                idVal = esTemplate.getValFromRS(mapping, rs, fieldName, fieldName);
+                            } else {
+                                Object val = esTemplate.getValFromRS(mapping, rs, fieldName, fieldName);
+                                esFieldData.put(Util.cleanColumn(fieldName), val);
+                            }
 
                         }
+
+                        if (!mapping.getRelations().isEmpty()) {
+                            mapping.getRelations().forEach((relationField, relationMapping) -> {
+                                Map<String, Object> relations = new HashMap<>();
+                                relations.put("name", relationMapping.getName());
+                                if (StringUtils.isNotEmpty(relationMapping.getParent())) {
+                                    FieldItem parentFieldItem = mapping.getSchemaItem()
+                                            .getSelectFields()
+                                            .get(relationMapping.getParent());
+                                    Object parentVal;
+                                    try {
+                                        parentVal = esTemplate.getValFromRS(mapping,
+                                                rs,
+                                                parentFieldItem.getFieldName(),
+                                                parentFieldItem.getFieldName());
+                                    } catch (SQLException e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                    if (parentVal != null) {
+                                        relations.put("parent", parentVal.toString());
+                                        esFieldData.put("$parent_routing", parentVal.toString());
+
+                                    }
+                                }
+                                esFieldData.put(Util.cleanColumn(relationField), relations);
+                            });
+                        }
+
+                        if (idVal != null) {
+                            String parentVal = (String) esFieldData.remove("$parent_routing");
+                            if (mapping.isUpsert()) {
+                                ESUpdateRequest esUpdateRequest = this.esConnection.new ES6xUpdateRequest(mapping.get_index(),
+                                        mapping.get_type(),
+                                        idVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);
+
+                                if (StringUtils.isNotEmpty(parentVal)) {
+                                    esUpdateRequest.setRouting(parentVal);
+                                }
+
+                                batchBegin = add(mapping, esBulkRequest, esFieldData, esUpdateRequest, batchBegin);
+                            } else {
+                                ESIndexRequest esIndexRequest = this.esConnection.new ES6xIndexRequest(mapping.get_index(),
+                                        mapping.get_type(),
+                                        idVal.toString()).setSource(esFieldData);
+                                if (StringUtils.isNotEmpty(parentVal)) {
+                                    esIndexRequest.setRouting(parentVal);
+                                }
+                                batchBegin = add(mapping, esBulkRequest, esFieldData, esIndexRequest, batchBegin);
+                            }
+                        } else {
+                            idVal = esFieldData.get(mapping.getPk());
+                            ESSearchRequest esSearchRequest = this.esConnection.new ESSearchRequest(mapping.get_index(),
+                                    mapping.get_type()).setQuery(QueryBuilders.termQuery(mapping.getPk(), idVal)).size(10000);
+                            SearchResponse response = esSearchRequest.getResponse();
+                            for (SearchHit hit : response.getHits()) {
+                                ESUpdateRequest esUpdateRequest = this.esConnection.new ES6xUpdateRequest(mapping.get_index(),
+                                        mapping.get_type(),
+                                        hit.getId()).setDoc(esFieldData);
+                                batchBegin = add(mapping, esBulkRequest, esFieldData, esUpdateRequest, batchBegin);
+                            }
+                        }
+
+                        if (esBulkRequest.numberOfActions() % mapping.getCommitBatch() == 0 && esBulkRequest.numberOfActions() > 0) {
+                            bulk(mapping, esBulkRequest, batchBegin, false);
+                            batchBegin = System.currentTimeMillis();
+                        }
+                        count++;
+                        impCount.incrementAndGet();
                     }
-                    esFieldData.put(Util.cleanColumn(relationField), relations);
-                });
-            }
 
-            if (idVal != null) {
-                String parentVal = (String) esFieldData.remove("$parent_routing");
-                if (mapping.isUpsert()) {
-                    ESUpdateRequest esUpdateRequest = this.esConnection.new ES6xUpdateRequest(mapping.get_index(),
-                        mapping.get_type(),
-                        idVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);
-
-                    if (StringUtils.isNotEmpty(parentVal)) {
-                        esUpdateRequest.setRouting(parentVal);
+                    if (esBulkRequest.numberOfActions() > 0) {
+                        bulk(mapping, esBulkRequest, batchBegin, true);
                     }
-
-                    esBulkRequest.add(esUpdateRequest);
-                } else {
-                    ESIndexRequest esIndexRequest = this.esConnection.new ES6xIndexRequest(mapping.get_index(),
-                        mapping.get_type(),
-                        idVal.toString()).setSource(esFieldData);
-                    if (StringUtils.isNotEmpty(parentVal)) {
-                        esIndexRequest.setRouting(parentVal);
-                    }
-                    esBulkRequest.add(esIndexRequest);
+                } catch (Exception e) {
+                    logger.error(e.getMessage(), e);
+                    errMsg.add(mapping.get_index() + " etl failed! ==>" + e.getMessage());
+                    throw new RuntimeException(e);
                 }
-            } else {
-                idVal = esFieldData.get(mapping.getPk());
-                ESSearchRequest esSearchRequest = this.esConnection.new ESSearchRequest(mapping.get_index(),
-                    mapping.get_type()).setQuery(QueryBuilders.termQuery(mapping.getPk(), idVal)).size(10000);
-                SearchResponse response = esSearchRequest.getResponse();
-                for (SearchHit hit : response.getHits()) {
-                    ESUpdateRequest esUpdateRequest = this.esConnection.new ES6xUpdateRequest(mapping.get_index(),
-                        mapping.get_type(),
-                        hit.getId()).setDoc(esFieldData);
-                    esBulkRequest.add(esUpdateRequest);
-                }
-            }
-
-            if (esBulkRequest.numberOfActions() % mapping.getCommitBatch() == 0 && esBulkRequest.numberOfActions() > 0) {
-                long esBatchBegin = System.currentTimeMillis();
-                ESBulkResponse rp = esBulkRequest.bulk();
-                if (rp.hasFailures()) {
-                    rp.processFailBulkResponse("全量数据 etl 异常 ");
-                }
-
-                if (logger.isTraceEnabled()) {
-                    logger.trace("全量数据批量导入批次耗时: {}, es执行时间: {}, 批次大小: {}, index; {}",
-                        (System.currentTimeMillis() - batchBegin),
-                        (System.currentTimeMillis() - esBatchBegin),
-                        esBulkRequest.numberOfActions(),
-                        mapping.get_index());
-                }
-                batchBegin = System.currentTimeMillis();
-                esBulkRequest.resetBulk();
-            }
-            count++;
-            impCount.incrementAndGet();
-        }
-
-        if (esBulkRequest.numberOfActions() > 0) {
-            long esBatchBegin = System.currentTimeMillis();
-            ESBulkResponse rp = esBulkRequest.bulk();
-            if (rp.hasFailures()) {
-                rp.processFailBulkResponse("全量数据 etl 异常 ");
-            }
-            if (logger.isTraceEnabled()) {
-                logger.trace("全量数据批量导入最后批次耗时: {}, es执行时间: {}, 批次大小: {}, index; {}",
-                    (System.currentTimeMillis() - batchBegin),
-                    (System.currentTimeMillis() - esBatchBegin),
-                    esBulkRequest.numberOfActions(),
-                    mapping.get_index());
-            }
-        }
-    } catch (Exception e) {
-        logger.error(e.getMessage(), e);
-        errMsg.add(mapping.get_index() + " etl failed! ==>" + e.getMessage());
-        throw new RuntimeException(e);
-    }
-    return count;
-}           );
+                return count;
+            });
 
             return true;
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
             return false;
+        }
+    }
+
+
+    private long add(ESMapping mapping, ESBulkRequest esBulkRequest, Map<String, Object> esFieldData, IESRequest esRequest, long batchBegin) {
+        boolean leCommitBatchSize =
+                esBulkRequest.add(esRequest, mapping.getCommitBatchSize(), bytesSizeToAdd -> {
+                    if (esBulkRequest.numberOfActions() <= 0) {
+                        try {
+                            esBulkRequest.add(esRequest);
+                            bulk(mapping, esBulkRequest, batchBegin, false);
+                        } catch (Exception e) {
+                            logger.error("全量数据批量导入批次中单条数据已达上限, 尝试单独推送失败！" + JSON.toJSONString(esFieldData), e);
+                        }
+                    } else {
+                        //若批次数据大小已达上限，不继续添加，先提交再手动添加
+
+                        bulk(mapping, esBulkRequest, batchBegin, false);
+                        esBulkRequest.add(esRequest);
+                    }
+                    return false;
+                });
+        if (leCommitBatchSize) {
+            return batchBegin;
+        }
+        return System.currentTimeMillis();
+    }
+
+    private void bulk(ESMapping mapping, ESBulkRequest esBulkRequest, long batchBegin, boolean isLast) {
+        int numberOfActions = esBulkRequest.numberOfActions();
+        if (numberOfActions <= 0) {
+            logger.warn("全量数据批量导入批次无数据, 忽略");
+            return;
+        }
+
+        try {
+            long esBatchBegin = System.currentTimeMillis();
+            ESBulkResponse rp = esBulkRequest.bulk();
+            if (rp.hasFailures()) {
+                rp.processFailBulkResponse("全量数据 etl 异常 ");
+            }
+
+            if (logger.isTraceEnabled()) {
+                logger.trace("全量数据批量导入{}批次耗时: {}, es执行时间: {}, 批次个数: {}, 批次大小: {}, index; {}",
+                        isLast ? "最后" : "",
+                        (System.currentTimeMillis() - batchBegin),
+                        (System.currentTimeMillis() - esBatchBegin),
+                        esBulkRequest.numberOfActions(),
+                        esBulkRequest.estimatedSizeInBytes(),
+                        mapping.get_index());
+            }
+        } finally {
+            esBulkRequest.resetBulk();
         }
     }
 }

--- a/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/etl/ESEtlService.java
+++ b/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/etl/ESEtlService.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig.ESMapping;
 import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.FieldItem;
+import com.alibaba.otter.canal.client.adapter.es.core.service.ESSyncService;
 import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest;
 import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest.ESBulkResponse;
 import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest.ESIndexRequest;
@@ -41,12 +42,14 @@ public class ESEtlService extends AbstractEtlService {
     private ESConnection esConnection;
     private ESTemplate   esTemplate;
     private ESSyncConfig config;
+    private ESSyncService esSyncService;
 
-    public ESEtlService(ESConnection esConnection, ESSyncConfig config){
+    public ESEtlService(ESConnection esConnection, ESSyncConfig config, ESSyncService esSyncService){
         super("ES", config);
         this.esConnection = esConnection;
         this.esTemplate = new ES6xTemplate(esConnection);
         this.config = config;
+        this.esSyncService = esSyncService;
     }
 
     public EtlResult importData(List<String> params) {
@@ -113,6 +116,9 @@ public class ESEtlService extends AbstractEtlService {
                                 esFieldData.put(Util.cleanColumn(relationField), relations);
                             });
                         }
+
+                        //填充对象字段值
+                        esFieldData.putAll(esSyncService.getObjectFieldDatasForMainTableInsert(config, esFieldData));
 
                         if (idVal != null) {
                             String parentVal = (String) esFieldData.remove("$parent_routing");

--- a/client-adapter/es6x/src/main/resources/es6/biz_order.yml
+++ b/client-adapter/es6x/src/main/resources/es6/biz_order.yml
@@ -19,3 +19,4 @@ esMapping:
     - customer_id
   etlCondition: "where t.c_time>={}"
   commitBatch: 3000
+  commitBatchSize: 1048576

--- a/client-adapter/es6x/src/main/resources/es6/customer.yml
+++ b/client-adapter/es6x/src/main/resources/es6/customer.yml
@@ -11,6 +11,7 @@ esMapping:
   sql: "select t.id, t.name, t.email from customer t"
   etlCondition: "where t.c_time>={}"
   commitBatch: 3000
+  commitBatchSize: 1048576
 
 
 #{

--- a/client-adapter/es6x/src/main/resources/es6/mytest_user.yml
+++ b/client-adapter/es6x/src/main/resources/es6/mytest_user.yml
@@ -10,8 +10,13 @@ esMapping:
   sql: "select a.id as _id, a.name as _name, a.role_id as _role_id, b.role_name as _role_name,
         a.c_time as _c_time from user a
         left join role b on b.id=a.role_id"
+
 #  objFields:
-#    _labels: array:;
+#    fields:
+#      _labels:
+#        type: array
+#        separator: ;
+
   etlCondition: "where a.c_time>={}"
   commitBatch: 3000
   commitBatchSize: 1048576

--- a/client-adapter/es6x/src/main/resources/es6/mytest_user.yml
+++ b/client-adapter/es6x/src/main/resources/es6/mytest_user.yml
@@ -14,3 +14,4 @@ esMapping:
 #    _labels: array:;
   etlCondition: "where a.c_time>={}"
   commitBatch: 3000
+  commitBatchSize: 1048576

--- a/client-adapter/es6x/src/main/resources/es6/person.yml
+++ b/client-adapter/es6x/src/main/resources/es6/person.yml
@@ -1,0 +1,71 @@
+dataSourceKey: defaultDS
+destination: example
+groupId: g1
+esMapping:
+  _index: person
+  _type: _doc
+  _id: _id
+  #pk: id
+
+  #示例数据: {"id":"1","name":"刘一","age":"51","create_time":"2020-05-17T21:43:40+08:00","country_id":"1","relationshipIds":["1","2","3","4","5","6","7","8","9"],"friendNames":["陈二","张三2"],"country":{"id":"1","create_time":"2020-05-17T19:03:15+08:00","name":"中国"},"friends":[{"id":"2","name":"陈二"},{"id":"3","name":"张三2"}],"knowPersonNames":"郑十;吴九;周八;孙七;赵六;王五;李四;张三2;陈二","country_create_time":"2020-05-17T19:03:15+08:00","country_name":"中国"}
+
+  sql: "select
+          p._id, p._id as id, p._name as name, p._age as age, p._create_time as create_time, p._country_id as country_id, rst.relationshipIds
+          from person p left join (select rs._person_id, group_concat(rs._id separator ';') as relationshipIds from person_relationship rs group by rs._person_id) rst on rst._person_id=p._id"
+
+  # 对象字段
+  objFields:
+    # 是否并行查询, 开启并行时建议调大数据库连接数, 默认为false(不开启)
+    parallel: false
+    # 并行线程数, 默认为1
+    threadSize: 1
+    # 对象字段详情
+    fields:
+
+      friendNames:
+        # 类型【必填】
+        #   esMapping.objFields.fields.?.sql 非空情况下 支持 单字段数组(array)、JSON对象(object)、JSON对象数组(objectArray)、字符串拼接(joining)、扁平化(objectFlat)
+        #   esMapping.objFields.fields.?.sql 为空情况下 支持 单字段数组(array)、JSON对象(object), 需要主表sql(esMapping.sql)中利用group_concat函数拼接好数组、对象JSON, 需注意调大mysql的group_concat_max_len配置
+        type: array
+        # 子表查询语句
+        #   不支持 多表关联查询
+        #   不支持 “select * ” 写法
+        #   需对主表sql中任意一个或以上的字段进行关联查询, 可用“${?}”表达式引用主表字段(需保证值不为null), 如: where _fk = '${rid}'
+        sql: "select _other_person_name from person_relationship where _relationship='朋友' and _person_id='${id}'"
+        # 分隔符
+        #   esMapping.objFields.fields.?.sql 非空情况下 esMapping.objFields.fields.?.type = joining 有效
+        #   esMapping.objFields.fields.?.sql 为空情况下 esMapping.objFields.fields.?.type = array 有效
+        separator:
+        # 是否反向更新, 默认为true(当子表有数据变动时，也会同步更新到es中)
+        reverseUpdate: true
+
+      relationshipIds:
+        type: array
+        separator: ;
+
+      country:
+        type: object
+        sql: "select c._id as id, c._create_time as create_time, c._name as name from country c where c._id='${country_id}'"
+
+      friends:
+        type: objectArray
+        sql: "select _other_person_id as id, _other_person_name as name from person_relationship where _relationship='朋友' and _person_id='${id}'"
+
+      knowPersonNames:
+        type: joining
+        sql: "select _other_person_name from person_relationship where _person_id='${id}' order by _other_person_id desc"
+        separator: ;
+
+      countryFlat:
+        # 扁平化(objectFlat): 将该子表数据全部扁平化放入主表数据中, 而不作为某个对象字段存在, 适用场景: 子表数据无需反向更新主表es数据
+        type: objectFlat
+        sql: "select _create_time as country_create_time, _name as country_name from country where _id='${country_id}'"
+        reverseUpdate: false
+
+
+  # etl 的条件参数
+  etlCondition: "where p._create_time >= {} and p._create_time <= {} order by p._id"
+  # 提交批数量
+  commitBatch: 1000
+  # 提交批大小, 默认值为1M (1048576)
+  commitBatchSize: 1048576

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/ES7xAdapter.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/ES7xAdapter.java
@@ -1,14 +1,5 @@
 package com.alibaba.otter.canal.client.adapter.es7x;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
-import javax.sql.DataSource;
-
-import org.elasticsearch.action.search.SearchResponse;
-
 import com.alibaba.otter.canal.client.adapter.es.core.ESAdapter;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig;
 import com.alibaba.otter.canal.client.adapter.es7x.etl.ESEtlService;
@@ -18,6 +9,13 @@ import com.alibaba.otter.canal.client.adapter.support.DatasourceConfig;
 import com.alibaba.otter.canal.client.adapter.support.EtlResult;
 import com.alibaba.otter.canal.client.adapter.support.OuterAdapterConfig;
 import com.alibaba.otter.canal.client.adapter.support.SPI;
+import org.elasticsearch.action.search.SearchResponse;
+
+import javax.sql.DataSource;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * ES 7.x 外部适配器
@@ -74,7 +72,7 @@ public class ES7xAdapter extends ESAdapter {
         ESSyncConfig config = esSyncConfig.get(task);
         if (config != null) {
             DataSource dataSource = DatasourceConfig.DATA_SOURCES.get(config.getDataSourceKey());
-            ESEtlService esEtlService = new ESEtlService(esConnection, config);
+            ESEtlService esEtlService = new ESEtlService(esConnection, config, esSyncService);
             if (dataSource != null) {
                 return esEtlService.importData(params);
             } else {
@@ -88,7 +86,7 @@ public class ES7xAdapter extends ESAdapter {
             for (ESSyncConfig configTmp : esSyncConfig.values()) {
                 // 取所有的destination为task的配置
                 if (configTmp.getDestination().equals(task)) {
-                    ESEtlService esEtlService = new ESEtlService(esConnection, configTmp);
+                    ESEtlService esEtlService = new ESEtlService(esConnection, configTmp, esSyncService);
                     EtlResult etlRes = esEtlService.importData(params);
                     if (!etlRes.getSucceeded()) {
                         resSuccess = false;

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/etl/ESEtlService.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/etl/ESEtlService.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig.ESMapping;
 import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.FieldItem;
+import com.alibaba.otter.canal.client.adapter.es.core.service.ESSyncService;
 import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest;
 import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest.ESBulkResponse;
 import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest.ESIndexRequest;
@@ -40,12 +41,14 @@ public class ESEtlService extends AbstractEtlService {
     private ESConnection esConnection;
     private ESTemplate   esTemplate;
     private ESSyncConfig config;
+    private ESSyncService esSyncService;
 
-    public ESEtlService(ESConnection esConnection, ESSyncConfig config){
+    public ESEtlService(ESConnection esConnection, ESSyncConfig config, ESSyncService esSyncService){
         super("ES", config);
         this.esConnection = esConnection;
         this.esTemplate = new ES7xTemplate(esConnection);
         this.config = config;
+        this.esSyncService = esSyncService;
     }
 
     public EtlResult importData(List<String> params) {
@@ -112,6 +115,9 @@ public class ESEtlService extends AbstractEtlService {
                                 esFieldData.put(Util.cleanColumn(relationField), relations);
                             });
                         }
+
+                        //填充对象字段值
+                        esFieldData.putAll(esSyncService.getObjectFieldDatasForMainTableInsert(config, esFieldData));
 
                         if (idVal != null) {
                             String parentVal = (String) esFieldData.remove("$parent_routing");

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/etl/ESEtlService.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/etl/ESEtlService.java
@@ -1,19 +1,6 @@
 package com.alibaba.otter.canal.client.adapter.es7x.etl;
 
-import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
-
-import javax.sql.DataSource;
-
-import org.apache.commons.lang.StringUtils;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.SearchHit;
-
+import com.alibaba.fastjson.JSON;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig.ESMapping;
 import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.FieldItem;
@@ -29,6 +16,18 @@ import com.alibaba.otter.canal.client.adapter.support.AbstractEtlService;
 import com.alibaba.otter.canal.client.adapter.support.AdapterConfig;
 import com.alibaba.otter.canal.client.adapter.support.EtlResult;
 import com.alibaba.otter.canal.client.adapter.support.Util;
+import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * ES ETL Service
@@ -125,7 +124,7 @@ public class ESEtlService extends AbstractEtlService {
                                     esUpdateRequest.setRouting(parentVal);
                                 }
 
-                                esBulkRequest.add(esUpdateRequest);
+                                batchBegin = add(mapping, esBulkRequest, esFieldData, esUpdateRequest, batchBegin);
                             } else {
                                 ESIndexRequest esIndexRequest = this.esConnection.new ES7xIndexRequest(
                                     mapping.get_index(),
@@ -133,7 +132,7 @@ public class ESEtlService extends AbstractEtlService {
                                 if (StringUtils.isNotEmpty(parentVal)) {
                                     esIndexRequest.setRouting(parentVal);
                                 }
-                                esBulkRequest.add(esIndexRequest);
+                                batchBegin = add(mapping, esBulkRequest, esFieldData, esIndexRequest, batchBegin);
                             }
                         } else {
                             idVal = esFieldData.get(mapping.getPk());
@@ -145,45 +144,21 @@ public class ESEtlService extends AbstractEtlService {
                                 ESUpdateRequest esUpdateRequest = this.esConnection.new ES7xUpdateRequest(
                                     mapping.get_index(),
                                     hit.getId()).setDoc(esFieldData);
-                                esBulkRequest.add(esUpdateRequest);
+                                batchBegin = add(mapping, esBulkRequest, esFieldData, esUpdateRequest, batchBegin);
                             }
                         }
 
                         if (esBulkRequest.numberOfActions() % mapping.getCommitBatch() == 0
                             && esBulkRequest.numberOfActions() > 0) {
-                            long esBatchBegin = System.currentTimeMillis();
-                            ESBulkResponse rp = esBulkRequest.bulk();
-                            if (rp.hasFailures()) {
-                                rp.processFailBulkResponse("全量数据 etl 异常 ");
-                            }
-
-                            if (logger.isTraceEnabled()) {
-                                logger.trace("全量数据批量导入批次耗时: {}, es执行时间: {}, 批次大小: {}, index; {}",
-                                    (System.currentTimeMillis() - batchBegin),
-                                    (System.currentTimeMillis() - esBatchBegin),
-                                    esBulkRequest.numberOfActions(),
-                                    mapping.get_index());
-                            }
+                            bulk(mapping, esBulkRequest, batchBegin, false);
                             batchBegin = System.currentTimeMillis();
-                            esBulkRequest.resetBulk();
                         }
                         count++;
                         impCount.incrementAndGet();
                     }
 
                     if (esBulkRequest.numberOfActions() > 0) {
-                        long esBatchBegin = System.currentTimeMillis();
-                        ESBulkResponse rp = esBulkRequest.bulk();
-                        if (rp.hasFailures()) {
-                            rp.processFailBulkResponse("全量数据 etl 异常 ");
-                        }
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("全量数据批量导入最后批次耗时: {}, es执行时间: {}, 批次大小: {}, index; {}",
-                                (System.currentTimeMillis() - batchBegin),
-                                (System.currentTimeMillis() - esBatchBegin),
-                                esBulkRequest.numberOfActions(),
-                                mapping.get_index());
-                        }
+                        bulk(mapping, esBulkRequest, batchBegin, true);
                     }
                 } catch (Exception e) {
                     logger.error(e.getMessage(), e);
@@ -197,6 +172,58 @@ public class ESEtlService extends AbstractEtlService {
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
             return false;
+        }
+    }
+
+    private long add(ESMapping mapping, ESBulkRequest esBulkRequest, Map<String, Object> esFieldData, ESBulkRequest.IESRequest esRequest, long batchBegin) {
+        boolean leCommitBatchSize =
+                esBulkRequest.add(esRequest, mapping.getCommitBatchSize(), bytesSizeToAdd -> {
+                    if (esBulkRequest.numberOfActions() <= 0) {
+                        try {
+                            esBulkRequest.add(esRequest);
+                            bulk(mapping, esBulkRequest, batchBegin, false);
+                        } catch (Exception e) {
+                            logger.error("全量数据批量导入批次中单条数据已达上限, 尝试单独推送失败！" + JSON.toJSONString(esFieldData), e);
+                        }
+                    } else {
+                        //若批次数据大小已达上限，不继续添加，先提交再手动添加
+
+                        bulk(mapping, esBulkRequest, batchBegin, false);
+                        esBulkRequest.add(esRequest);
+                    }
+                    return false;
+                });
+        if (leCommitBatchSize) {
+            return batchBegin;
+        }
+        return System.currentTimeMillis();
+    }
+
+    private void bulk(ESMapping mapping, ESBulkRequest esBulkRequest, long batchBegin, boolean isLast) {
+        int numberOfActions = esBulkRequest.numberOfActions();
+        if (numberOfActions <= 0) {
+            logger.warn("全量数据批量导入批次无数据, 忽略");
+            return;
+        }
+
+        try {
+            long esBatchBegin = System.currentTimeMillis();
+            ESBulkResponse rp = esBulkRequest.bulk();
+            if (rp.hasFailures()) {
+                rp.processFailBulkResponse("全量数据 etl 异常 ");
+            }
+
+            if (logger.isTraceEnabled()) {
+                logger.trace("全量数据批量导入{}批次耗时: {}, es执行时间: {}, 批次个数: {}, 批次大小: {}, index; {}",
+                        isLast ? "最后" : "",
+                        (System.currentTimeMillis() - batchBegin),
+                        (System.currentTimeMillis() - esBatchBegin),
+                        esBulkRequest.numberOfActions(),
+                        esBulkRequest.estimatedSizeInBytes(),
+                        mapping.get_index());
+            }
+        } finally {
+            esBulkRequest.resetBulk();
         }
     }
 }

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
@@ -24,6 +24,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
 
 import javax.sql.DataSource;
 import java.sql.ResultSet;
@@ -44,7 +45,7 @@ public class ES7xTemplate implements ESTemplate {
     private ESBulkRequest                                     esBulkRequest;
 
     // es 字段类型本地缓存
-    private static ConcurrentMap<String, Map<String, String>> esFieldTypes   = new ConcurrentHashMap<>();
+    private static ConcurrentMap<String, Map<String, Object>> esFieldTypes   = new ConcurrentHashMap<>();
 
     public ES7xTemplate(ESConnection esConnection){
         this.esConnection = esConnection;
@@ -208,12 +209,31 @@ public class ES7xTemplate implements ESTemplate {
             }
         }
 
+        return convertEsObj(mapping, fieldName, esType, value);
+    }
+
+    private Object convertEsObj(ESMapping mapping, String fieldName, String esType, Object value) {
+        Map<String, ESSyncConfig.ObjField> objFields = mapping.getObjFields().getFields();
+
         // 如果是对象类型
-        if (mapping.getObjFields().containsKey(fieldName)) {
-            return ESSyncUtil.convertToEsObj(value, mapping.getObjFields().get(fieldName));
-        } else {
-            return ESSyncUtil.typeConvert(value, esType);
+        if ((!CollectionUtils.isEmpty(objFields)) && objFields.containsKey(fieldName)) {
+            ESSyncConfig.ObjField objField = objFields.get(fieldName);
+
+            if (StringUtils.isBlank(objField.getSql())) {
+
+                String separator = objField.getSeparator();
+                ESSyncConfig.ObjFieldType type = objField.getType();
+                String expr = StringUtils.isNotEmpty(separator) ? type.name() + ":" + separator : type.name();
+
+                return ESSyncUtil.convertToEsObj(value, expr);
+
+            } else {
+                //有子表sql的对象字段不在这里获取值
+                return null;
+            }
         }
+
+        return ESSyncUtil.typeConvert(value, esType);
     }
 
     @Override
@@ -294,12 +314,7 @@ public class ES7xTemplate implements ESTemplate {
             }
         }
 
-        // 如果是对象类型
-        if (mapping.getObjFields().containsKey(fieldName)) {
-            return ESSyncUtil.convertToEsObj(value, mapping.getObjFields().get(fieldName));
-        } else {
-            return ESSyncUtil.typeConvert(value, esType);
-        }
+        return convertEsObj(mapping, fieldName, esType, value);
     }
 
     @Override
@@ -394,17 +409,41 @@ public class ES7xTemplate implements ESTemplate {
     /**
      * 获取es mapping中的属性类型
      *
-     * @param mapping mapping配置
+     * @param mapping   mapping配置
      * @param fieldName 属性名
      * @return 类型
      */
+    public String getEsType(ESMapping mapping, String fieldName) {
+        Object esType = getEsMapping(mapping).get(fieldName);
+        return esType instanceof Map ? "object" : Objects.toString(esType, null);
+    }
+
+    /**
+     * 获取es mapping中的子属性类型
+     *
+     * @param mapping           mapping配置
+     * @param fieldName         属性名
+     * @param childFieldName    子属性名
+     * @return 类型
+     */
+    public String getEsType(ESMapping mapping, String fieldName, String childFieldName) {
+        Object esType = getEsMapping(mapping).get(fieldName);
+        if (esType instanceof Map) {
+            return Objects.toString(((Map) esType).get(childFieldName), null);
+        }
+        return Objects.toString(esType, null);
+    }
+
+    /**
+     * 获取es mapping信息
+     * @param mapping es配置信息
+     * @return
+     */
     @SuppressWarnings("unchecked")
-    private String getEsType(ESMapping mapping, String fieldName) {
+    private Map<String, Object> getEsMapping(ESMapping mapping) {
         String key = mapping.get_index() + "-" + mapping.get_type();
-        Map<String, String> fieldType = esFieldTypes.get(key);
-        if (fieldType != null) {
-            return fieldType.get(fieldName);
-        } else {
+        Map<String, Object> fieldType = esFieldTypes.get(key);
+        if (fieldType == null) {
             MappingMetaData mappingMetaData = esConnection.getMapping(mapping.get_index());
 
             if (mappingMetaData == null) {
@@ -418,15 +457,19 @@ public class ES7xTemplate implements ESTemplate {
             for (Map.Entry<String, Object> entry : esMapping.entrySet()) {
                 Map<String, Object> value = (Map<String, Object>) entry.getValue();
                 if (value.containsKey("properties")) {
-                    fieldType.put(entry.getKey(), "object");
+                    Map<String, Object> childFieldType = new LinkedHashMap<>();
+                    ((Map<String, Map<String, Object>>)value.get("properties"))
+                            .forEach((propKey, propValue) -> childFieldType.put(propKey, propValue.get("type")));
+
+                    fieldType.put(entry.getKey(), childFieldType);
                 } else {
-                    fieldType.put(entry.getKey(), (String) value.get("type"));
+                    fieldType.put(entry.getKey(), value.get("type"));
                 }
             }
             esFieldTypes.put(key, fieldType);
 
-            return fieldType.get(fieldName);
         }
+        return fieldType;
     }
 
     private void putRelationDataFromRS(ESMapping mapping, SchemaItem schemaItem, ResultSet resultSet,

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ESConnection.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ESConnection.java
@@ -1,10 +1,6 @@
 package com.alibaba.otter.canal.client.adapter.es7x.support;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.Map;
-
+import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -32,6 +28,7 @@ import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -41,7 +38,11 @@ import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.alibaba.otter.canal.client.adapter.es.core.support.ESBulkRequest;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * ES 连接器, Transport Rest 两种方式
@@ -197,6 +198,43 @@ public class ESConnection {
         public void setIndexRequest(IndexRequest indexRequest) {
             this.indexRequest = indexRequest;
         }
+
+        @Override
+        public ESBulkRequest add(ESBulkRequest esBulkRequest) {
+            ES7xBulkRequest es7xBulkRequest = (ES7xBulkRequest) esBulkRequest;
+            if (mode == ESClientMode.TRANSPORT) {
+                es7xBulkRequest.getBulkRequestBuilder().add(indexRequestBuilder);
+            } else {
+                es7xBulkRequest.getBulkRequest().add(indexRequest);
+            }
+            return esBulkRequest;
+        }
+
+        @Override
+        public boolean add(ESBulkRequest esBulkRequest, int commitBatchSize, Function<Long, Boolean> ifGtCommitBatchSize) {
+            ES7xBulkRequest es7xBulkRequest = (ES7xBulkRequest) esBulkRequest;
+            BytesReference source;
+            BulkRequest bulkRequest;
+            if (mode == ESClientMode.TRANSPORT) {
+                source = indexRequestBuilder.request().source();
+                bulkRequest = es7xBulkRequest.getBulkRequestBuilder().request();
+            } else {
+                source = indexRequest.source();
+                bulkRequest = es7xBulkRequest.getBulkRequest();
+            }
+
+            long addSize = (source != null ? source.length() : 0) + ES7xBulkRequest.REQUEST_OVERHEAD;
+
+            //超出 批次提交大小 限制（单位为字节）, 且回调函数返回true就可以继续添加, 否则就抛弃这一条
+            if ((addSize + bulkRequest.estimatedSizeInBytes()) > commitBatchSize
+                    && ! ifGtCommitBatchSize.apply(addSize)) {
+                return false;
+            }
+
+            add(esBulkRequest);
+
+            return true;
+        }
     }
 
     public class ES7xUpdateRequest implements ESBulkRequest.ESUpdateRequest {
@@ -257,6 +295,53 @@ public class ESConnection {
         public void setUpdateRequest(UpdateRequest updateRequest) {
             this.updateRequest = updateRequest;
         }
+
+        @Override
+        public ESBulkRequest add(ESBulkRequest esBulkRequest) {
+            ES7xBulkRequest eS7xBulkRequest = (ES7xBulkRequest) esBulkRequest;
+            if (mode == ESClientMode.TRANSPORT) {
+                eS7xBulkRequest.getBulkRequestBuilder().add(updateRequestBuilder);
+            } else {
+                eS7xBulkRequest.getBulkRequest().add(updateRequest);
+            }
+            return esBulkRequest;
+        }
+
+        @Override
+        public boolean add(ESBulkRequest esBulkRequest, int commitBatchSize, Function<Long, Boolean> ifGtCommitBatchSize) {
+            ES7xBulkRequest eS7xBulkRequest = (ES7xBulkRequest) esBulkRequest;
+            UpdateRequest request;
+            BulkRequest bulkRequest;
+            if (mode == ESClientMode.TRANSPORT) {
+                request = updateRequestBuilder.request();
+                bulkRequest = eS7xBulkRequest.getBulkRequestBuilder().request();
+            } else {
+                request = updateRequest;
+                bulkRequest = eS7xBulkRequest.getBulkRequest();
+            }
+
+            long addSize = 0;
+
+            if (request.doc() != null) {
+                addSize += request.doc().source().length();
+            }
+            if (request.upsertRequest() != null) {
+                addSize += request.upsertRequest().source().length();
+            }
+            if (request.script() != null) {
+                addSize += request.script().getIdOrCode().length() * 2;
+            }
+
+            //超出 批次提交大小 限制（单位为字节）, 且回调函数返回true就可以继续添加, 否则就抛弃这一条
+            if ((addSize + bulkRequest.estimatedSizeInBytes()) > commitBatchSize
+                    && ! ifGtCommitBatchSize.apply(addSize)) {
+                return false;
+            }
+
+            add(esBulkRequest);
+
+            return true;
+        }
     }
 
     public class ES7xDeleteRequest implements ESBulkRequest.ESDeleteRequest {
@@ -289,6 +374,40 @@ public class ESConnection {
 
         public void setDeleteRequest(DeleteRequest deleteRequest) {
             this.deleteRequest = deleteRequest;
+        }
+
+        @Override
+        public ESBulkRequest add(ESBulkRequest esBulkRequest) {
+            ES7xBulkRequest eS7xBulkRequest = (ES7xBulkRequest) esBulkRequest;
+            if (mode == ESClientMode.TRANSPORT) {
+                eS7xBulkRequest.getBulkRequestBuilder().add(deleteRequestBuilder);
+            } else {
+                eS7xBulkRequest.getBulkRequest().add(deleteRequest);
+            }
+            return esBulkRequest;
+        }
+
+        @Override
+        public boolean add(ESBulkRequest esBulkRequest, int commitBatchSize, Function<Long, Boolean> ifGtCommitBatchSize) {
+            ES7xBulkRequest eS7xBulkRequest = (ES7xBulkRequest) esBulkRequest;
+            BulkRequest bulkRequest;
+            if (mode == ESClientMode.TRANSPORT) {
+                bulkRequest = eS7xBulkRequest.getBulkRequestBuilder().request();
+            } else {
+                bulkRequest = eS7xBulkRequest.getBulkRequest();
+            }
+
+            long addSize = ES7xBulkRequest.REQUEST_OVERHEAD;
+
+            //超出 批次提交大小 限制（单位为字节）, 且回调函数返回true就可以继续添加, 否则就抛弃这一条
+            if ((addSize + bulkRequest.estimatedSizeInBytes()) > commitBatchSize
+                    && ! ifGtCommitBatchSize.apply(addSize)) {
+                return false;
+            }
+
+            add(esBulkRequest);
+
+            return true;
         }
     }
 
@@ -359,6 +478,8 @@ public class ESConnection {
 
     public class ES7xBulkRequest implements ESBulkRequest {
 
+        private static final int REQUEST_OVERHEAD = 50;
+
         private BulkRequestBuilder bulkRequestBuilder;
 
         private BulkRequest        bulkRequest;
@@ -379,41 +500,20 @@ public class ESConnection {
             }
         }
 
-        public ES7xBulkRequest add(ESIndexRequest esIndexRequest) {
-            ES7xIndexRequest eir = (ES7xIndexRequest) esIndexRequest;
-            if (mode == ESClientMode.TRANSPORT) {
-                bulkRequestBuilder.add(eir.indexRequestBuilder);
-            } else {
-                bulkRequest.add(eir.indexRequest);
-            }
-            return this;
-        }
-
-        public ES7xBulkRequest add(ESUpdateRequest esUpdateRequest) {
-            ES7xUpdateRequest eur = (ES7xUpdateRequest) esUpdateRequest;
-            if (mode == ESClientMode.TRANSPORT) {
-                bulkRequestBuilder.add(eur.updateRequestBuilder);
-            } else {
-                bulkRequest.add(eur.updateRequest);
-            }
-            return this;
-        }
-
-        public ES7xBulkRequest add(ESDeleteRequest esDeleteRequest) {
-            ES7xDeleteRequest edr = (ES7xDeleteRequest) esDeleteRequest;
-            if (mode == ESClientMode.TRANSPORT) {
-                bulkRequestBuilder.add(edr.deleteRequestBuilder);
-            } else {
-                bulkRequest.add(edr.deleteRequest);
-            }
-            return this;
-        }
-
         public int numberOfActions() {
             if (mode == ESClientMode.TRANSPORT) {
                 return bulkRequestBuilder.numberOfActions();
             } else {
                 return bulkRequest.numberOfActions();
+            }
+        }
+
+        @Override
+        public long estimatedSizeInBytes() {
+            if (mode == ESClientMode.TRANSPORT) {
+                return bulkRequestBuilder.request().estimatedSizeInBytes();
+            } else {
+                return bulkRequest.estimatedSizeInBytes();
             }
         }
 

--- a/client-adapter/es7x/src/main/resources/es7/biz_order.yml
+++ b/client-adapter/es7x/src/main/resources/es7/biz_order.yml
@@ -18,3 +18,4 @@ esMapping:
     - customer_id
   etlCondition: "where t.c_time>={}"
   commitBatch: 3000
+  commitBatchSize: 1048576

--- a/client-adapter/es7x/src/main/resources/es7/customer.yml
+++ b/client-adapter/es7x/src/main/resources/es7/customer.yml
@@ -10,6 +10,7 @@ esMapping:
   sql: "select t.id, t.name, t.email from customer t"
   etlCondition: "where t.c_time>={}"
   commitBatch: 3000
+  commitBatchSize: 1048576
 
 
 #{

--- a/client-adapter/es7x/src/main/resources/es7/mytest_user.yml
+++ b/client-adapter/es7x/src/main/resources/es7/mytest_user.yml
@@ -9,8 +9,13 @@ esMapping:
   sql: "select a.id as _id, a.name, a.role_id, b.role_name,
         a.c_time from user a
         left join role b on b.id=a.role_id"
+
 #  objFields:
-#    _labels: array:;
+#    fields:
+#      _labels:
+#        type: array
+#        separator: ;
+
   etlCondition: "where a.c_time>={}"
   commitBatch: 3000
   commitBatchSize: 1048576

--- a/client-adapter/es7x/src/main/resources/es7/mytest_user.yml
+++ b/client-adapter/es7x/src/main/resources/es7/mytest_user.yml
@@ -13,3 +13,4 @@ esMapping:
 #    _labels: array:;
   etlCondition: "where a.c_time>={}"
   commitBatch: 3000
+  commitBatchSize: 1048576

--- a/client-adapter/es7x/src/main/resources/es7/person.yml
+++ b/client-adapter/es7x/src/main/resources/es7/person.yml
@@ -1,0 +1,70 @@
+dataSourceKey: defaultDS
+destination: example
+groupId: g1
+esMapping:
+  _index: person
+  _id: _id
+  #pk: id
+
+  #示例数据: {"id":"1","name":"刘一","age":"51","create_time":"2020-05-17T21:43:40+08:00","country_id":"1","relationshipIds":["1","2","3","4","5","6","7","8","9"],"friendNames":["陈二","张三2"],"country":{"id":"1","create_time":"2020-05-17T19:03:15+08:00","name":"中国"},"friends":[{"id":"2","name":"陈二"},{"id":"3","name":"张三2"}],"knowPersonNames":"郑十;吴九;周八;孙七;赵六;王五;李四;张三2;陈二","country_create_time":"2020-05-17T19:03:15+08:00","country_name":"中国"}
+
+  sql: "select
+          p._id, p._id as id, p._name as name, p._age as age, p._create_time as create_time, p._country_id as country_id, rst.relationshipIds
+          from person p left join (select rs._person_id, group_concat(rs._id separator ';') as relationshipIds from person_relationship rs group by rs._person_id) rst on rst._person_id=p._id"
+
+  # 对象字段
+  objFields:
+    # 是否并行查询, 开启并行时建议调大数据库连接数, 默认为false(不开启)
+    parallel: false
+    # 并行线程数, 默认为1
+    threadSize: 1
+    # 对象字段详情
+    fields:
+
+      friendNames:
+        # 类型【必填】
+        #   esMapping.objFields.fields.?.sql 非空情况下 支持 单字段数组(array)、JSON对象(object)、JSON对象数组(objectArray)、字符串拼接(joining)、扁平化(objectFlat)
+        #   esMapping.objFields.fields.?.sql 为空情况下 支持 单字段数组(array)、JSON对象(object), 需要主表sql(esMapping.sql)中利用group_concat函数拼接好数组、对象JSON, 需注意调大mysql的group_concat_max_len配置
+        type: array
+        # 子表查询语句
+        #   不支持 多表关联查询
+        #   不支持 “select * ” 写法
+        #   需对主表sql中任意一个或以上的字段进行关联查询, 可用“${?}”表达式引用主表字段(需保证值不为null), 如: where _fk = '${rid}'
+        sql: "select _other_person_name from person_relationship where _relationship='朋友' and _person_id='${id}'"
+        # 分隔符
+        #   esMapping.objFields.fields.?.sql 非空情况下 esMapping.objFields.fields.?.type = joining 有效
+        #   esMapping.objFields.fields.?.sql 为空情况下 esMapping.objFields.fields.?.type = array 有效
+        separator:
+        # 是否反向更新, 默认为true(当子表有数据变动时，也会同步更新到es中)
+        reverseUpdate: true
+
+      relationshipIds:
+        type: array
+        separator: ;
+
+      country:
+        type: object
+        sql: "select c._id as id, c._create_time as create_time, c._name as name from country c where c._id='${country_id}'"
+
+      friends:
+        type: objectArray
+        sql: "select _other_person_id as id, _other_person_name as name from person_relationship where _relationship='朋友' and _person_id='${id}'"
+
+      knowPersonNames:
+        type: joining
+        sql: "select _other_person_name from person_relationship where _person_id='${id}' order by _other_person_id desc"
+        separator: ;
+
+      countryFlat:
+        # 扁平化(objectFlat): 将该子表数据全部扁平化放入主表数据中, 而不作为某个对象字段存在, 适用场景: 子表数据无需反向更新主表es数据
+        type: objectFlat
+        sql: "select _create_time as country_create_time, _name as country_name from country where _id='${country_id}'"
+        reverseUpdate: false
+
+
+  # etl 的条件参数
+  etlCondition: "where p._create_time >= {} and p._create_time <= {} order by p._id"
+  # 提交批数量
+  commitBatch: 1000
+  # 提交批大小, 默认值为1M (1048576)
+  commitBatchSize: 1048576

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/ESSyncConfig.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/ESSyncConfig.java
@@ -2,10 +2,7 @@ package com.alibaba.otter.canal.client.adapter.es.core.config;
 
 import com.alibaba.otter.canal.client.adapter.support.AdapterConfig;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * ES 映射配置
@@ -103,9 +100,7 @@ public class ESSyncConfig implements AdapterConfig {
         private String                       pk;
         private Map<String, RelationMapping> relations       = new LinkedHashMap<>();
         private String                       sql;
-        // 对象字段, 例: objFields:
-        // - _labels: array:;
-        private Map<String, String>          objFields       = new LinkedHashMap<>();
+        private ObjFields                    objFields       = new ObjFields();      //对象字段配置
         private List<String>                 skips           = new ArrayList<>();
         private int                          commitBatch     = 1000;
         private int                          commitBatchSize = 1048576;              // 批次提交大小（单位为字节）
@@ -155,11 +150,11 @@ public class ESSyncConfig implements AdapterConfig {
             this.pk = pk;
         }
 
-        public Map<String, String> getObjFields() {
+        public ObjFields getObjFields() {
             return objFields;
         }
 
-        public void setObjFields(Map<String, String> objFields) {
+        public void setObjFields(ObjFields objFields) {
             this.objFields = objFields;
         }
 
@@ -256,5 +251,159 @@ public class ESSyncConfig implements AdapterConfig {
         public void setParent(String parent) {
             this.parent = parent;
         }
+    }
+
+
+    /**
+     * 对象字段配置
+     * @author zze0 2020-05-06
+     */
+    public static class ObjFields {
+
+        /**
+         * 是否并行查询
+         */
+        private boolean                 parallel    = false;
+
+        /**
+         * 并行线程数
+         */
+        private int                     threadSize  = 1;
+
+        /**
+         * 对象字段
+         */
+        private Map<String, ObjField>   fields      = new LinkedHashMap<>();
+
+        public boolean isParallel() {
+            return parallel;
+        }
+
+        public void setParallel(boolean parallel) {
+            this.parallel = parallel;
+        }
+
+        public int getThreadSize() {
+            return threadSize;
+        }
+
+        public void setThreadSize(int threadSize) {
+            this.threadSize = threadSize;
+        }
+
+        public Map<String, ObjField> getFields() {
+            return fields;
+        }
+
+        public void setFields(Map<String, ObjField> fields) {
+            this.fields = fields;
+        }
+    }
+
+    /**
+     * 对象字段
+     * @author zze0 2020-05-06
+     */
+    public static class ObjField {
+
+        /**
+         * 类型
+         */
+        private ObjFieldType    type;
+
+        /**
+         * 子表sql（使用“${?}”来引用主表sql 字段值），如：“select _id,_name from role where _type='${_role_type}'”
+         * @see ESMapping#sql
+         */
+        private String          sql;
+
+        /**
+         * sql解析结果
+         */
+        private SchemaItem      schemaItem;
+
+        /**
+         * 分隔符（当type为joining时有效）
+         * @see ObjFieldType#joining
+         */
+        private String          separator;
+
+        /**
+         * 是否反向更新（true表示当子表有数据变动时，也会同步更新到es中）
+         */
+        private boolean         reverseUpdate = true;
+
+        public ObjFieldType getType() {
+            return type;
+        }
+
+        public void setType(ObjFieldType type) {
+            this.type = type;
+        }
+
+        public String getSql() {
+            return sql;
+        }
+
+        public void setSql(String sql) {
+            this.sql = sql;
+        }
+
+        public SchemaItem getSchemaItem() {
+            return schemaItem;
+        }
+
+        public void setSchemaItem(SchemaItem schemaItem) {
+            this.schemaItem = schemaItem;
+        }
+
+        public String getSeparator() {
+            return Objects.toString(separator, "");
+        }
+
+        public void setSeparator(String separator) {
+            this.separator = separator;
+        }
+
+        public boolean isReverseUpdate() {
+            return reverseUpdate;
+        }
+
+        public void setReverseUpdate(boolean reverseUpdate) {
+            this.reverseUpdate = reverseUpdate;
+        }
+    }
+
+    /**
+     * 对象类型
+     */
+    public enum ObjFieldType {
+
+        /**
+         * 数组，如: ["1","2","3","4"]
+         */
+        array,
+
+        /**
+         * JSON对象，如: {"key":"value"}
+         */
+        object,
+
+        /**
+         * JSON对象数组，如: [{"key":"value"}]
+         */
+        objectArray,
+
+        /**
+         * 字符串拼接（搭配ObjField#separator分隔符使用），如: “1,2,3,4”
+         * @see ObjField#separator
+         */
+        joining,
+
+        /**
+         * JSON对象扁平化，如: {"key":"value"} <p/>
+         * 将该子表sql的数据全部扁平化放入主表数据中，而不作为某个对象字段存在。
+         */
+        objectFlat,
     }
 }

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/ESSyncConfig.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/ESSyncConfig.java
@@ -1,11 +1,11 @@
 package com.alibaba.otter.canal.client.adapter.es.core.config;
 
+import com.alibaba.otter.canal.client.adapter.support.AdapterConfig;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.alibaba.otter.canal.client.adapter.support.AdapterConfig;
 
 /**
  * ES 映射配置
@@ -108,6 +108,7 @@ public class ESSyncConfig implements AdapterConfig {
         private Map<String, String>          objFields       = new LinkedHashMap<>();
         private List<String>                 skips           = new ArrayList<>();
         private int                          commitBatch     = 1000;
+        private int                          commitBatchSize = 1048576;              // 批次提交大小（单位为字节）
         private String                       etlCondition;
         private boolean                      syncByTimestamp = false;                // 是否按时间戳定时同步
         private Long                         syncInterval;                           // 同步时间间隔
@@ -224,6 +225,14 @@ public class ESSyncConfig implements AdapterConfig {
 
         public void setSchemaItem(SchemaItem schemaItem) {
             this.schemaItem = schemaItem;
+        }
+
+        public int getCommitBatchSize() {
+            return commitBatchSize;
+        }
+
+        public void setCommitBatchSize(int commitBatchSize) {
+            this.commitBatchSize = commitBatchSize;
         }
     }
 

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/SchemaItem.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/SchemaItem.java
@@ -21,6 +21,7 @@ public class SchemaItem {
     private volatile Map<String, List<TableItem>> tableItemAliases;
     private volatile Map<String, List<FieldItem>> columnFields;
     private volatile Boolean                      allFieldsSimple;
+    private String                                limit;
 
     public void init() {
         this.getTableItemAliases();
@@ -141,6 +142,14 @@ public class SchemaItem {
         } else {
             return getSelectFields().get(mapping.getPk());
         }
+    }
+
+    public String getLimit() {
+        return limit;
+    }
+
+    public void setLimit(String limit) {
+        this.limit = limit;
     }
 
     public static class TableItem {

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/SqlParser.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/SqlParser.java
@@ -1,27 +1,9 @@
 package com.alibaba.otter.canal.client.adapter.es.core.config;
 
-import static com.alibaba.fastsql.sql.ast.expr.SQLBinaryOperator.BooleanAnd;
-import static com.alibaba.fastsql.sql.ast.expr.SQLBinaryOperator.Equality;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.alibaba.fastsql.sql.SQLUtils;
 import com.alibaba.fastsql.sql.ast.SQLExpr;
-import com.alibaba.fastsql.sql.ast.expr.SQLBinaryOpExpr;
-import com.alibaba.fastsql.sql.ast.expr.SQLCaseExpr;
-import com.alibaba.fastsql.sql.ast.expr.SQLCharExpr;
-import com.alibaba.fastsql.sql.ast.expr.SQLIdentifierExpr;
-import com.alibaba.fastsql.sql.ast.expr.SQLMethodInvokeExpr;
-import com.alibaba.fastsql.sql.ast.expr.SQLPropertyExpr;
-import com.alibaba.fastsql.sql.ast.statement.SQLExprTableSource;
-import com.alibaba.fastsql.sql.ast.statement.SQLJoinTableSource;
-import com.alibaba.fastsql.sql.ast.statement.SQLSelectGroupByClause;
-import com.alibaba.fastsql.sql.ast.statement.SQLSelectItem;
-import com.alibaba.fastsql.sql.ast.statement.SQLSelectStatement;
-import com.alibaba.fastsql.sql.ast.statement.SQLSubqueryTableSource;
-import com.alibaba.fastsql.sql.ast.statement.SQLTableSource;
+import com.alibaba.fastsql.sql.ast.expr.*;
+import com.alibaba.fastsql.sql.ast.statement.*;
 import com.alibaba.fastsql.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
 import com.alibaba.fastsql.sql.dialect.mysql.parser.MySqlStatementParser;
 import com.alibaba.fastsql.sql.parser.ParserException;
@@ -30,6 +12,16 @@ import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.ColumnIt
 import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.FieldItem;
 import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.RelationFieldsPair;
 import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.TableItem;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.util.CollectionUtils;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.alibaba.fastsql.sql.ast.expr.SQLBinaryOperator.BooleanAnd;
+import static com.alibaba.fastsql.sql.ast.expr.SQLBinaryOperator.Equality;
 
 /**
  * ES同步指定sql格式解析
@@ -38,6 +30,11 @@ import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.TableIte
  * @version 1.0.0
  */
 public class SqlParser {
+
+    /**
+     * 子表sql中的逻辑主表名
+     */
+    public static final String OBJ_FIELD_SQL_MAIN_TABLE_LOGIC_NAME = "[$_main]";
 
     /**
      * 解析sql
@@ -53,6 +50,7 @@ public class SqlParser {
 
             SchemaItem schemaItem = new SchemaItem();
             schemaItem.setSql(SQLUtils.toMySqlString(sqlSelectQueryBlock));
+            schemaItem.setLimit(Objects.toString(sqlSelectQueryBlock.getLimit(), null));
             SQLTableSource sqlTableSource = sqlSelectQueryBlock.getFrom();
             List<TableItem> tableItems = new ArrayList<>();
             SqlParser.visitSelectTable(schemaItem, sqlTableSource, tableItems, null);
@@ -68,8 +66,95 @@ public class SqlParser {
             }
             return schemaItem;
         } catch (Exception e) {
-            throw new ParserException();
+            throw new ParserException(e, sql);
         }
+    }
+
+
+    /**
+     * 解析对象字段 sql
+     *
+     * @param objFieldName      对象字段名
+     * @param sql               对象字段 sql
+     * @param mainSchemaItem    主表sql解析结果
+     * @return 视图对象
+     */
+    public static SchemaItem parseObjField(String objFieldName, String sql, SchemaItem mainSchemaItem) {
+        SchemaItem schemaItem = parse(sql);
+
+        try {
+            sql = schemaItem.getSql();
+            Map<String, TableItem> aliasTableItems = schemaItem.getAliasTableItems();
+            if (aliasTableItems.size() > 1) {
+                throw new ParserException("("+objFieldName+") Parse obj field sql error: only support one table!");
+            }
+
+            TableItem mainTableRefItem = new TableItem(schemaItem);
+            mainTableRefItem.setAlias(OBJ_FIELD_SQL_MAIN_TABLE_LOGIC_NAME);
+            mainTableRefItem.setTableName(OBJ_FIELD_SQL_MAIN_TABLE_LOGIC_NAME);
+            mainTableRefItem.setSchema(mainSchemaItem.getMainTable().getSchema());
+
+            //主表sql字段
+            Set<String> mainTableFieldNames = mainSchemaItem.getSelectFields().keySet();
+
+            //子表sql和主表sql的关联字段
+            List<RelationFieldsPair> relationFieldsPairs = new ArrayList<>();
+            //子表sql引用的主表字段
+            List<FieldItem> mainFieldRefList = new ArrayList<>();
+
+            Matcher matcher = Pattern.compile("\\s+(\\S*?)\\s+=\\s+([\"']?\\$\\{(\\S*?)\\}[\"']?)\\s+").matcher(sql + " ");
+            while (matcher.find()){
+                FieldItem leftPart = new FieldItem();
+                FieldItem rightPart = new FieldItem();
+                RelationFieldsPair relationFieldsPair = new RelationFieldsPair(leftPart, rightPart);
+
+                //子表字段，如：“r._id”
+                String childFieldExpr = matcher.group(1);
+                leftPart.setExpr(childFieldExpr);
+                if (StringUtils.isBlank(childFieldExpr)) {
+                    throw new ParserException("("+objFieldName+") Parse obj field sql error: left relation expr parse error = "+matcher.group());
+                }
+
+                //子表字段名，如：“_id”
+                String childFieldName = childFieldExpr.contains(".") ? StringUtils.substringAfter(childFieldExpr, ".") : childFieldExpr;
+                leftPart.setFieldName(childFieldName);
+                if (StringUtils.isBlank(childFieldName)) {
+                    throw new ParserException("("+objFieldName+") Parse obj field sql error: left relation expr parse field name error = "+matcher.group());
+                }
+
+                //主表字段，如：“${_id}”
+                String mainFieldExpr = matcher.group(2);
+                rightPart.setExpr(mainFieldExpr);
+                if (StringUtils.isBlank(mainFieldExpr)) {
+                    throw new ParserException("("+objFieldName+") Parse obj field sql error: right relation expr parse error = "+matcher.group());
+                }
+
+                //主表字段名，如：“_id”
+                String mainFieldName = matcher.group(3);
+                rightPart.setFieldName(mainFieldName);
+                if (StringUtils.isBlank(mainFieldName)) {
+                    throw new ParserException("("+objFieldName+") Parse obj field sql error: right relation expr parse field name error = "+matcher.group());
+                }
+
+                if (mainTableFieldNames.stream().noneMatch(fieldName -> StringUtils.equalsIgnoreCase(mainFieldName, fieldName))) {
+                    throw new ParserException("("+objFieldName+") Parse obj field sql error: unknown main table field name = "+mainFieldName);
+                }
+                mainFieldRefList.add(rightPart);
+                relationFieldsPairs.add(relationFieldsPair);
+            }
+            if (CollectionUtils.isEmpty(relationFieldsPairs)) {
+                throw new ParserException("Child table sql hasn't associated with main table sql field");
+            }
+            mainTableRefItem.setSubQueryFields(mainFieldRefList);
+            mainTableRefItem.setRelationFields(relationFieldsPairs);
+
+            aliasTableItems.put(OBJ_FIELD_SQL_MAIN_TABLE_LOGIC_NAME, mainTableRefItem);
+            schemaItem.getTableItemAliases().put(OBJ_FIELD_SQL_MAIN_TABLE_LOGIC_NAME, Collections.singletonList(mainTableRefItem));
+
+        } catch (Exception e) {
+            throw new ParserException(e, sql);
+        }
+        return schemaItem;
     }
 
     /**

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/service/ESSyncService.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/service/ESSyncService.java
@@ -1,24 +1,18 @@
 package com.alibaba.otter.canal.client.adapter.es.core.service;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.sql.DataSource;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.alibaba.fastsql.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig.ESMapping;
+import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig.ObjField;
+import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig.ObjFieldType;
+import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig.ObjFields;
 import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem;
 import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.ColumnItem;
 import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.FieldItem;
+import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.RelationFieldsPair;
 import com.alibaba.otter.canal.client.adapter.es.core.config.SchemaItem.TableItem;
 import com.alibaba.otter.canal.client.adapter.es.core.config.SqlParser;
 import com.alibaba.otter.canal.client.adapter.es.core.support.ESSyncUtil;
@@ -26,6 +20,21 @@ import com.alibaba.otter.canal.client.adapter.es.core.support.ESTemplate;
 import com.alibaba.otter.canal.client.adapter.support.DatasourceConfig;
 import com.alibaba.otter.canal.client.adapter.support.Dml;
 import com.alibaba.otter.canal.client.adapter.support.Util;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
+
+import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * ES 同步 Service
@@ -129,6 +138,12 @@ public class ESSyncService {
             return;
         }
         SchemaItem schemaItem = config.getEsMapping().getSchemaItem();
+
+        //dml涉及表名
+        String dmlTableName = dml.getTable();
+        //主表名
+        String mainTableName = schemaItem.getMainTable().getTableName();
+
         for (Map<String, Object> data : dataList) {
             if (data == null || data.isEmpty()) {
                 continue;
@@ -136,11 +151,19 @@ public class ESSyncService {
 
             if (schemaItem.getAliasTableItems().size() == 1 && schemaItem.isAllFieldsSimple()) {
                 // ------单表 & 所有字段都为简单字段------
-                singleTableSimpleFiledInsert(config, dml, data);
+                if (mainTableName.equalsIgnoreCase(dmlTableName)) {
+                    singleTableSimpleFiledInsert(config, dml, data);
+                } else {
+                    // 对象字段涉及的子表数据插入
+                    updateObjectFields(config, dml, data, null);
+                }
             } else {
                 // ------是主表 查询sql来插入------
-                if (schemaItem.getMainTable().getTableName().equalsIgnoreCase(dml.getTable())) {
+                if (mainTableName.equalsIgnoreCase(dmlTableName)) {
                     mainTableInsert(config, dml, data);
+                } else {
+                    // 对象字段涉及的子表数据插入
+                    updateObjectFields(config, dml, data, null);
                 }
 
                 // 从表的操作
@@ -148,7 +171,7 @@ public class ESSyncService {
                     if (tableItem.isMain()) {
                         continue;
                     }
-                    if (!tableItem.getTableName().equals(dml.getTable())) {
+                    if (!tableItem.getTableName().equals(dmlTableName)) {
                         continue;
                     }
                     // 关联条件出现在主表查询条件是否为简单字段
@@ -200,6 +223,12 @@ public class ESSyncService {
             return;
         }
         SchemaItem schemaItem = config.getEsMapping().getSchemaItem();
+
+        //dml涉及表名
+        String dmlTableName = dml.getTable();
+        //主数据表名
+        String mainTableName = schemaItem.getMainTable().getTableName();
+
         int i = 0;
         for (Map<String, Object> data : dataList) {
             Map<String, Object> old = oldList.get(i);
@@ -209,10 +238,15 @@ public class ESSyncService {
 
             if (schemaItem.getAliasTableItems().size() == 1 && schemaItem.isAllFieldsSimple()) {
                 // ------单表 & 所有字段都为简单字段------
-                singleTableSimpleFiledUpdate(config, dml, data, old);
+                if (mainTableName.equalsIgnoreCase(dmlTableName)) {
+                    singleTableSimpleFiledUpdate(config, dml, data, old);
+                } else {
+                    // 对象字段涉及的子表数据更新
+                    updateObjectFields(config, dml, data, old);
+                }
             } else {
                 // ------主表 查询sql来更新------
-                if (schemaItem.getMainTable().getTableName().equalsIgnoreCase(dml.getTable())) {
+                if (mainTableName.equalsIgnoreCase(dmlTableName)) {
                     ESMapping mapping = config.getEsMapping();
                     String idFieldName = mapping.get_id() == null ? mapping.getPk() : mapping.get_id();
                     FieldItem idFieldItem = schemaItem.getSelectFields().get(idFieldName);
@@ -267,14 +301,18 @@ public class ESSyncService {
                     } else {
                         mainTableUpdate(config, dml, data, old);
                     }
+                } else {
+                    // 对象字段涉及的子表数据更新
+                    updateObjectFields(config, dml, data, old);
                 }
+
 
                 // 从表的操作
                 for (TableItem tableItem : schemaItem.getAliasTableItems().values()) {
                     if (tableItem.isMain()) {
                         continue;
                     }
-                    if (!tableItem.getTableName().equals(dml.getTable())) {
+                    if (!tableItem.getTableName().equals(dmlTableName)) {
                         continue;
                     }
 
@@ -384,6 +422,9 @@ public class ESSyncService {
                     }
                 }
 
+            } else {
+                // 对象字段涉及的子表数据删除
+                updateObjectFields(config, dml, data, null);
             }
 
             // 从表的操作
@@ -434,9 +475,14 @@ public class ESSyncService {
      * @param data 单行dml数据
      */
     private void singleTableSimpleFiledInsert(ESSyncConfig config, Dml dml, Map<String, Object> data) {
+
         ESMapping mapping = config.getEsMapping();
+
         Map<String, Object> esFieldData = new LinkedHashMap<>();
         Object idVal = esTemplate.getESDataFromDmlData(mapping, data, esFieldData);
+
+        //填充对象字段值
+        esFieldData.putAll(getObjectFieldDatasForMainTableInsert(config, esFieldData));
 
         if (logger.isTraceEnabled()) {
             logger.trace("Single table insert to es index, destination:{}, table: {}, index: {}, id: {}",
@@ -473,6 +519,9 @@ public class ESSyncService {
                 while (rs.next()) {
                     Map<String, Object> esFieldData = new LinkedHashMap<>();
                     Object idVal = esTemplate.getESDataFromRS(mapping, rs, esFieldData);
+
+                    //填充对象字段值
+                    esFieldData.putAll(getObjectFieldDatasForMainTableInsert(config, esFieldData));
 
                     if (logger.isTraceEnabled()) {
                         logger.trace(
@@ -868,6 +917,393 @@ public class ESSyncService {
             }
             return 0;
         });
+    }
+
+    /**
+     * 批量获取对象字段值(适用：子表 增删改)，并把子表sql中有关主表的查询条件信息放入conditions4Main
+     * @param config            es配置
+     * @param dml               dml信息
+     * @param data              单行dml数据
+     * @param oldData           被改动的字段旧值
+     * @param conditions4Main   主数据查询条件
+     *
+     * @return map（key是对象字段名，value是对象字段值）
+     */
+    public Map<String, Object> getObjectFieldDatasForChildTableUpdate(
+            ESSyncConfig config, Dml dml, Map<String, Object> data, Map<String, Object> oldData, Map<String, Object> conditions4Main) {
+
+        ESMapping esMapping = config.getEsMapping();
+        Map<String, ObjField> objFields = esMapping.getObjFields().getFields();
+        if (CollectionUtils.isEmpty(objFields)) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Object> objectFieldDatas = new LinkedHashMap<>();
+
+        //子表名
+        String tableName = dml.getTable();
+
+        objFields.forEach((objFieldName, objField) -> {
+
+            SchemaItem schemaItem = objField.getSchemaItem();
+
+            //只处理 开启了反向更新、跟该表有关的对象字段
+            if (!(null != schemaItem
+                    && objField.isReverseUpdate()
+                    && tableName.equalsIgnoreCase(schemaItem.getMainTable().getTableName()))) {
+                return;
+            }
+
+
+            //当是update类型时，需要进行对比是否更新了关键字段，如果没有更新是不需要重新解析对象字段
+            if (!CollectionUtils.isEmpty(oldData)) {
+                Set<String> oldDataColumnNames = oldData.keySet().stream().filter(StringUtils::isNotBlank).map(String::toUpperCase).collect(Collectors.toSet());
+                boolean needUpd =
+                        schemaItem.getSelectFields()
+                                .values()
+                                .stream()
+                                .map(FieldItem::getColumnItems)
+                                .filter(Objects::nonNull)
+                                .flatMap(Collection::stream)
+                                .map(ColumnItem::getColumnName)
+                                .filter(StringUtils::isNotBlank)
+                                .map(String::toUpperCase)
+                                .anyMatch(oldDataColumnNames::contains);
+
+                if (!needUpd) {
+                    return;
+                }
+            }
+
+            //主表字段值map（key是主表字段引用信息，value是字段值）
+            Map<FieldItem, Optional<Object>> mainFieldValueMap4Each =
+                    schemaItem.getAliasTableItems()
+                            .get(SqlParser.OBJ_FIELD_SQL_MAIN_TABLE_LOGIC_NAME)
+                            .getRelationFields()
+                            .stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            RelationFieldsPair::getRightFieldItem,
+                                            relationFieldsPair -> {
+                                                FieldItem mainFieldItem = relationFieldsPair.getRightFieldItem();
+                                                FieldItem childFieldItem = relationFieldsPair.getLeftFieldItem();
+                                                //子表字段名
+                                                String childFieldName = childFieldItem.getFieldName();
+                                                //子表字段值
+                                                Object fieldValue = data.get(childFieldName);
+
+                                                //记录所有有关主表的查询条件信息
+                                                conditions4Main.put(mainFieldItem.getFieldName(), fieldValue);
+
+                                                //可能为null, Map.merge会报错, 使用Optional规避
+                                                return Optional.ofNullable(fieldValue);
+                                            },
+                                            (v1, v2) -> v2,
+                                            LinkedHashMap::new
+                                    )
+                            );
+
+
+            Object objFieldValue = getObjectFieldData(config, objFieldName, objField, mainFieldValueMap4Each);
+            putObjFieldValue(objectFieldDatas, objFieldName, objFieldValue, objField.getType());
+        });
+
+        return objectFieldDatas;
+    }
+
+    /**
+     * 批量获取对象字段值(适用：主表新增数据)
+     * @param config        es配置
+     * @param esFieldData   es数据
+     * @return map（key是对象字段名，value是对象字段值）
+     */
+    public Map<String, Object> getObjectFieldDatasForMainTableInsert(ESSyncConfig config, Map<String, Object> esFieldData) {
+
+        long startTs = System.currentTimeMillis();
+
+        ObjFields objFieldsConfig = config.getEsMapping().getObjFields();
+        //对象字段
+        Map<String, ObjField> objFields = objFieldsConfig.getFields();
+        if (CollectionUtils.isEmpty(objFields)) {
+            return Collections.emptyMap();
+        }
+
+        List<Map.Entry<String, ObjField>> objFieldList =
+                objFields.entrySet()
+                        .stream()
+                        //无sql的直接忽略
+                        .filter(entry -> null != entry.getValue().getSchemaItem())
+                        .collect(Collectors.toList());
+
+        if (CollectionUtils.isEmpty(objFieldList)) {
+            return Collections.emptyMap();
+        }
+
+        //串行查询对象字段值
+        if (objFieldList.size() <=1 || objFieldsConfig.getThreadSize() <= 1 || !objFieldsConfig.isParallel()) {
+            Map<String, Object> objectFieldDatas = new LinkedHashMap<>();
+            for (Map.Entry<String, ObjField> entry : objFieldList) {
+                getObjectFieldDatasForMainTableInsert(config, esFieldData, entry.getKey(), entry.getValue(), objectFieldDatas);
+            }
+            return objectFieldDatas;
+        }
+
+        //并行查询对象字段值, 无法保证字段顺序
+        ExecutorService executor = Util.newFixedThreadPool(objFieldsConfig.getThreadSize(), 5000L);
+        List<Future<?>> futures = new ArrayList<>();
+
+        //不能用ConcurrentHashMap, 因为他不允许值为null
+        List<Map<String, Object>> objectFieldDatas = Collections.synchronizedList(new ArrayList<>());
+
+        try {
+
+            for (Map.Entry<String, ObjField> entry : objFieldList) {
+
+                futures.add(executor.submit(() -> {
+                    Map<String, Object> map = new LinkedHashMap<>();
+                    objectFieldDatas.add(map);
+
+                    getObjectFieldDatasForMainTableInsert(config, esFieldData, entry.getKey(), entry.getValue(), map);
+                }));
+            }
+
+            futures.forEach(future -> {
+                try {
+                    future.get();
+                } catch (RuntimeException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+        } finally {
+            executor.shutdown();
+        }
+
+        if (logger.isTraceEnabled()) {
+            logger.trace("getObjectFieldDatasForMainTableInsert - cost:{}; esFieldData={}", System.currentTimeMillis()-startTs, JSON.toJSONString(esFieldData));
+        }
+
+        //value可能为null
+        Map<String, Object> map = new LinkedHashMap<>();
+        objectFieldDatas.stream().map(Map::entrySet).flatMap(Collection::stream).forEach(entry -> map.put(entry.getKey(), entry.getValue()));
+        return map;
+    }
+
+    /**
+     * 获取对象字段值(适用：主表新增数据), 并把对象字段值放入objectFieldDatas然后返回
+     * @param config            es配置
+     * @param esFieldData       es数据
+     * @param objFieldName      对象字段名
+     * @param objField          对象字段
+     * @param objectFieldDatas  对象字段值map（key是对象字段名，value是对象字段值）, 为null时会新实例化
+     * @return map（key是对象字段名，value是对象字段值）
+     */
+    private void getObjectFieldDatasForMainTableInsert(
+            ESSyncConfig config, Map<String, Object> esFieldData,
+            String objFieldName, ObjField objField, Map<String, Object> objectFieldDatas) {
+        //主表字段值map（key是主表字段引用信息，value是字段值）
+        Map<FieldItem, Optional<Object>> mainFieldValueMap =
+                objField.getSchemaItem()
+                        .getAliasTableItems()
+                        .get(SqlParser.OBJ_FIELD_SQL_MAIN_TABLE_LOGIC_NAME)
+                        .getRelationFields()
+                        .stream()
+                        .map(RelationFieldsPair::getRightFieldItem)
+                        .collect(
+                                Collectors.toMap(
+                                        Function.identity(),
+                                        //可能为null, Map.merge会报错, 使用Optional规避
+                                        mainField -> Optional.ofNullable(esFieldData.get(mainField.getFieldName())),
+                                        (v1, v2) -> v2,
+                                        LinkedHashMap::new
+                                )
+                        );
+
+        Object objFieldValue = getObjectFieldData(config, objFieldName, objField, mainFieldValueMap);
+        putObjFieldValue(objectFieldDatas, objFieldName, objFieldValue, objField.getType());
+    }
+
+    /**
+     * 获取对象字段值
+     * @param config                es配置
+     * @param objFieldName          对象字段名
+     * @param objField              对象字段配置
+     * @param mainFieldValueMap     主表字段值map（key是主表字段引用信息，value是字段值）
+     * @return 对象字段值
+     */
+    private Object getObjectFieldData(
+            ESSyncConfig config, String objFieldName, ObjField objField,
+            Map<FieldItem, Optional<Object>> mainFieldValueMap) {
+
+        SchemaItem schemaItem = objField.getSchemaItem();
+
+        //分隔符
+        String separator = objField.getSeparator();
+        //对象字段类型
+        ObjFieldType objFieldType = objField.getType();
+        //子表sql
+        String sql = objField.getSql();
+
+        //对象类型，只查询一条
+        if (ObjFieldType.object.equals(objFieldType) && StringUtils.isBlank(schemaItem.getLimit())) {
+            sql += " limit 1";
+        }
+
+        //查询条件值
+        List<Object> values = new ArrayList<>();
+        //将sql中的主表字段引用表达式替换为占位符
+        for (Map.Entry<FieldItem, Optional<Object>> entry : mainFieldValueMap.entrySet()) {
+            FieldItem fieldItem = entry.getKey();
+            sql = sql.replace(fieldItem.getExpr(), "?");
+            values.add(entry.getValue().orElse(null));
+        }
+
+        DataSource ds = DatasourceConfig.DATA_SOURCES.get(config.getDataSourceKey());
+        return
+                Util.sqlRS(ds, sql, values, rs -> {
+                    try {
+                        List<Object> list = new ArrayList<>();
+                        Supplier<Object> supplier = () -> list;
+
+                        if (ObjFieldType.object.equals(objFieldType) || ObjFieldType.objectFlat.equals(objFieldType)) {
+
+                            //对象类型，只取第一个对象
+                            supplier = () -> list.isEmpty() ? null : list.get(0);
+
+                        } else if (ObjFieldType.joining.equals(objFieldType)) {
+
+                            supplier = () -> list.isEmpty() ? "" : StringUtils.removeEnd(list.get(0).toString(), separator);
+
+                        }
+
+                        while (rs.next()) {
+
+                            ResultSetMetaData metaData = rs.getMetaData();
+                            //字段数
+                            int columnCount = metaData.getColumnCount();
+
+                            if (ObjFieldType.array.equals(objFieldType)) {
+                                //数组 (只取第一个字段值)
+
+                                list.add(getFieldValueInObjectField(rs, metaData, 1, config, objFieldName, objField));
+
+                            } else if (ObjFieldType.object.equals(objFieldType)
+                                        || ObjFieldType.objectArray.equals(objFieldType)
+                                        || ObjFieldType.objectFlat.equals(objFieldType)) {
+                                //JSON对象、JSON对象数组、JSON对象扁平化
+
+                                JSONObject jsonObject = new JSONObject(true);
+                                for (int columnIndex = 1; columnIndex <= columnCount; columnIndex++) {
+                                    //字段名
+                                    String columnName = metaData.getColumnLabel(columnIndex);
+
+                                    //字段值
+                                    Object columnValue = getFieldValueInObjectField(rs, metaData, columnIndex, config, objFieldName, objField);
+
+                                    jsonObject.put(columnName, columnValue);
+                                }
+                                list.add(jsonObject);
+
+                                if (ObjFieldType.object.equals(objFieldType) || ObjFieldType.objectFlat.equals(objFieldType)) {
+                                    //对象类型，只取第一个对象，即可退出结果集遍历
+                                    break;
+                                }
+
+                            } else if (ObjFieldType.joining.equals(objFieldType)) {
+                                //字符串拼接 (只取第一个字段值)
+
+                                StringBuilder joiningBuilder;
+                                if (list.isEmpty()) {
+                                    joiningBuilder = new StringBuilder();
+                                    list.add(joiningBuilder);
+                                } else {
+                                    joiningBuilder = (StringBuilder) list.get(0);
+                                }
+                                joiningBuilder.append(getFieldValueInObjectField(rs, metaData, 1, config, objFieldName, objField))
+                                        .append(separator);
+                            }
+                        }
+
+                        return supplier.get();
+
+                    } catch (RuntimeException e) {
+                        throw e;
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+
+    /**
+     * 将对象字段值放入 objectFieldDatas
+     * @param objectFieldDatas  对象字段值map
+     * @param objFieldName      对象字段名
+     * @param objFieldValue     对象字段值
+     * @param objFieldType      对象字段类型
+     */
+    @SuppressWarnings("unchecked")
+    private void putObjFieldValue(Map<String, Object> objectFieldDatas, String objFieldName, Object objFieldValue, ObjFieldType objFieldType) {
+        if (ObjFieldType.objectFlat.equals(objFieldType)) {
+            if (null != objFieldValue) {
+                //扁平化放入
+                objectFieldDatas.putAll((Map<String, Object>) objFieldValue);
+            }
+        } else {
+            objectFieldDatas.put(objFieldName, objFieldValue);
+        }
+    }
+
+    /**
+     * 获取对象字段内的字段值
+     * @param rs                结果集
+     * @param metaData          结果集元数据
+     * @param columnIndex       字段下标
+     * @param config            es配置
+     * @param objFieldName      对象字段名
+     * @param objField          对象字段配置信息
+     * @return
+     * @throws SQLException
+     */
+    private Object getFieldValueInObjectField(
+            ResultSet rs, ResultSetMetaData metaData, int columnIndex,
+            ESSyncConfig config, String objFieldName, ObjField objField) throws SQLException {
+
+        //字段名
+        String columnName = metaData.getColumnLabel(columnIndex);
+
+        //字段值
+        Object columnValue = rs.getObject(columnName);
+
+        //es类型
+        String esType =
+                ObjFieldType.objectFlat.equals(objField.getType())
+                        ?
+                        esTemplate.getEsType(config.getEsMapping(), columnName)
+                        :
+                        esTemplate.getEsType(config.getEsMapping(), objFieldName, columnName);
+
+        //根据es类型转换值
+        return ESSyncUtil.typeConvert(columnValue, esType);
+    }
+
+    /**
+     * 对象字段涉及的子表更新(增删改)
+     * @param config    es配置
+     * @param dml       dml信息
+     * @param data      单行data数据
+     * @param old       单行old数据（insert、delete情况下没有）
+     */
+    private void updateObjectFields(ESSyncConfig config, Dml dml, Map<String, Object> data, Map<String, Object> old) {
+        //子表sql中有关主表的查询条件信息
+        Map<String, Object> conditions4Main = new LinkedHashMap<>();
+
+        //先获取对象字段值
+        Map<String, Object> esFieldData = getObjectFieldDatasForChildTableUpdate(config, dml, data, old, conditions4Main);
+
+        //反向更新es主表数据
+        esTemplate.updateByQuery(config, conditions4Main, esFieldData);
     }
 
     /**

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/support/ESBulkRequest.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/support/ESBulkRequest.java
@@ -1,29 +1,57 @@
 package com.alibaba.otter.canal.client.adapter.es.core.support;
 
 import java.util.Map;
+import java.util.function.Function;
 
 public interface ESBulkRequest {
 
     void resetBulk();
 
-    ESBulkRequest add(ESIndexRequest esIndexRequest);
+    default ESBulkRequest add(IESRequest esRequest) {
+        return esRequest.add(this);
+    }
 
-    ESBulkRequest add(ESUpdateRequest esUpdateRequest);
-
-    ESBulkRequest add(ESDeleteRequest esDeleteRequest);
+    /**
+     * @param esRequest es请求对象
+     * @param commitBatchSize 批次提交大小（单位为字节）
+     * @param ifGtCommitBatchSize 回调函数（入参：追加内容字节长度。当批中超出 批次提交大小(commitBatchSize) 限制, 且回调函数返回true就可以继续添加, 否则就抛弃这一条）
+     * @return 是否添加成功
+     */
+    default boolean add(IESRequest esRequest, int commitBatchSize, Function<Long, Boolean> ifGtCommitBatchSize) {
+        return esRequest.add(this, commitBatchSize, ifGtCommitBatchSize);
+    }
 
     int numberOfActions();
 
+    /**
+     * 批次大小（单位为字节）
+     * @return
+     */
+    long estimatedSizeInBytes();
+
     ESBulkResponse bulk();
 
-    interface ESIndexRequest {
+    interface IESRequest {
+
+        ESBulkRequest add(ESBulkRequest esBulkRequest);
+
+        /**
+         * @param esBulkRequest es请求批次
+         * @param commitBatchSize 批次提交大小（单位为字节）
+         * @param ifGtCommitBatchSize 回调函数（入参：追加内容字节长度。当批中超出 批次提交大小(commitBatchSize) 限制, 且回调函数返回true就可以继续添加, 否则就抛弃这一条）
+         * @return 是否添加成功
+         */
+        boolean add(ESBulkRequest esBulkRequest, int commitBatchSize, Function<Long, Boolean> ifGtCommitBatchSize);
+    }
+
+    interface ESIndexRequest extends IESRequest {
 
         ESIndexRequest setSource(Map<String, ?> source);
 
         ESIndexRequest setRouting(String routing);
     }
 
-    interface ESUpdateRequest {
+    interface ESUpdateRequest extends IESRequest {
 
         ESUpdateRequest setDoc(Map source);
 
@@ -32,7 +60,7 @@ public interface ESBulkRequest {
         ESUpdateRequest setRouting(String routing);
     }
 
-    interface ESDeleteRequest {
+    interface ESDeleteRequest extends IESRequest {
     }
 
     interface ESBulkResponse {

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/support/ESTemplate.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/support/ESTemplate.java
@@ -1,11 +1,11 @@
 package com.alibaba.otter.canal.client.adapter.es.core.support;
 
+import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig;
+import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig.ESMapping;
+
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
-
-import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig;
-import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig.ESMapping;
 
 public interface ESTemplate {
 
@@ -66,4 +66,23 @@ public interface ESTemplate {
 
     Object getESDataFromDmlData(ESMapping mapping, Map<String, Object> dmlData, Map<String, Object> dmlOld,
                                 Map<String, Object> esFieldData);
+
+    /**
+     * 获取es mapping中的属性类型
+     *
+     * @param mapping   mapping配置
+     * @param fieldName 属性名
+     * @return 类型
+     */
+    String getEsType(ESMapping mapping, String fieldName);
+
+    /**
+     * 获取es mapping中的子属性类型
+     *
+     * @param mapping           mapping配置
+     * @param fieldName         属性名
+     * @param childFieldName    子属性名
+     * @return 类型
+     */
+    String getEsType(ESMapping mapping, String fieldName, String childFieldName);
 }


### PR DESCRIPTION
改动点：
1、支持限制每次批量提交的字节大小 (通过esMapping.commitBatchSize配置)。
2、增强objFields对象字段, 可写子表sql, 无需强依赖group_concat函数, 避免受制于group_concat_max_len长度限制。支持类型有: 单字段数组(array)、JSON对象(object)、JSON对象数组(objectArray)、字符串拼接(joining)、扁平化(objectFlat)。

具体用法可参照以下配置
````
dataSourceKey: defaultDS
destination: example
groupId: g1
esMapping:
  _index: person
  _type: _doc
  _id: _id
  #pk: id

  #示例数据: {"id":"1","name":"刘一","age":"51","create_time":"2020-05-17T21:43:40+08:00","country_id":"1","relationshipIds":["1","2","3","4","5","6","7","8","9"],"friendNames":["陈二","张三2"],"country":{"id":"1","create_time":"2020-05-17T19:03:15+08:00","name":"中国"},"friends":[{"id":"2","name":"陈二"},{"id":"3","name":"张三2"}],"knowPersonNames":"郑十;吴九;周八;孙七;赵六;王五;李四;张三2;陈二","country_create_time":"2020-05-17T19:03:15+08:00","country_name":"中国"}

  sql: "select
          p._id, p._id as id, p._name as name, p._age as age, p._create_time as create_time, p._country_id as country_id, rst.relationshipIds
          from person p left join (select rs._person_id, group_concat(rs._id separator ';') as relationshipIds from person_relationship rs group by rs._person_id) rst on rst._person_id=p._id"

  # 对象字段
  objFields:
    # 是否并行查询, 开启并行时建议调大数据库连接数, 默认为false(不开启)
    parallel: false
    # 并行线程数, 默认为1
    threadSize: 1
    # 对象字段详情
    fields:

      friendNames:
        # 类型【必填】
        #   esMapping.objFields.fields.?.sql 非空情况下 支持 单字段数组(array)、JSON对象(object)、JSON对象数组(objectArray)、字符串拼接(joining)、扁平化(objectFlat)
        #   esMapping.objFields.fields.?.sql 为空情况下 支持 单字段数组(array)、JSON对象(object), 需要主表sql(esMapping.sql)中利用group_concat函数拼接好数组、对象JSON, 需注意调大mysql的group_concat_max_len配置
        type: array
        # 子表查询语句
        #   不支持 多表关联查询
        #   不支持 “select * ” 写法
        #   需对主表sql中任意一个或以上的字段进行关联查询, 可用“${?}”表达式引用主表字段(需保证值不为null), 如: where _fk = '${rid}'
        sql: "select _other_person_name from person_relationship where _relationship='朋友' and _person_id='${id}'"
        # 分隔符
        #   esMapping.objFields.fields.?.sql 非空情况下 esMapping.objFields.fields.?.type = joining 有效
        #   esMapping.objFields.fields.?.sql 为空情况下 esMapping.objFields.fields.?.type = array 有效
        separator:
        # 是否反向更新, 默认为true(当子表有数据变动时，也会同步更新到es中)
        reverseUpdate: true

      relationshipIds:
        type: array
        separator: ;

      country:
        type: object
        sql: "select c._id as id, c._create_time as create_time, c._name as name from country c where c._id='${country_id}'"

      friends:
        type: objectArray
        sql: "select _other_person_id as id, _other_person_name as name from person_relationship where _relationship='朋友' and _person_id='${id}'"

      knowPersonNames:
        type: joining
        sql: "select _other_person_name from person_relationship where _person_id='${id}' order by _other_person_id desc"
        separator: ;

      countryFlat:
        # 扁平化(objectFlat): 将该子表数据全部扁平化放入主表数据中, 而不作为某个对象字段存在, 适用场景: 子表数据无需反向更新主表es数据
        type: objectFlat
        sql: "select _create_time as country_create_time, _name as country_name from country where _id='${country_id}'"
        reverseUpdate: false


  # etl 的条件参数
  etlCondition: "where p._create_time >= {} and p._create_time <= {} order by p._id"
  # 提交批数量
  commitBatch: 1000
  # 提交批大小, 默认值为1M (1048576)
  commitBatchSize: 1048576 
````