### PR TITLE
hotfix/create-ddl-duplicate-apply

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/TableMetaCache.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/TableMetaCache.java
@@ -242,6 +242,10 @@ public class TableMetaCache {
         }
     }
 
+    public synchronized TableMeta find(String schema, String table) {
+        return tableMetaTSDB.find(schema, table);
+    }
+
     private String getFullName(String schema, String table) {
         StringBuilder builder = new StringBuilder();
         return builder.append('`')


### PR DESCRIPTION
正常MySQL `slave`回放执行 `CREATE IF NOT EXISTS xxx_table` 这样的SQL，如果`slave`中已经存在表，是与`master`执行效果一致，不会成功；所以`canal`中发现`table meta cache`已经存在，则应该忽略这样的ddl语句，但是ddl语句也会同步到kafka之类目标存储中。