### PR TITLE
扩展LogEventConvert中的字段过滤，支持只过滤真正发生变化的字段

### DIFF
--- a/deployer/src/main/resources/spring/default-instance.xml
+++ b/deployer/src/main/resources/spring/default-instance.xml
@@ -101,6 +101,7 @@
 		
 		<property name="fieldFilter" value="${canal.instance.filter.field}" />
 		<property name="fieldBlackFilter" value="${canal.instance.filter.black.field}" />
+		<property name="needOnlyChangedField" value="${canal.instance.filter.changed.field:false}" />
 
 		<!-- 最大事务解析大小，超过该大小后事务将被切分为多个事务投递 -->
 		<property name="transactionSize" value="${canal.instance.transaction.size:1024}" />

--- a/deployer/src/main/resources/spring/file-instance.xml
+++ b/deployer/src/main/resources/spring/file-instance.xml
@@ -87,6 +87,7 @@
 		
 		<property name="fieldFilter" value="${canal.instance.filter.field}" />
 		<property name="fieldBlackFilter" value="${canal.instance.filter.black.field}" />
+		<property name="needOnlyChangedField" value="${canal.instance.filter.changed.field:false}" />
 		
 		<!-- 最大事务解析大小，超过该大小后事务将被切分为多个事务投递 -->
 		<property name="transactionSize" value="${canal.instance.transaction.size:1024}" />

--- a/deployer/src/main/resources/spring/group-instance.xml
+++ b/deployer/src/main/resources/spring/group-instance.xml
@@ -93,6 +93,7 @@
 		
 		<property name="fieldFilter" value="${canal.instance.filter.field}" />
 		<property name="fieldBlackFilter" value="${canal.instance.filter.black.field}" />
+		<property name="needOnlyChangedField" value="${canal.instance.filter.changed.field:false}" />
 		
 		<!-- 最大事务解析大小，超过该大小后事务将被切分为多个事务投递 -->
 		<property name="transactionSize" value="${canal.instance.transaction.size:1024}" />

--- a/deployer/src/main/resources/spring/memory-instance.xml
+++ b/deployer/src/main/resources/spring/memory-instance.xml
@@ -84,6 +84,7 @@
 		
 		<property name="fieldFilter" value="${canal.instance.filter.field}" />
 		<property name="fieldBlackFilter" value="${canal.instance.filter.black.field}" />
+		<property name="needOnlyChangedField" value="${canal.instance.filter.changed.field:false}" />
 		
 		<!-- 最大事务解析大小，超过该大小后事务将被切分为多个事务投递 -->
 		<property name="transactionSize" value="${canal.instance.transaction.size:1024}" />

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/AbstractEventParser.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/AbstractEventParser.java
@@ -9,6 +9,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -60,7 +61,11 @@ public abstract class AbstractEventParser<EVENT> extends AbstractCanalLifeCycle 
     protected Map<String, List<String>> 			fieldFilterMap;
     protected String		  			  			fieldBlackFilter;
     protected Map<String, List<String>> 			fieldBlackFilterMap;
-    
+    // 是否只需要发生变化的字段
+    protected boolean                               needOnlyChangedField        = false;
+    // 无论是否变化，都必需的字段
+    protected Map<String, List<String>>             fieldNecessaryMap           = null;
+
     private CanalAlarmHandler                        alarmHandler               = null;
 
     // 统计参数
@@ -536,30 +541,42 @@ public abstract class AbstractEventParser<EVENT> extends AbstractCanalLifeCycle 
         }
         heartBeatTimerTask = null;
     }
