### PR TITLE
Change maven repository to HTTPS

### DIFF
--- a/client-adapter/pom.xml
+++ b/client-adapter/pom.xml
@@ -50,7 +50,7 @@
     <repositories>
         <repository>
             <id>central</id>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -41,7 +41,7 @@
     <repositories>
         <repository>
             <id>central</id>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <repositories>
         <repository>
             <id>central</id>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
Maven Repository no longer support HTTP any more, we should use HTTPS, more detail:
https://support.sonatype.com/hc/en-us/articles/360041287334