-    
+
     /**
      * 解析字段过滤规则
      */
     private Map<String, List<String>> parseFieldFilterMap(String config) {
-    	
-    	Map<String, List<String>> map = new HashMap<String, List<String>>();
-		
-		if (StringUtils.isNotBlank(config)) {
-			for (String filter : config.split(",")) {
-				if (StringUtils.isBlank(filter)) {
-					continue;
-				}
-				
-				String[] filterConfig = filter.split(":");
-				if (filterConfig.length != 2) {
-					continue;
-				}
-				
-				map.put(filterConfig[0].trim().toUpperCase(), Arrays.asList(filterConfig[1].trim().toUpperCase().split("/")));
-			}
-		}
-		
-		return map;
+        return parseFieldFilterMap(config, (filterConfig, map) -> {
+            if (filterConfig.length >= 2) {
+                map.put(filterConfig[0].trim().toUpperCase(), Arrays.asList(filterConfig[1].trim().toUpperCase().split("/")));
+            }
+        });
+    }
+
+    /**
+     * 解析必需字段
+     */
+    private Map<String, List<String>> parseFieldNecessaryMap(String config) {
+        return parseFieldFilterMap(config, (filterConfig, map) -> {
+            //在旧格式上扩展
+            if (filterConfig.length >= 3) {
+                map.put(filterConfig[0].trim().toUpperCase(), Arrays.asList(filterConfig[2].trim().toUpperCase().split("/")));
+            }
+        });
+    }
+
+    private Map<String, List<String>> parseFieldFilterMap(String config, BiConsumer<String[], Map<String, List<String>>> consumer) {
+        Map<String, List<String>> map = new HashMap<String, List<String>>();
+        if (StringUtils.isNotBlank(config)) {
+            for (String filter : config.split(",")) {
+                if (StringUtils.isBlank(filter)) {
+                    continue;
+                }
+                String[] filterConfig = filter.split(":");
+                consumer.accept(filterConfig, map);
+            }
+        }
+        return map;
     }
 
     public void setEventFilter(CanalEventFilter eventFilter) {
@@ -695,7 +712,12 @@ public abstract class AbstractEventParser<EVENT> extends AbstractCanalLifeCycle 
 	public void setFieldFilter(String fieldFilter) {
 		this.fieldFilter = fieldFilter.trim();
 		this.fieldFilterMap = parseFieldFilterMap(fieldFilter);
+        this.fieldNecessaryMap = parseFieldNecessaryMap(fieldFilter);
 	}
+
+    public void setNeedOnlyChangedField(boolean needOnlyChangedField) {
+        this.needOnlyChangedField = needOnlyChangedField;
+    }
 	
 	public String getFieldBlackFilter() {
 		return fieldBlackFilter;
@@ -725,6 +747,15 @@ public abstract class AbstractEventParser<EVENT> extends AbstractCanalLifeCycle 
 	public Map<String, List<String>> getFieldBlackFilterMap() {
 		return fieldBlackFilterMap;
 	}
-	
+
+    /**
+     * 获取必须的表字段名单
+     *
+     * @return key:	schema.tableName
+     * value:	字段列表
+     */
+    public Map<String, List<String>> getFieldNecessaryMap() {
+        return fieldNecessaryMap;
+    }
 	
 }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/AbstractMysqlEventParser.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/AbstractMysqlEventParser.java
@@ -53,6 +53,8 @@ public abstract class AbstractMysqlEventParser extends AbstractEventParser {
         
         convert.setFieldFilterMap(getFieldFilterMap());
         convert.setFieldBlackFilterMap(getFieldBlackFilterMap());
+        convert.setNeedOnlyChangedField(needOnlyChangedField);
+        convert.setFieldNecessaryMap(getFieldNecessaryMap());
 
         convert.setCharset(connectionCharset);
         convert.setFilterQueryDcl(filterQueryDcl);

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvert.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvert.java
@@ -6,12 +6,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.sql.Types;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
+import com.alibaba.otter.canal.protocol.CanalEntry;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
@@ -62,7 +60,7 @@ import com.taobao.tddl.dbsync.binlog.event.mariadb.AnnotateRowsEvent;
 
 /**
  * 基于{@linkplain LogEvent}转化为Entry对象的处理
- * 
+ *
  * @author jianghang 2013-1-17 下午02:41:14
  * @version 1.0.0
  */
@@ -90,6 +88,10 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
     private volatile AviaterRegexFilter nameBlackFilter;
     private Map<String, List<String>> 	fieldFilterMap 		= new HashMap<String, List<String>>();
     private Map<String, List<String>> 	fieldBlackFilterMap = new HashMap<String, List<String>>();
+    // 必须字段（忽略fieldFilter）
+    private Map<String, List<String>> 	fieldNecessaryMap 		= new HashMap<String, List<String>>();
+    // 控制是否只关心filter字段发生变化，默认向前兼容-否
+    private boolean needOnlyChangedField;
 
     private TableMetaCache              tableMetaCache;
     private Charset                     charset             = Charset.defaultCharset();
@@ -540,13 +542,20 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
                     tableError |= parseOneRow(rowDataBuilder, event, buffer, columns, false, tableMeta);
                 } else {
                     // update需要处理before/after
+                    // after可以理解成老数据，before是新数据
                     tableError |= parseOneRow(rowDataBuilder, event, buffer, columns, false, tableMeta);
                     if (!buffer.nextOneRow(changeColumns, true)) {
                         rowChangeBuider.addRowDatas(rowDataBuilder.build());
                         break;
                     }
-
+                    // 解析发生变化的字段
                     tableError |= parseOneRow(rowDataBuilder, event, buffer, changeColumns, true, tableMeta);
+                    if (needOnlyChangedField) {
+                        boolean reallyChange = doFilterReallyChangeField(tableMeta, rowDataBuilder);
+                        if (!reallyChange) {
+                            continue;
+                        }
+                    }
                 }
 
                 rowsCount++;
@@ -564,6 +573,9 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
                 Entry entry = createEntry(header, EntryType.ROWDATA, ByteString.EMPTY);
                 logger.warn("table parser error : {}storeValue: {}", entry.toString(), rowChange.toString());
                 return null;
+            } else if(rowChangeBuider.getRowDatasCount() == 0) {
+                //这种情况没意义
+                return null;
             } else {
                 Entry entry = createEntry(header, EntryType.ROWDATA, rowChange.toByteString());
                 return entry;
@@ -571,6 +583,30 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
         } catch (Exception e) {
             throw new CanalParseException("parse row data failed.", e);
         }
+    }
+
+    private boolean doFilterReallyChangeField(TableMeta tableMeta, RowData.Builder rowDataBuilder) {
+        String schemaKey = tableMeta.getFullName().toUpperCase();
+        List<String> fieldNecessaryList = fieldNecessaryMap.containsKey(schemaKey) ?
+                fieldNecessaryMap.get(schemaKey) : Collections.emptyList();
+        List<Column> newAfterColumns = rowDataBuilder.getAfterColumnsList().stream()
+                //把必要字段也塞进来
+                .filter(item -> item.getUpdated() || fieldNecessaryList.contains(item.getName().toUpperCase()))
+                .collect(Collectors.toList());
+        Map<String, Column> beforeMap = rowDataBuilder.getBeforeColumnsList().stream()
+                .collect(Collectors.toMap(item -> item.getName(), item -> item));
+        List<Column> newBeforeColumns = newAfterColumns.stream()
+                .map(item-> beforeMap.get(item.getName()))
+                .collect(Collectors.toList());
+        rowDataBuilder.clearAfterColumns();
+        rowDataBuilder.clearBeforeColumns();
+        if (!newAfterColumns.isEmpty() && newAfterColumns.size() > fieldNecessaryList.size()) {
+            //如果仅仅只有必要字段，说明filterField中都没变
+            rowDataBuilder.addAllAfterColumns(newAfterColumns);
+            rowDataBuilder.addAllBeforeColumns(newBeforeColumns);
+            return true;
+        }
+        return false;
     }
 
     private EntryPosition createPosition(LogHeader logHeader) {
@@ -591,12 +627,14 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
         //获取字段过滤条件
         List<String> fieldList = null;
         List<String> blackFieldList = null;
-        
+        List<String> fieldNecessaryList = null;
+
         if (tableMeta != null) {
         	fieldList = fieldFilterMap.get(tableMeta.getFullName().toUpperCase());
         	blackFieldList = fieldBlackFilterMap.get(tableMeta.getFullName().toUpperCase());
+            fieldNecessaryList = fieldNecessaryMap.get(tableMeta.getFullName().toUpperCase());
         }
-        
+
         if (tableMeta != null && columnInfo.length > tableMeta.getFields().size()) {
             if (tableMetaCache.isOnRDS()) {
                 // 特殊处理下RDS的场景
@@ -663,7 +701,7 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
                 columnBuilder.setSqlType(Types.BIGINT);
                 columnBuilder.setUpdated(false);
 
-                if (needField(fieldList, blackFieldList, columnBuilder.getName())) {
+                if (needField(fieldNecessaryList, fieldList, blackFieldList, columnBuilder.getName())) {
                 	if (isAfter) {
                         rowDataBuilder.addAfterColumns(columnBuilder.build());
                     } else {
@@ -831,11 +869,13 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
 
             columnBuilder.setSqlType(javaType);
             // 设置是否update的标记位
-            columnBuilder.setUpdated(isAfter
-                                     && isUpdate(rowDataBuilder.getBeforeColumnsList(),
-                                         columnBuilder.getIsNull() ? null : columnBuilder.getValue(),
-                                         i));
-            if (needField(fieldList, blackFieldList, columnBuilder.getName())) {
+            boolean isUpdated = isAfter
+                    && isUpdate(rowDataBuilder.getBeforeColumnsList(),
+                    columnBuilder.getIsNull() ? null : columnBuilder.getValue(),
+                    i);
+            columnBuilder.setUpdated(isUpdated);
+
+            if (needField(fieldNecessaryList, fieldList, blackFieldList, columnBuilder.getName())) {
             	if (isAfter) {
                     rowDataBuilder.addAfterColumns(columnBuilder.build());
                 } else {
@@ -975,11 +1015,14 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
     private boolean isRDSHeartBeat(String schema, String table) {
         return "mysql".equalsIgnoreCase(schema) && "ha_health_check".equalsIgnoreCase(table);
     }
-    
+
     /**
      * 字段过滤判断
      */
-    private boolean needField(List<String> fieldList, List<String> blackFieldList, String columnName) {
+    private boolean needField(List<String> fieldNecessaryList, List<String> fieldList, List<String> blackFieldList, String columnName) {
+        if (fieldNecessaryList != null && fieldNecessaryList.contains(columnName.toUpperCase())) {
+            return true;
+        }
     	if (fieldList == null || fieldList.isEmpty()) {
     		return blackFieldList == null || blackFieldList.isEmpty() || !blackFieldList.contains(columnName.toUpperCase());
     	} else {
@@ -1027,31 +1070,46 @@ public class LogEventConvert extends AbstractCanalLifeCycle implements BinlogPar
         this.nameBlackFilter = nameBlackFilter;
         logger.warn("--> init table black filter : " + nameBlackFilter.toString());
     }
-    
+
+    public void setNeedOnlyChangedField(boolean needOnlyChangedField) {
+        this.needOnlyChangedField = needOnlyChangedField;
+        logger.warn("--> init table field filter switch : " + needOnlyChangedField);
+    }
+
     public void setFieldFilterMap(Map<String, List<String>> fieldFilterMap) {
     	if (fieldFilterMap != null) {
     		this.fieldFilterMap = fieldFilterMap;
     	} else {
     		this.fieldFilterMap = new HashMap<String, List<String>>();
     	}
-		
-		
+
 		for (Map.Entry<String, List<String>> entry : this.fieldFilterMap.entrySet()) {
 			logger.warn("--> init field filter : " + entry.getKey() + "->" + entry.getValue());
 		}
 	}
-    
+
     public void setFieldBlackFilterMap(Map<String, List<String>> fieldBlackFilterMap) {
 		if (fieldBlackFilterMap != null) {
     		this.fieldBlackFilterMap = fieldBlackFilterMap;
     	} else {
     		this.fieldBlackFilterMap = new HashMap<String, List<String>>();
     	}
-		
+
 		for (Map.Entry<String, List<String>> entry : this.fieldBlackFilterMap.entrySet()) {
 			logger.warn("--> init field black filter : " + entry.getKey() + "->" + entry.getValue());
 		}
 	}
+
+    public void setFieldNecessaryMap(Map<String, List<String>> fieldNecessaryMap) {
+        if (fieldNecessaryMap != null) {
+            this.fieldNecessaryMap = fieldNecessaryMap;
+        }else {
+            this.fieldNecessaryMap = new HashMap<String, List<String>>();;
+        }
+        for (Map.Entry<String, List<String>> entry : this.fieldNecessaryMap.entrySet()) {
+            logger.warn("--> init field necessary : " + entry.getKey() + "->" + entry.getValue());
+        }
+    }
 
     public void setTableMetaCache(TableMetaCache tableMetaCache) {
         this.tableMetaCache = tableMetaCache;

--- a/server/src/main/java/com/alibaba/otter/canal/kafka/CanalKafkaProducer.java
+++ b/server/src/main/java/com/alibaba/otter/canal/kafka/CanalKafkaProducer.java
@@ -207,7 +207,7 @@ public class CanalKafkaProducer implements CanalMQProducer {
             // 批量刷出
             producerTmp.flush();
 
-            // flush操作也有可能是发送失败,这里需要异步关注一下发送结果,针对有异常的直接出发rollback
+            // flush操作也有可能是发送失败,这里需要异步关注一下发送结果,针对有异常的直接触发rollback
             for (Future future : futures) {
                 try {
                     future.get();


### PR DESCRIPTION
扩展这个fieldFilter的PR https://github.com/alibaba/canal/pull/1914

它仅支持当一张表的任意字段发生变更，即便不在过滤字段内，也会sink、store到后续的流程中。

扩展后，对外暴露配置有如下变更
```
# 增强已有的字段过滤--在后面新增一个`:`，可以自行指定的必要字段（同样也是`/`分隔）
canal.instance.filter.field=dbName.tableName:column4/column5:column2/column3
# 新增配置，控制是否只关心filter字段的变化，不配置时默认false，向前兼容
canal.instance.filter.changed.field=true
```

这样后续对增量数据的处理有更好的灵活性和准确性。