### PR TITLE
Mongodb changestream support

### DIFF
--- a/admin/admin-web/src/main/resources/canal-template.properties
+++ b/admin/admin-web/src/main/resources/canal-template.properties
@@ -109,6 +109,7 @@ canal.instance.global.manager.address = ${canal.admin.manager}
 #canal.instance.global.spring.xml = classpath:spring/memory-instance.xml
 canal.instance.global.spring.xml = classpath:spring/file-instance.xml
 #canal.instance.global.spring.xml = classpath:spring/default-instance.xml
+#canal.instance.global.spring.xml = classpath:spring/mongo-instance.xml
 
 ##################################################
 ######### 		     MQ 		     #############

--- a/admin/admin-web/src/main/resources/instance-template.properties
+++ b/admin/admin-web/src/main/resources/instance-template.properties
@@ -17,6 +17,10 @@ canal.instance.rds.accesskey=
 canal.instance.rds.secretkey=
 canal.instance.rds.instanceId=
 
+# mongo position info
+#canal.instance.mongodb.hosts=127.0.0.1:27017,127.0.0.1:27018
+#canal.instance.mongodb.timestamp=
+
 # table meta tsdb info
 canal.instance.tsdb.enable=true
 #canal.instance.tsdb.url=jdbc:mysql://127.0.0.1:3306/canal_tsdb

--- a/deployer/src/main/resources/canal.properties
+++ b/deployer/src/main/resources/canal.properties
@@ -105,6 +105,7 @@ canal.instance.global.manager.address = ${canal.admin.manager}
 #canal.instance.global.spring.xml = classpath:spring/memory-instance.xml
 canal.instance.global.spring.xml = classpath:spring/file-instance.xml
 #canal.instance.global.spring.xml = classpath:spring/default-instance.xml
+#canal.instance.global.spring.xml = classpath:spring/mongo-instance.xml
 
 ##################################################
 ######### 	      MQ Properties      #############

--- a/deployer/src/main/resources/example/instance.properties
+++ b/deployer/src/main/resources/example/instance.properties
@@ -12,6 +12,11 @@ canal.instance.master.position=
 canal.instance.master.timestamp=
 canal.instance.master.gtid=
 
+
+# mongo position info
+#canal.instance.mongodb.hosts=127.0.0.1:27017
+#canal.instance.mongodb.timestamp=
+
 # rds oss binlog
 canal.instance.rds.accesskey=
 canal.instance.rds.secretkey=

--- a/deployer/src/main/resources/spring/mongo-instance.xml
+++ b/deployer/src/main/resources/spring/mongo-instance.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
+	xmlns:aop="http://www.springframework.org/schema/aop" xmlns:lang="http://www.springframework.org/schema/lang"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
+           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.0.xsd
+           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.0.xsd
+           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+	default-autowire="byName">
+
+	<import resource="classpath:spring/base-instance.xml" />
+
+	<bean id="instance" class="com.alibaba.otter.canal.instance.spring.CanalInstanceWithSpring">
+		<property name="destination" value="${canal.instance.destination}" />
+		<property name="eventParser">
+			<ref local="eventParser" />
+		</property>
+		<property name="eventSink">
+			<ref local="eventSink" />
+		</property>
+		<property name="eventStore">
+			<ref local="eventStore" />
+		</property>
+		<property name="metaManager">
+			<ref local="metaManager" />
+		</property>
+		<property name="alarmHandler">
+			<ref local="alarmHandler" />
+		</property>
+        <property name="mqConfig">
+            <ref local="mqConfig" />
+        </property>
+	</bean>
+
+	<!-- 报警处理类 -->
+	<bean id="alarmHandler" class="com.alibaba.otter.canal.common.alarm.LogAlarmHandler" />
+
+	<bean id="zkClientx" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean" >
+		<property name="targetClass" value="com.alibaba.otter.canal.common.zookeeper.ZkClientx" />
+		<property name="targetMethod" value="getZkClient" />
+		<property name="arguments">
+			<list>
+				<value>${canal.zkServers:127.0.0.1:2181}</value>
+			</list>
+		</property>
+	</bean>
+
+	<bean id="metaManager" class="com.alibaba.otter.canal.meta.PeriodMixedMetaManager">
+		<property name="zooKeeperMetaManager">
+			<bean class="com.alibaba.otter.canal.meta.ZooKeeperMetaManager">
+				<property name="zkClientx" ref="zkClientx" />
+			</bean>
+		</property>
+		<property name="period" value="${canal.zookeeper.flush.period:1000}" />
+	</bean>
+
+	<bean id="eventStore" class="com.alibaba.otter.canal.store.memory.MemoryEventStoreWithBuffer">
+		<property name="bufferSize" value="${canal.instance.memory.buffer.size:16384}" />
+		<property name="bufferMemUnit" value="${canal.instance.memory.buffer.memunit:1024}" />
+		<property name="batchMode" value="${canal.instance.memory.batch.mode:MEMSIZE}" />
+		<property name="ddlIsolation" value="${canal.instance.get.ddl.isolation:false}" />
+		<property name="raw" value="${canal.instance.memory.rawEntry:true}" />
+	</bean>
+
+	<bean id="eventSink" class="com.alibaba.otter.canal.sink.entry.EntryEventSink">
+		<property name="eventStore" ref="eventStore" />
+		<property name="filterTransactionEntry" value="${canal.instance.filter.transaction.entry:false}"/>
+	</bean>
+
+	<bean id="eventParser" class="com.alibaba.otter.canal.parse.inbound.mongodb.MongoEventParser" >
+		<property name="destination" value="${canal.instance.destination}" />
+
+		<property name="alarmHandler" ref="alarmHandler" />
+
+		<!-- 解析过滤处理 -->
+		<property name="eventFilter">
+			<bean class="com.alibaba.otter.canal.filter.aviater.AviaterRegexFilter" >
+				<constructor-arg index="0" value="${canal.instance.filter.regex:.*\..*}" />
+			</bean>
+		</property>
+
+		<property name="eventBlackFilter">
+			<bean class="com.alibaba.otter.canal.filter.aviater.AviaterRegexFilter" >
+				<constructor-arg index="0" value="${canal.instance.filter.black.regex:}" />
+				<constructor-arg index="1" value="false" />
+			</bean>
+		</property>
+		
+		<property name="fieldFilter" value="${canal.instance.filter.field}" />
+		<property name="fieldBlackFilter" value="${canal.instance.filter.black.field}" />
+
+		<!-- 解析位点记录 -->
+		<property name="logPositionManager">
+			<bean class="com.alibaba.otter.canal.parse.index.FailbackLogPositionManager">
+				<constructor-arg>
+					<bean class="com.alibaba.otter.canal.parse.index.MemoryLogPositionManager" />
+				</constructor-arg>
+				<constructor-arg>
+					<bean class="com.alibaba.otter.canal.parse.index.MetaLogPositionManager">
+						<constructor-arg ref="metaManager"/>
+					</bean>
+				</constructor-arg>
+			</bean>
+		</property>
+
+		<!-- 解析数据库信息 -->
+		<property name="authenticationInfo">
+			<bean class="com.alibaba.otter.canal.parse.inbound.mongodb.MongoAuthenticationInfo">
+				<constructor-arg index="0" value="${canal.instance.mongodb.hosts}" />
+				<constructor-arg index="1" value="${canal.instance.dbUsername:retl}" />
+				<constructor-arg index="2" value="${canal.instance.dbPassword:retl}" />
+				<constructor-arg index="3" value="${canal.instance.defaultDatabaseName:admin}" />
+			</bean>
+		</property>
+
+		<!-- 解析起始位点 -->
+		<property name="specifiedPosition">
+			<bean class="com.alibaba.otter.canal.protocol.position.EntryPosition">
+				<property name="journalName" value="oplog.rs" />
+				<property name="position" value="${canal.instance.mongodb.position}" />
+				<property name="timestamp" value="${canal.instance.mongodb.timestamp}" />
+			</bean>
+		</property>
+
+		<!-- parallel parser -->
+		<property name="parallel" value="${canal.instance.parser.parallel:true}" />
+		<property name="parallelThreadSize" value="${canal.instance.parser.parallelThreadSize}" />
+		<property name="parallelBufferSize" value="${canal.instance.parser.parallelBufferSize:256}" />
+	</bean>
+
+	<bean id="mqConfig" class="com.alibaba.otter.canal.instance.core.CanalMQConfig">
+		<property name="topic" value="${canal.mq.topic}" />
+		<property name="dynamicTopic" value="${canal.mq.dynamicTopic}" />
+		<property name="partition" value="${canal.mq.partition}" />
+		<property name="partitionsNum" value="${canal.mq.partitionsNum}" />
+		<property name="partitionHash" value="${canal.mq.partitionHash}" />
+	</bean>
+</beans>

--- a/deployer/src/main/resources/spring/mongo-instance.xml
+++ b/deployer/src/main/resources/spring/mongo-instance.xml
@@ -62,6 +62,7 @@
 		<property name="batchMode" value="${canal.instance.memory.batch.mode:MEMSIZE}" />
 		<property name="ddlIsolation" value="${canal.instance.get.ddl.isolation:false}" />
 		<property name="raw" value="${canal.instance.memory.rawEntry:true}" />
+		<property name="ignoredTxn" value="true" />
 	</bean>
 
 	<bean id="eventSink" class="com.alibaba.otter.canal.sink.entry.EntryEventSink">

--- a/deployer/src/main/resources/spring/mongo-memory-instance.xml
+++ b/deployer/src/main/resources/spring/mongo-memory-instance.xml
@@ -45,6 +45,7 @@
 		<property name="batchMode" value="${canal.instance.memory.batch.mode:MEMSIZE}" />
 		<property name="ddlIsolation" value="${canal.instance.get.ddl.isolation:false}" />
 		<property name="raw" value="${canal.instance.memory.rawEntry:true}" />
+		<property name="ignoredTxn" value="true" />
 	</bean>
 
 	<bean id="eventSink" class="com.alibaba.otter.canal.sink.entry.EntryEventSink">

--- a/deployer/src/main/resources/spring/mongo-memory-instance.xml
+++ b/deployer/src/main/resources/spring/mongo-memory-instance.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
+	xmlns:aop="http://www.springframework.org/schema/aop" xmlns:lang="http://www.springframework.org/schema/lang"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
+           http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.0.xsd
+           http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.0.xsd
+           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd"
+	default-autowire="byName">
+
+	<import resource="classpath:spring/base-instance.xml" />
+
+	<bean id="instance" class="com.alibaba.otter.canal.instance.spring.CanalInstanceWithSpring">
+		<property name="destination" value="${canal.instance.destination}" />
+		<property name="eventParser">
+			<ref local="eventParser" />
+		</property>
+		<property name="eventSink">
+			<ref local="eventSink" />
+		</property>
+		<property name="eventStore">
+			<ref local="eventStore" />
+		</property>
+		<property name="metaManager">
+			<ref local="metaManager" />
+		</property>
+		<property name="alarmHandler">
+			<ref local="alarmHandler" />
+		</property>
+        <property name="mqConfig">
+            <ref local="mqConfig" />
+        </property>
+	</bean>
+
+	<!-- 报警处理类 -->
+	<bean id="alarmHandler" class="com.alibaba.otter.canal.common.alarm.LogAlarmHandler" />
+
+	<bean id="metaManager" class="com.alibaba.otter.canal.meta.MemoryMetaManager" />
+
+	<bean id="eventStore" class="com.alibaba.otter.canal.store.memory.MemoryEventStoreWithBuffer">
+		<property name="bufferSize" value="${canal.instance.memory.buffer.size:16384}" />
+		<property name="bufferMemUnit" value="${canal.instance.memory.buffer.memunit:1024}" />
+		<property name="batchMode" value="${canal.instance.memory.batch.mode:MEMSIZE}" />
+		<property name="ddlIsolation" value="${canal.instance.get.ddl.isolation:false}" />
+		<property name="raw" value="${canal.instance.memory.rawEntry:true}" />
+	</bean>
+
+	<bean id="eventSink" class="com.alibaba.otter.canal.sink.entry.EntryEventSink">
+		<property name="eventStore" ref="eventStore" />
+		<property name="filterTransactionEntry" value="${canal.instance.filter.transaction.entry:false}"/>
+	</bean>
+
+	<bean id="eventParser" class="com.alibaba.otter.canal.parse.inbound.mongodb.MongoEventParser" >
+		<property name="destination" value="${canal.instance.destination}" />
+
+		<property name="alarmHandler" ref="alarmHandler" />
+
+		<!-- 解析过滤处理 -->
+		<property name="eventFilter">
+			<bean class="com.alibaba.otter.canal.filter.aviater.AviaterRegexFilter" >
+				<constructor-arg index="0" value="${canal.instance.filter.regex:.*\..*}" />
+			</bean>
+		</property>
+
+		<property name="eventBlackFilter">
+			<bean class="com.alibaba.otter.canal.filter.aviater.AviaterRegexFilter" >
+				<constructor-arg index="0" value="${canal.instance.filter.black.regex:}" />
+				<constructor-arg index="1" value="false" />
+			</bean>
+		</property>
+
+		<property name="fieldFilter" value="${canal.instance.filter.field}" />
+		<property name="fieldBlackFilter" value="${canal.instance.filter.black.field}" />
+
+		<!-- 解析位点记录 -->
+		<property name="logPositionManager">
+			<bean class="com.alibaba.otter.canal.parse.index.MemoryLogPositionManager" />
+		</property>
+
+		<!-- 解析数据库信息 -->
+		<property name="authenticationInfo">
+			<bean class="com.alibaba.otter.canal.parse.inbound.mongodb.MongoAuthenticationInfo">
+				<constructor-arg index="0" value="${canal.instance.mongodb.hosts}" />
+				<constructor-arg index="1" value="${canal.instance.dbUsername:retl}" />
+				<constructor-arg index="2" value="${canal.instance.dbPassword:retl}" />
+				<constructor-arg index="3" value="${canal.instance.defaultDatabaseName:admin}" />
+			</bean>
+		</property>
+
+		<!-- 解析起始位点 -->
+		<property name="specifiedPosition">
+			<bean class="com.alibaba.otter.canal.protocol.position.EntryPosition">
+				<property name="journalName" value="oplog.rs" />
+				<property name="position" value="${canal.instance.mongodb.position}" />
+				<property name="timestamp" value="${canal.instance.mongodb.timestamp}" />
+			</bean>
+		</property>
+
+		<!-- parallel parser -->
+		<property name="parallel" value="${canal.instance.parser.parallel:true}" />
+		<property name="parallelThreadSize" value="${canal.instance.parser.parallelThreadSize}" />
+		<property name="parallelBufferSize" value="${canal.instance.parser.parallelBufferSize:256}" />
+	</bean>
+
+	<bean id="mqConfig" class="com.alibaba.otter.canal.instance.core.CanalMQConfig">
+		<property name="topic" value="${canal.mq.topic}" />
+		<property name="dynamicTopic" value="${canal.mq.dynamicTopic}" />
+		<property name="partition" value="${canal.mq.partition}" />
+		<property name="partitionsNum" value="${canal.mq.partitionsNum}" />
+		<property name="partitionHash" value="${canal.mq.partitionHash}" />
+	</bean>
+</beans>

--- a/filter/src/main/java/com/alibaba/otter/canal/filter/aviater/AviaterRegexFilter.java
+++ b/filter/src/main/java/com/alibaba/otter/canal/filter/aviater/AviaterRegexFilter.java
@@ -125,6 +125,10 @@ public class AviaterRegexFilter implements CanalEventFilter<String> {
         return result;
     }
 
+    public String getPattern() {
+        return pattern;
+    }
+
     @Override
     public String toString() {
         return pattern;

--- a/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/model/CanalParameter.java
+++ b/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/model/CanalParameter.java
@@ -236,6 +236,8 @@ public class CanalParameter implements Serializable {
         LOCALBINLOG,
         /** oracle DB */
         ORACLE,
+        /** mongo DB */
+        MONGODB,
         /** 多库合并模式 */
         GROUP;
 
@@ -249,6 +251,10 @@ public class CanalParameter implements Serializable {
 
         public boolean isOracle() {
             return this.equals(SourcingType.ORACLE);
+        }
+
+        public boolean isMongoDB() {
+            return this.equals(SourcingType.MONGODB);
         }
 
         public boolean isGroup() {

--- a/parse/pom.xml
+++ b/parse/pom.xml
@@ -66,6 +66,10 @@
 			<artifactId>h2</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 		</dependency>

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/EntrySinkDelegate.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/EntrySinkDelegate.java
@@ -1,0 +1,9 @@
+package com.alibaba.otter.canal.parse.inbound.mongodb;
+
+import com.alibaba.otter.canal.protocol.CanalEntry;
+
+import java.util.List;
+
+public interface EntrySinkDelegate {
+    void sink(List<CanalEntry.Entry> entries) throws InterruptedException;
+}

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/MongoAuthenticationInfo.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/MongoAuthenticationInfo.java
@@ -1,0 +1,51 @@
+package com.alibaba.otter.canal.parse.inbound.mongodb;
+
+import com.mongodb.ConnectionString;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+public class MongoAuthenticationInfo {
+
+    private final String hosts;
+
+    private final String username;
+
+    private final String password;
+
+    private final String defaultDatabaseName;
+
+    private final ConnectionString connectionString;
+
+    private final static String URL_TEMPLATE = "mongodb://%s:%s@%s/%s";
+
+    public MongoAuthenticationInfo(String hosts, String username, String password){
+        this(hosts, username, password, "admin");
+    }
+
+    public MongoAuthenticationInfo(String hosts, String username, String password, String defaultDatabaseName){
+        this.hosts = hosts;
+        this.username = username;
+        this.password = password;
+        this.defaultDatabaseName = defaultDatabaseName;
+        this.connectionString = new ConnectionString(String.format(URL_TEMPLATE, username, password, hosts, defaultDatabaseName));
+    }
+
+    public List<String> getHosts() {
+        return this.connectionString.getHosts();
+    }
+
+    public String getDatabase() {
+        return this.connectionString.getDatabase();
+    }
+
+    public ConnectionString getConnectionString() {
+        return connectionString;
+    }
+
+    public InetSocketAddress getPrimaryINetSocketAddresses() {
+        String[] hostChunk = getHosts().get(0).split(":");
+        return new InetSocketAddress(hostChunk[0], Integer.parseInt(hostChunk[1]));
+    }
+
+}

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/MongoConnection.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/MongoConnection.java
@@ -80,15 +80,14 @@ public class MongoConnection {
                                  builder.connectTimeout(connTimeout, TimeUnit.MILLISECONDS)
                                         .readTimeout(soTimeout, TimeUnit.MILLISECONDS);
                             }
-                        })
-                        .build();
+                        }).build();
 
                 this.mongoClient = MongoClients.create(settings);
 
                 ClusterType clusterType;
                 boolean detected = false;
                 for (int retryTimes = 0; retryTimes < detectingRetryTimes; retryTimes++) {
-                  clusterType = this.mongoClient.getClusterDescription().getType();
+                    clusterType = this.mongoClient.getClusterDescription().getType();
                     switch (clusterType) {
                         case UNKNOWN:
                             //返回unknown表示集群正在连接中，过1s后重试
@@ -127,7 +126,6 @@ public class MongoConnection {
 
     public void disconnect() throws IOException {
         if (connected.compareAndSet(true, false)) {
-
             try {
                 // 等待订阅结束
                 subscribingLock.tryLock(3000, TimeUnit.MILLISECONDS);

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/MongoConnection.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/MongoConnection.java
@@ -1,0 +1,242 @@
+package com.alibaba.otter.canal.parse.inbound.mongodb;
+
+import com.alibaba.otter.canal.common.CanalException;
+import com.alibaba.otter.canal.parse.inbound.SinkFunction;
+import com.alibaba.otter.canal.parse.inbound.mongodb.dbsync.BsonConverter;
+import com.alibaba.otter.canal.parse.inbound.mongodb.dbsync.ChangeStreamEvent;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.mongodb.Block;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.ReadPreference;
+import com.mongodb.client.MongoChangeStreamCursor;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ClusterType;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.SocketSettings;
+import org.bson.BsonTimestamp;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+
+/**
+ * Mongo Connection
+ *
+ * @author jiabao.sun 2020-07-13 15:23:57
+ * @version 1.0.0
+ */
+public class MongoConnection {
+
+    private   static final  Logger                       logger        = LoggerFactory.getLogger(MongoConnection.class);
+
+    private   static final  long                         detectingRetryTimes = 6;
+
+    private                 AtomicBoolean                connected     = new AtomicBoolean(false);
+
+    private   final         MongoAuthenticationInfo      authenticationInfo;
+    private   volatile      MongoClient                  mongoClient;
+
+    protected               int                          connTimeout   = 5 * 1000;           // 5秒
+    protected               int                          soTimeout     = 60 * 60 * 1000;     // 1小时
+
+    private                 String                       eventRegex;
+    private                 String                       eventBlackRegex;
+
+    private                 AtomicLong                   receivedEventCount;
+
+    private                 Lock                         subscribingLock = new ReentrantLock();
+
+    public MongoConnection(MongoAuthenticationInfo authenticationInfo){
+        Assert.notNull(authenticationInfo, "authentication info can not be null;");
+        this.authenticationInfo = authenticationInfo;
+    }
+
+    public void connect() throws IOException {
+        if (connected.compareAndSet(false, true)) {
+            try {
+
+                MongoClientSettings settings = MongoClientSettings.builder()
+                        .applyConnectionString(authenticationInfo.getConnectionString())
+                        .applyToSocketSettings(new Block<SocketSettings.Builder>() {
+                            public void apply(SocketSettings.Builder builder) {
+                                 builder.connectTimeout(connTimeout, TimeUnit.MILLISECONDS)
+                                        .readTimeout(soTimeout, TimeUnit.MILLISECONDS);
+                            }
+                        })
+                        .build();
+
+                this.mongoClient = MongoClients.create(settings);
+
+                ClusterType clusterType;
+                boolean detected = false;
+                for (int retryTimes = 0; retryTimes < detectingRetryTimes; retryTimes++) {
+                  clusterType = this.mongoClient.getClusterDescription().getType();
+                    switch (clusterType) {
+                        case UNKNOWN:
+                            //返回unknown表示集群正在连接中，过1s后重试
+                            logger.info("detecting cluster type...");
+                            Thread.sleep(500L);
+                            break;
+                        case REPLICA_SET:    //Change streams are available for replica sets and sharded clusters:
+                        case SHARDED:
+                            detected = true;
+                            break;
+                        case STANDALONE:
+                        default:
+                            throw new IllegalStateException("unsupported cluster type of " + clusterType);
+                    }
+
+                    if (detected) {
+                        logger.info("mongo client connected");
+                        return;
+                    } else if (retryTimes >= detectingRetryTimes - 1) {
+                        throw new IllegalStateException("detecting cluster type failed");
+                    }
+                }
+            } catch (Exception e) {
+                disconnect();
+                throw new IOException("connect to mongodb failed", e);
+            }
+        } else {
+            logger.error("the mongo client {} can't be connected twice.", authenticationInfo.getHosts());
+        }
+    }
+
+    public void reconnect() throws IOException {
+        disconnect();
+        connect();
+    }
+
+    public void disconnect() throws IOException {
+        if (connected.compareAndSet(true, false)) {
+
+            try {
+                // 等待订阅结束
+                subscribingLock.tryLock(3000, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                logger.error("waiting for change stream closed failed", e);
+            } finally {
+                subscribingLock.unlock();
+            }
+
+            try {
+                if (mongoClient != null) {
+                    mongoClient.close();
+                    mongoClient = null;
+                }
+                logger.info("disConnect mongo client of {}...", authenticationInfo.getHosts());
+            } catch (Exception e) {
+                throw new IOException("disconnect mongo client failure", e);
+            }
+        } else {
+            logger.info("the mongo client of {} is not connected", authenticationInfo.getHosts());
+        }
+    }
+
+    public ServerDescription getPrimary() {
+        checkConnected();
+
+        ClusterDescription clusterDesc = this.mongoClient.getClusterDescription();
+        List<ServerDescription> primaries = ReadPreference.primary().choose(clusterDesc);
+        if (CollectionUtils.isEmpty(primaries)) {
+            throw new IllegalStateException("get primary failed, no primary server");
+        }
+
+        return primaries.get(0);
+    }
+
+    public void dump(long timestamp, SinkFunction<ChangeStreamEvent> func) {
+        dump(BsonConverter.convertTime(timestamp), func);
+    }
+
+    public void dump(BsonTimestamp bsonTimestamp, SinkFunction<ChangeStreamEvent> func) {
+        doDump(bsonTimestamp, func);
+    }
+
+    private void doDump(BsonTimestamp bsonTimestamp, SinkFunction<ChangeStreamEvent> func) {
+        checkConnected();
+
+        if(subscribingLock.tryLock()) {
+            try (MongoChangeStreamCursor<ChangeStreamDocument<Document>> changeCursor = openChangeStream(bsonTimestamp)) {
+                while (changeCursor.hasNext() && connected.get()) {
+                    if (!func.sink(ChangeStreamEvent.from(changeCursor.next()))) {
+                        logger.warn("sink failed, close change stream");
+                        break;
+                    }
+                    accumulateReceivedCount();
+                }
+            } catch (Throwable e) {
+                throw new CanalException("watch change stream failed", e);
+            } finally {
+                subscribingLock.unlock();
+            }
+        } else {
+            logger.error("the change stream can not opening twice.", authenticationInfo.getHosts());
+        }
+    }
+
+    private MongoChangeStreamCursor<ChangeStreamDocument<Document>> openChangeStream(BsonTimestamp startAtOperationTime) {
+        List<Bson> pipeline = Lists.newArrayList(Aggregates.addFields(new Field<>("schemeTable"
+                        , new Document("$concat", Lists.newArrayList("$ns.db", ".", "$ns.coll")))));
+
+        List<Bson> filters = Lists.newArrayList();
+        if (!Strings.isNullOrEmpty(eventRegex)) {
+            filters.add(Filters.regex("schemeTable", eventRegex));
+        }
+
+        if (!Strings.isNullOrEmpty(eventBlackRegex)) {
+            filters.add(Filters.not(Filters.regex("schemeTable", eventBlackRegex)));
+        }
+
+        if (!filters.isEmpty()) {
+            pipeline.add(Aggregates.match(Filters.and(filters)));
+        }
+
+        return mongoClient.watch(pipeline)
+                .startAtOperationTime(startAtOperationTime)
+                .cursor();
+    }
+
+    private void checkConnected() {
+        if (!connected.get()) {
+            throw new IllegalStateException("operation failed, the mongo client is not connected");
+        }
+    }
+
+    private void accumulateReceivedCount() {
+        if (receivedEventCount != null) {
+            receivedEventCount.addAndGet(1);
+        }
+    }
+
+    public void setEventRegex(String eventRegex) {
+        this.eventRegex = eventRegex;
+    }
+
+    public void setEventBlackRegex(String eventBlackRegex) {
+        this.eventBlackRegex = eventBlackRegex;
+    }
+
+    public void setReceivedEventCount(AtomicLong receivedEventCount) {
+        this.receivedEventCount = receivedEventCount;
+    }
+
+}

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/MongoEventParser.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/MongoEventParser.java
@@ -1,0 +1,658 @@
+package com.alibaba.otter.canal.parse.inbound.mongodb;
+
+import com.alibaba.otter.canal.common.AbstractCanalLifeCycle;
+import com.alibaba.otter.canal.common.alarm.CanalAlarmHandler;
+import com.alibaba.otter.canal.common.utils.JsonUtils;
+import com.alibaba.otter.canal.filter.aviater.AviaterRegexFilter;
+import com.alibaba.otter.canal.parse.CanalEventParser;
+import com.alibaba.otter.canal.parse.exception.CanalParseException;
+import com.alibaba.otter.canal.parse.exception.PositionNotFoundException;
+import com.alibaba.otter.canal.parse.inbound.ParserExceptionHandler;
+import com.alibaba.otter.canal.parse.inbound.SinkFunction;
+import com.alibaba.otter.canal.parse.inbound.mongodb.dbsync.ChangeStreamEvent;
+import com.alibaba.otter.canal.parse.inbound.mongodb.dbsync.ChangeStreamEventConverter;
+import com.alibaba.otter.canal.parse.index.CanalLogPositionManager;
+import com.alibaba.otter.canal.protocol.CanalEntry;
+import com.alibaba.otter.canal.protocol.position.EntryPosition;
+import com.alibaba.otter.canal.protocol.position.LogIdentity;
+import com.alibaba.otter.canal.protocol.position.LogPosition;
+import com.alibaba.otter.canal.sink.CanalEventSink;
+import com.alibaba.otter.canal.sink.exception.CanalSinkException;
+import com.google.common.collect.Lists;
+import com.taobao.tddl.dbsync.binlog.exception.TableIdNotFoundException;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang.math.RandomUtils;
+import org.bson.BsonTimestamp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * MongoEventParser
+ *
+ * @author jiabao.sun 2020-7-13
+ * @version 1.0.0
+ */
+public class MongoEventParser extends AbstractCanalLifeCycle implements CanalEventParser {
+
+    private   final Logger                           logger                     = LoggerFactory.getLogger(MongoEventParser.class);
+
+    private   CanalLogPositionManager                logPositionManager         = null;
+    private   CanalEventSink<List<CanalEntry.Entry>> eventSink                  = null;
+    private   AviaterRegexFilter                     eventFilter                = null;
+    private   AviaterRegexFilter                     eventBlackFilter           = null;
+
+    // 字段过滤
+    private   String                                 fieldFilter;
+    private   Map<String, List<String>>              fieldFilterMap;
+    private   String                                 fieldBlackFilter;
+    private   Map<String, List<String>>              fieldBlackFilterMap;
+
+    private   CanalAlarmHandler                      alarmHandler               = null;
+
+    //指定binlog位置
+    private   EntryPosition                          specifiedPosition;
+
+    // 统计参数
+    private   AtomicBoolean                          profilingEnabled           = new AtomicBoolean(false);    // profile开关参数
+    private   AtomicLong                             receivedEventCount         = new AtomicLong();
+    private   AtomicLong                             parsedEventCount           = new AtomicLong();
+    private   AtomicLong                             consumedEventCount         = new AtomicLong();
+    private   long                                   parsingInterval            = -1;
+    private   long                                   processingInterval         = -1;
+
+    private   final AtomicLong                       eventsPublishBlockingTime  = new AtomicLong(0L);
+
+    // 认证信息
+    private   volatile MongoAuthenticationInfo       authenticationInfo         = null;
+    private   String                                 destination;
+
+    // binLogParser
+    private   ChangeStreamEventConverter             binlogParser               = null;
+
+    private   Thread                                 parseThread                = null;
+
+    private   Thread.UncaughtExceptionHandler        handler                    = new Thread.UncaughtExceptionHandler() {
+                                                                                      public void uncaughtException(Thread t, Throwable e) {
+                                                                                          logger.error("parse events has an error",e);
+                                                                                      }
+                                                                                  };
+
+    private   EntrySinkDelegate                      entrySinkDelegate          = null;
+
+    private   long                                   lastEntryTime              = 0L;
+
+    private   Throwable                              exception                  = null;
+
+    private   boolean                                parallel                   = true;                                    // 是否开启并行解析模式
+    private   Integer                                parallelThreadSize         = Runtime.getRuntime().availableProcessors() * 60 / 100;     // 60%的能力跑解析,剩余部分处理网络
+    private   int                                    parallelBufferSize         = 256;                                     // 必须为2的幂
+    private   MongoMultiStageCoprocessor             multiStageCoprocessor;
+    private   ParserExceptionHandler                 parserExceptionHandler;
+
+    private ChangeStreamEventConverter buildParser() {
+        ChangeStreamEventConverter converter = new ChangeStreamEventConverter();
+        if (eventFilter != null) {
+            converter.setNameFilter(eventFilter);
+        }
+
+        if (eventBlackFilter != null) {
+            converter.setNameBlackFilter(eventBlackFilter);
+        }
+        converter.setFieldFilterMap(getFieldFilterMap());
+        converter.setFieldBlackFilterMap(getFieldBlackFilterMap());
+        return converter;
+    }
+
+    protected MongoConnection buildMongoConnection() {
+        MongoConnection connection = new MongoConnection(authenticationInfo);
+        if (eventFilter != null) {
+            connection.setEventRegex(eventFilter.getPattern());
+        }
+        if (eventBlackFilter != null) {
+            connection.setEventBlackRegex(eventBlackFilter.getPattern());
+        }
+        connection.setReceivedEventCount(receivedEventCount);
+        return connection;
+    }
+
+    protected MongoMultiStageCoprocessor buildMultiStageCoprocessor() {
+        MongoMultiStageCoprocessor mongoMultiStageCoprocessor = new MongoMultiStageCoprocessor(parallelBufferSize,
+                parallelThreadSize,
+                binlogParser,
+                entrySinkDelegate,
+                destination);
+        mongoMultiStageCoprocessor.setEventsPublishBlockingTime(eventsPublishBlockingTime);
+        return mongoMultiStageCoprocessor;
+    }
+
+    protected void preDump(MongoConnection connection) {
+        logger.info("preDump mongo oplog to destination {}", destination);
+    }
+
+    protected void afterDump(MongoConnection connection) {
+        logger.info("afterDump mongo oplog to destination {}", destination);
+    }
+
+    public MongoEventParser(){
+        // 初始化一下
+        entrySinkDelegate = new EntrySinkDelegate() {
+            @Override
+            public void sink(List<CanalEntry.Entry> entries) throws InterruptedException {
+                boolean succeed = consumeTheEventAndProfilingIfNecessary(entries);
+                if (!running) {
+                    return;
+                }
+
+                if (!succeed) {
+                    throw new CanalParseException("consume failed!");
+                }
+
+                LogPosition position = buildLastPosition(entries.get(entries.size() - 1));
+                if (position != null) { // 可能position为空
+                    logPositionManager.persistLogPosition(MongoEventParser.this.destination, position);
+                }
+            }
+        };
+    }
+
+    public void start() {
+        super.start();
+        MDC.put("destination", destination);
+
+        // 构造bin log parser
+        binlogParser = buildParser();// 初始化一下BinLogParser
+        binlogParser.start();
+
+        // 启动工作线程
+        parseThread = new Thread(new Runnable() {
+
+            public void run() {
+                MDC.put("destination", String.valueOf(destination));
+                MongoConnection mongoConnection = null;
+                while (running) {
+                    try {
+                        // 开始执行replication
+                        // 1. 构造Mongo连接
+                        mongoConnection = buildMongoConnection();
+
+                        // 2. 执行dump前的准备工作
+                        preDump(mongoConnection);
+
+                        mongoConnection.connect();// 链接
+
+                        // 3. 获取最后的位置信息
+                        long start = System.currentTimeMillis();
+                        logger.warn("---> begin to find start position, it will be long time for reset or first position");
+                        EntryPosition position = findStartPosition(mongoConnection);
+                        final EntryPosition startPosition = position;
+                        if (startPosition == null) {
+                            throw new PositionNotFoundException("can't find start position for " + destination);
+                        }
+
+                        long end = System.currentTimeMillis();
+                        logger.warn("---> find start position successfully, {}", startPosition.toString() + " cost : "
+                                + (end - start)
+                                + "ms , the next step is oplog dump");
+
+
+                        SinkFunction<ChangeStreamEvent> sinkHandler;
+                        // 4. 开始dump数据
+                        if (parallel) {
+                            // build stage processor
+                            multiStageCoprocessor = buildMultiStageCoprocessor();
+                            multiStageCoprocessor.start();
+
+                            sinkHandler = new SinkFunction<ChangeStreamEvent>() {
+                                public boolean sink(ChangeStreamEvent changeStreamEvent) {
+                                    return multiStageCoprocessor.publish(changeStreamEvent);
+                                }
+                            };
+
+                        } else {
+                            sinkHandler = new SinkFunction<ChangeStreamEvent>() {
+
+                                private LogPosition lastPosition;
+
+                                public boolean sink(ChangeStreamEvent event) {
+                                    try {
+                                        CanalEntry.Entry entry = parseAndProfilingIfNecessary(event, false);
+
+                                        if (!running) {
+                                            return false;
+                                        }
+
+                                        if (entry != null) {
+                                            exception = null; // 有正常数据流过，清空exception
+                                            entrySinkDelegate.sink(Lists.newArrayList(entry));
+                                            // 记录一下对应的positions
+                                            this.lastPosition = buildLastPosition(entry);
+                                            // 记录一下最后一次有数据的时间
+                                            lastEntryTime = System.currentTimeMillis();
+                                        }
+                                        return running;
+                                    } catch (TableIdNotFoundException e) {
+                                        throw e;
+                                    } catch (Throwable e) {
+                                        if (e.getCause() instanceof TableIdNotFoundException) {
+                                            throw (TableIdNotFoundException) e.getCause();
+                                        }
+                                        // 记录一下，出错的位点信息
+                                        processSinkError(e,
+                                                this.lastPosition,
+                                                startPosition.getJournalName(),
+                                                startPosition.getPosition());
+                                        throw new CanalParseException(e); // 继续抛出异常，让上层统一感知
+                                    }
+                                }
+
+                            };
+                        }
+
+                        if (startPosition.getPosition() != null) {
+                            mongoConnection.dump(new BsonTimestamp(startPosition.getPosition()), sinkHandler);
+                        } else {
+                            mongoConnection.dump(startPosition.getTimestamp(), sinkHandler);
+                        }
+
+                    } catch (TableIdNotFoundException e) {
+                        exception = e;
+                        logger.error("dump address {} has an error, retrying. caused by ",
+                                authenticationInfo.getHosts(), e);
+                    } catch (Throwable e) {
+                        processDumpError(e);
+                        exception = e;
+                        if (!running) {
+                            if (!(e instanceof java.nio.channels.ClosedByInterruptException
+                                    || e.getCause() instanceof java.nio.channels.ClosedByInterruptException)) {
+                                throw new CanalParseException(String.format("dump address %s has an error, retrying. ",
+                                        authenticationInfo.getHosts()), e);
+                            }
+                        } else {
+                            logger.error("dump address {} has an error, retrying. caused by ",
+                                    authenticationInfo.getHosts(), e);
+                            sendAlarm(destination, ExceptionUtils.getFullStackTrace(e));
+                        }
+                        if (parserExceptionHandler != null) {
+                            parserExceptionHandler.handle(e);
+                        }
+                    } finally {
+                        // 重新置为中断状态
+                        Thread.interrupted();
+                        // 关闭一下链接
+                        afterDump(mongoConnection);
+                        try {
+                            if (mongoConnection != null) {
+                                mongoConnection.disconnect();
+                            }
+                        } catch (IOException e1) {
+                            if (!running) {
+                                throw new CanalParseException(String.format("disconnect address %s has an error, retrying. ",
+                                        authenticationInfo.getHosts().toString()),
+                                        e1);
+                            } else {
+                                logger.error("disconnect address {} has an error, retrying., caused by ",
+                                        authenticationInfo.getHosts().toString(),
+                                        e1);
+                            }
+                        }
+                    }
+                    // 出异常了，退出sink消费，释放一下状态
+                    eventSink.interrupt();
+                    binlogParser.reset();// 重新置位
+                    if (multiStageCoprocessor != null && multiStageCoprocessor.isStart()) {
+                        // 处理 RejectedExecutionException
+                        try {
+                            multiStageCoprocessor.stop();
+                        } catch (Throwable t) {
+                            logger.debug("multi processor rejected:", t);
+                        }
+                    }
+
+                    if (running) {
+                        // sleep一段时间再进行重试
+                        try {
+                            Thread.sleep(10000 + RandomUtils.nextInt(10000));
+                        } catch (InterruptedException e) {
+                        }
+                    }
+                }
+                MDC.remove("destination");
+            }
+        });
+
+        parseThread.setUncaughtExceptionHandler(handler);
+        parseThread.setName(String.format("destination = %s , address = %s , EventParser",
+                destination,
+                authenticationInfo == null ? null : authenticationInfo.getHosts()));
+        parseThread.start();
+    }
+
+    public void stop() {
+        super.stop();
+
+        parseThread.interrupt(); // 尝试中断
+        eventSink.interrupt();
+
+        if (multiStageCoprocessor != null && multiStageCoprocessor.isStart()) {
+            try {
+                multiStageCoprocessor.stop();
+            } catch (Throwable t) {
+                logger.debug("multi processor rejected:", t);
+            }
+        }
+
+        try {
+            parseThread.join();// 等待其结束
+        } catch (InterruptedException e) {
+            // ignore
+        }
+
+        if (binlogParser.isStart()) {
+            binlogParser.stop();
+        }
+    }
+
+    /**
+     * sink oplog
+     */
+    protected boolean consumeTheEventAndProfilingIfNecessary(List<CanalEntry.Entry> entrys) throws CanalSinkException,
+            InterruptedException {
+        long startTs = -1;
+        boolean enabled = getProfilingEnabled();
+        if (enabled) {
+            startTs = System.currentTimeMillis();
+        }
+
+        boolean result = eventSink.sink(entrys, authenticationInfo.getPrimaryINetSocketAddresses(), destination);
+
+        if (enabled) {
+            this.processingInterval = System.currentTimeMillis() - startTs;
+        }
+
+        if (consumedEventCount.incrementAndGet() < 0) {
+            consumedEventCount.set(0);
+        }
+
+        return result;
+    }
+
+    /**
+     * parse oplog
+     */
+    protected CanalEntry.Entry parseAndProfilingIfNecessary(ChangeStreamEvent bod, boolean isSeek) throws Exception {
+        long startTs = -1;
+        boolean enabled = getProfilingEnabled();
+        if (enabled) {
+            startTs = System.currentTimeMillis();
+        }
+
+        CanalEntry.Entry event = binlogParser.parse(bod, isSeek);
+        if (enabled) {
+            this.parsingInterval = System.currentTimeMillis() - startTs;
+        }
+
+        if (parsedEventCount.incrementAndGet() < 0) {
+            parsedEventCount.set(0);
+        }
+
+        return event;
+    }
+
+    public Boolean getProfilingEnabled() {
+        return profilingEnabled.get();
+    }
+
+    protected EntryPosition findStartPosition(MongoConnection connection) throws IOException {
+        LogPosition logPosition = logPositionManager.getLatestIndexBy(destination);
+        if (logPosition == null) {// 找不到历史成功记录
+
+            EntryPosition entryPosition = null;
+            if (specifiedPosition != null &&
+                    (specifiedPosition.getTimestamp() != null || specifiedPosition.getPosition() != null )) {
+                // 指定位点，从指定位点开始消费
+                entryPosition = specifiedPosition;
+            } else {
+                // 默认从当前最后一个位置进行消费
+                entryPosition = new EntryPosition();
+
+                Date lastWriteDate = connection.getPrimary().getLastWriteDate();
+                long timestamp = lastWriteDate == null ? System.currentTimeMillis() : lastWriteDate.getTime();
+
+                entryPosition.setJournalName(ChangeStreamEvent.LOG_FILE_COLLECTION);
+                entryPosition.setPosition(null);
+                entryPosition.setTimestamp(timestamp);
+            }
+
+            return entryPosition;
+        } else {
+            logger.warn("prepare to find start position just last position\n {}",
+                    JsonUtils.marshalToString(logPosition));
+            return logPosition.getPostion();
+        }
+    }
+
+    protected LogPosition buildLastPosition(CanalEntry.Entry entry) { // 初始化一下
+        LogPosition logPosition = new LogPosition();
+        EntryPosition position = new EntryPosition();
+
+        position.setJournalName(entry.getHeader().getLogfileName());
+        //mongo position 记录cluster time
+        position.setPosition(entry.getHeader().getLogfileOffset());
+        position.setTimestamp(entry.getHeader().getExecuteTime());
+
+        logPosition.setPostion(position);
+
+        LogIdentity identity = new LogIdentity(authenticationInfo.getPrimaryINetSocketAddresses(), -1L);
+        logPosition.setIdentity(identity);
+        return logPosition;
+    }
+
+    protected void processSinkError(Throwable e, LogPosition lastPosition, String startBinlogFile, Long startPosition) {
+        if (lastPosition != null) {
+            logger.warn(String.format("ERROR ## parse this event has an error , last position : [%s]",
+                    lastPosition.getPostion()),
+                    e);
+        } else {
+            logger.warn(String.format("ERROR ## parse this event has an error , last position : [%s,%s]",
+                    startBinlogFile,
+                    startPosition), e);
+        }
+    }
+
+    protected void processDumpError(Throwable e) {
+        if (e instanceof IOException) {
+            logger.warn("parse oplog error", e);
+        }
+    }
+
+    public void sendAlarm(String destination, String msg) {
+        if (this.alarmHandler != null) {
+            this.alarmHandler.sendAlarm(destination, msg);
+        }
+    }
+
+    /**
+     * 解析字段过滤规则
+     */
+    private Map<String, List<String>> parseFieldFilterMap(String config) {
+
+        Map<String, List<String>> map = new HashMap<String, List<String>>();
+
+        if (StringUtils.isNotBlank(config)) {
+            for (String filter : config.split(",")) {
+                if (StringUtils.isBlank(filter)) {
+                    continue;
+                }
+
+                String[] filterConfig = filter.split(":");
+                if (filterConfig.length != 2) {
+                    continue;
+                }
+
+                map.put(filterConfig[0].trim().toUpperCase(), Arrays.asList(filterConfig[1].trim().toUpperCase().split("/")));
+            }
+        }
+
+        return map;
+    }
+
+    public void setEventFilter(AviaterRegexFilter eventFilter) {
+        this.eventFilter = eventFilter;
+    }
+
+    public void setEventBlackFilter(AviaterRegexFilter eventBlackFilter) {
+        this.eventBlackFilter = eventBlackFilter;
+    }
+
+    public Long getParsedEventCount() {
+        return parsedEventCount.get();
+    }
+
+    public Long getConsumedEventCount() {
+        return consumedEventCount.get();
+    }
+
+    public void setProfilingEnabled(boolean profilingEnabled) {
+        this.profilingEnabled = new AtomicBoolean(profilingEnabled);
+    }
+
+    public long getParsingInterval() {
+        return parsingInterval;
+    }
+
+    public long getProcessingInterval() {
+        return processingInterval;
+    }
+
+    public void setEventSink(CanalEventSink<List<CanalEntry.Entry>> eventSink) {
+        this.eventSink = eventSink;
+    }
+
+    public void setDestination(String destination) {
+        this.destination = destination;
+    }
+
+    public void setBinlogParser(ChangeStreamEventConverter binlogParser) {
+        this.binlogParser = binlogParser;
+    }
+
+    public ChangeStreamEventConverter getBinlogParser() {
+        return binlogParser;
+    }
+
+    public void setAlarmHandler(CanalAlarmHandler alarmHandler) {
+        this.alarmHandler = alarmHandler;
+    }
+
+    public CanalAlarmHandler getAlarmHandler() {
+        return this.alarmHandler;
+    }
+
+    public void setLogPositionManager(CanalLogPositionManager logPositionManager) {
+        this.logPositionManager = logPositionManager;
+    }
+
+    public CanalLogPositionManager getLogPositionManager() {
+        return logPositionManager;
+    }
+
+    public Throwable getException() {
+        return exception;
+    }
+
+    public boolean isParallel() {
+        return parallel;
+    }
+
+    public void setParallel(boolean parallel) {
+        this.parallel = parallel;
+    }
+
+    public int getParallelThreadSize() {
+        return parallelThreadSize;
+    }
+
+    public void setParallelThreadSize(Integer parallelThreadSize) {
+        if (parallelThreadSize != null) {
+            this.parallelThreadSize = parallelThreadSize;
+        }
+    }
+
+    public Integer getParallelBufferSize() {
+        return parallelBufferSize;
+    }
+
+    public void setParallelBufferSize(int parallelBufferSize) {
+        this.parallelBufferSize = parallelBufferSize;
+    }
+
+    public ParserExceptionHandler getParserExceptionHandler() {
+        return parserExceptionHandler;
+    }
+
+    public void setParserExceptionHandler(ParserExceptionHandler parserExceptionHandler) {
+        this.parserExceptionHandler = parserExceptionHandler;
+    }
+
+    public String getFieldFilter() {
+        return fieldFilter;
+    }
+
+    public void setFieldFilter(String fieldFilter) {
+        this.fieldFilter = fieldFilter.trim();
+        this.fieldFilterMap = parseFieldFilterMap(fieldFilter);
+    }
+
+    public String getFieldBlackFilter() {
+        return fieldBlackFilter;
+    }
+
+    public void setFieldBlackFilter(String fieldBlackFilter) {
+        this.fieldBlackFilter = fieldBlackFilter;
+        this.fieldBlackFilterMap = parseFieldFilterMap(fieldBlackFilter);
+    }
+
+    public void setSpecifiedPosition(EntryPosition specifiedPosition) {
+        this.specifiedPosition = specifiedPosition;
+    }
+
+    public EntryPosition getSpecifiedPosition() {
+        return specifiedPosition;
+    }
+
+    public MongoAuthenticationInfo getAuthenticationInfo() {
+        return authenticationInfo;
+    }
+
+    public void setAuthenticationInfo(MongoAuthenticationInfo authenticationInfo) {
+        this.authenticationInfo = authenticationInfo;
+    }
+
+    public AtomicLong getEventsPublishBlockingTime() {
+        return eventsPublishBlockingTime;
+    }
+
+    public AtomicLong getReceivedEventCount() {
+        return receivedEventCount;
+    }
+
+    public void setReceivedEventCount(AtomicLong receivedEventCount) {
+        this.receivedEventCount = receivedEventCount;
+    }
+
+    public Map<String, List<String>> getFieldFilterMap() {
+        return fieldFilterMap;
+    }
+
+    public Map<String, List<String>> getFieldBlackFilterMap() {
+        return fieldBlackFilterMap;
+    }
+
+}

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/MongoMultiStageCoprocessor.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/MongoMultiStageCoprocessor.java
@@ -1,0 +1,293 @@
+package com.alibaba.otter.canal.parse.inbound.mongodb;
+
+import com.alibaba.otter.canal.common.AbstractCanalLifeCycle;
+import com.alibaba.otter.canal.common.utils.NamedThreadFactory;
+import com.alibaba.otter.canal.parse.exception.CanalParseException;
+import com.alibaba.otter.canal.parse.inbound.mongodb.dbsync.ChangeStreamEvent;
+import com.alibaba.otter.canal.parse.inbound.mongodb.dbsync.ChangeStreamEventConverter;
+import com.alibaba.otter.canal.protocol.CanalEntry;
+import com.google.common.collect.Lists;
+import com.lmax.disruptor.*;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
+
+
+/**
+ * 针对解析器提供一个多阶段协同的处理
+ *
+ * <pre>
+ * 1. 网络接收 publish(单线程)
+ * 2. 事件深度解析 (多线程, DML事件数据的完整解析)
+ * 3. 投递到store (单线程)
+ * </pre>
+ */
+public class MongoMultiStageCoprocessor extends AbstractCanalLifeCycle {
+
+    private static final int                  maxFullTimes = 10;
+    private ChangeStreamEventConverter logEventConvert;
+    private EntrySinkDelegate                 entrySinkDelegate;
+
+    private int                               parserThreadCount;
+    private int                               ringBufferSize;
+    private RingBuffer<MessageEvent>          disruptorMsgBuffer;
+    private ExecutorService                   parserExecutor;
+    private ExecutorService                   stageExecutor;
+    private String                            destination;
+    private volatile CanalParseException exception;
+    private AtomicLong                        eventsPublishBlockingTime;
+    private WorkerPool<MessageEvent>          workerPool;
+    private BatchEventProcessor<MessageEvent> sinkStoreStage;
+
+    public MongoMultiStageCoprocessor(int ringBufferSize, int parserThreadCount, ChangeStreamEventConverter logEventConvert,
+                                      EntrySinkDelegate entrySinkDelegate, String destination){
+        this.ringBufferSize = ringBufferSize;
+        this.parserThreadCount = parserThreadCount;
+        this.logEventConvert = logEventConvert;
+        this.entrySinkDelegate = entrySinkDelegate;
+        this.destination = destination;
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        this.exception = null;
+        this.disruptorMsgBuffer = RingBuffer.createSingleProducer(new MessageEventFactory(),
+                ringBufferSize,
+                new BlockingWaitStrategy());
+        int tc = parserThreadCount > 0 ? parserThreadCount : 1;
+        this.parserExecutor = Executors.newFixedThreadPool(tc, new NamedThreadFactory("MultiStageCoprocessor-Parser-"
+                + destination));
+
+        this.stageExecutor = Executors.newFixedThreadPool(2, new NamedThreadFactory("MultiStageCoprocessor-other-"
+                + destination));
+
+        ExceptionHandler exceptionHandler = new SimpleFatalExceptionHandler();
+
+        // stage 2
+        SequenceBarrier dmlParserSequenceBarrier = disruptorMsgBuffer.newBarrier();
+        WorkHandler<MessageEvent>[] workHandlers = new DmlParserStage[tc];
+        for (int i = 0; i < tc; i++) {
+            workHandlers[i] = new DmlParserStage();
+        }
+
+        workerPool = new WorkerPool<MessageEvent>(disruptorMsgBuffer,
+                dmlParserSequenceBarrier,
+                exceptionHandler,
+                workHandlers);
+        Sequence[] sequence = workerPool.getWorkerSequences();
+        disruptorMsgBuffer.addGatingSequences(sequence);
+
+        // stage 3
+        SequenceBarrier sinkSequenceBarrier = disruptorMsgBuffer.newBarrier(sequence);
+        sinkStoreStage = new BatchEventProcessor<MessageEvent>(disruptorMsgBuffer,
+                sinkSequenceBarrier,
+                new SinkStoreStage());
+        sinkStoreStage.setExceptionHandler(exceptionHandler);
+        disruptorMsgBuffer.addGatingSequences(sinkStoreStage.getSequence());
+
+        // start work
+        stageExecutor.submit(sinkStoreStage);
+        workerPool.start(parserExecutor);
+    }
+
+    @Override
+    public void stop() {
+        // fix bug #968，对于pool与
+        workerPool.halt();
+        sinkStoreStage.halt();
+        try {
+            parserExecutor.shutdownNow();
+            while (!parserExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
+                if (parserExecutor.isShutdown() || parserExecutor.isTerminated()) {
+                    break;
+                }
+
+                parserExecutor.shutdownNow();
+            }
+        } catch (Throwable e) {
+            // ignore
+        }
+
+        try {
+            stageExecutor.shutdownNow();
+            while (!stageExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
+                if (stageExecutor.isShutdown() || stageExecutor.isTerminated()) {
+                    break;
+                }
+
+                stageExecutor.shutdownNow();
+            }
+        } catch (Throwable e) {
+            // ignore
+        }
+        super.stop();
+    }
+
+    public boolean publish(ChangeStreamEvent event) {
+        if (!isStart()) {
+            if (exception != null) {
+                throw exception;
+            }
+            return false;
+        }
+
+        boolean interrupted = false;
+        long blockingStart = 0L;
+        int fullTimes = 0;
+        do {
+            /**
+             * 由于改为processor仅终止自身stage而不是stop，那么需要由incident标识coprocessor是否正常工作。
+             * 让dump线程能够及时感知
+             */
+            if (exception != null) {
+                throw exception;
+            }
+            try {
+                long next = disruptorMsgBuffer.tryNext();
+                MessageEvent data = disruptorMsgBuffer.get(next);
+                data.setEvent(event);
+                disruptorMsgBuffer.publish(next);
+                if (fullTimes > 0) {
+                    eventsPublishBlockingTime.addAndGet(System.nanoTime() - blockingStart);
+                }
+                break;
+            } catch (InsufficientCapacityException e) {
+                if (fullTimes == 0) {
+                    blockingStart = System.nanoTime();
+                }
+                // park
+                // LockSupport.parkNanos(1L);
+                applyWait(++fullTimes);
+                interrupted = Thread.interrupted();
+                if (fullTimes % 1000 == 0) {
+                    long nextStart = System.nanoTime();
+                    eventsPublishBlockingTime.addAndGet(nextStart - blockingStart);
+                    blockingStart = nextStart;
+                }
+            }
+        } while (!interrupted && isStart());
+        return isStart();
+    }
+
+    // 处理无数据的情况，避免空循环挂死
+    private void applyWait(int fullTimes) {
+        int newFullTimes = fullTimes > maxFullTimes ? maxFullTimes : fullTimes;
+        if (fullTimes <= 3) { // 3次以内
+            Thread.yield();
+        } else { // 超过3次，最多只sleep 1ms
+            LockSupport.parkNanos(100 * 1000L * newFullTimes);
+        }
+    }
+
+    private class DmlParserStage implements WorkHandler<MessageEvent>, LifecycleAware {
+
+        @Override
+        public void onEvent(MessageEvent event) throws Exception {
+            try {
+                ChangeStreamEvent logEvent = event.getEvent();
+                if (logEvent == null) {
+                    return;
+                }
+
+                CanalEntry.Entry entry = logEventConvert.parse(event.getEvent(), false);
+                event.setEntry(entry);
+            } catch (Throwable e) {
+                exception = new CanalParseException(e);
+                throw exception;
+            }
+        }
+
+        @Override
+        public void onStart() {
+
+        }
+
+        @Override
+        public void onShutdown() {
+
+        }
+    }
+
+    private class SinkStoreStage implements EventHandler<MessageEvent>, LifecycleAware {
+
+        public void onEvent(MessageEvent event, long sequence, boolean endOfBatch) throws Exception {
+            try {
+                if (event.getEntry() != null) {
+                    entrySinkDelegate.sink(Lists.newArrayList(event.getEntry()));
+                }
+                // clear for gc
+                event.setEvent(null);
+                event.setEntry(null);
+            } catch (Throwable e) {
+                exception = new CanalParseException(e);
+                throw exception;
+            }
+        }
+
+        @Override
+        public void onStart() {
+
+        }
+
+        @Override
+        public void onShutdown() {
+
+        }
+    }
+
+    class MessageEvent {
+        private CanalEntry.Entry        entry;
+        private ChangeStreamEvent event;
+
+        public ChangeStreamEvent getEvent() {
+            return event;
+        }
+
+        public void setEvent(ChangeStreamEvent event) {
+            this.event = event;
+        }
+
+        public CanalEntry.Entry getEntry() {
+            return entry;
+        }
+
+        public void setEntry(CanalEntry.Entry entry) {
+            this.entry = entry;
+        }
+    }
+
+    class SimpleFatalExceptionHandler implements ExceptionHandler {
+        @Override
+        public void handleEventException(final Throwable ex, final long sequence, final Object event) {
+            //异常上抛，否则processEvents的逻辑会默认会mark为成功执行，有丢数据风险
+            throw new CanalParseException(ex);
+        }
+
+        @Override
+        public void handleOnStartException(final Throwable ex) {
+        }
+
+        @Override
+        public void handleOnShutdownException(final Throwable ex) {
+        }
+    }
+
+    class MessageEventFactory implements EventFactory<MessageEvent> {
+        public MessageEvent newInstance() {
+            return new MessageEvent();
+        }
+    }
+
+    public void setLogEventConvert(ChangeStreamEventConverter logEventConvert) {
+        this.logEventConvert = logEventConvert;
+    }
+
+    public void setEventsPublishBlockingTime(AtomicLong eventsPublishBlockingTime) {
+        this.eventsPublishBlockingTime = eventsPublishBlockingTime;
+    }
+
+}

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/dbsync/BsonConverter.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/dbsync/BsonConverter.java
@@ -1,0 +1,41 @@
+package com.alibaba.otter.canal.parse.inbound.mongodb.dbsync;
+
+import com.mongodb.MongoClientSettings;
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+import org.bson.Document;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.util.concurrent.TimeUnit;
+
+public class BsonConverter {
+
+    private final static CodecRegistry registry = MongoClientSettings.getDefaultCodecRegistry();
+
+    private final static Codec<Document> codec = MongoClientSettings.getDefaultCodecRegistry().get(Document.class);
+
+    public static Document convert(BsonDocument bson) {
+        if (bson == null) {
+            return null;
+        }
+        return codec.decode(bson.asBsonReader(), DecoderContext.builder().build());
+    }
+
+    public static BsonDocument convert(Document document) {
+        if (document == null) {
+            return null;
+        }
+        return document.toBsonDocument(BsonDocument.class, registry);
+    }
+
+    public static BsonTimestamp convertTime(long timeMillis) {
+        return new BsonTimestamp((int) TimeUnit.MILLISECONDS.toSeconds(timeMillis), 1);
+    }
+
+    public static long convertTime(BsonTimestamp bsonTimestamp, TimeUnit timeUnit) {
+        return timeUnit.convert(bsonTimestamp.getTime(), TimeUnit.SECONDS);
+    }
+
+}

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/dbsync/ChangeStreamEvent.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/dbsync/ChangeStreamEvent.java
@@ -1,0 +1,165 @@
+package com.alibaba.otter.canal.parse.inbound.mongodb.dbsync;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import com.mongodb.client.model.changestream.OperationType;
+import org.bson.BsonTimestamp;
+import org.bson.Document;
+
+import java.util.List;
+
+/**
+ * Mongodb  ChangeStreamEvent
+ *
+ * @author  jiabao.sun 2020-07-13 15:23:21
+ * @version 1.0.0
+ */
+public class ChangeStreamEvent {
+
+    public static final String LOG_FILE_COLLECTION = "oplog.rs";
+
+    private Document resumeToken;
+    private MongoNamespace namespace;
+    private MongoNamespace destinationNamespace;
+    private Document fullDocument;
+    private Document documentKey;
+    private BsonTimestamp clusterTime;
+    private OperationType operationType;
+    private UpdateDescription updateDescription;
+    private long txnNumber;
+    private Document lsid;
+
+    public static ChangeStreamEvent from(ChangeStreamDocument<Document> changeStreamDoc) {
+        if (changeStreamDoc == null) {
+            return null;
+        }
+
+        ChangeStreamEvent changeStreamEvent = new ChangeStreamEvent();
+        changeStreamEvent.setResumeToken(BsonConverter.convert(changeStreamDoc.getResumeToken()));
+        changeStreamEvent.setNamespace(changeStreamDoc.getNamespace());
+        changeStreamEvent.setDestinationNamespace(changeStreamDoc.getDestinationNamespace());
+        changeStreamEvent.setFullDocument(changeStreamDoc.getFullDocument());
+        changeStreamEvent.setDocumentKey(BsonConverter.convert(changeStreamDoc.getDocumentKey()));
+        changeStreamEvent.setClusterTime(changeStreamDoc.getClusterTime());
+        changeStreamEvent.setOperationType(changeStreamDoc.getOperationType());
+
+        if (changeStreamDoc.getUpdateDescription() != null) {
+            ChangeStreamEvent.UpdateDescription updateDescription = new ChangeStreamEvent.UpdateDescription();
+            updateDescription.setRemovedFields(changeStreamDoc.getUpdateDescription().getRemovedFields());
+            if (changeStreamDoc.getUpdateDescription().getUpdatedFields() != null) {
+                updateDescription.setUpdatedFields(
+                        BsonConverter.convert(changeStreamDoc.getUpdateDescription().getUpdatedFields()));
+            }
+            changeStreamEvent.setUpdateDescription(updateDescription);
+        }
+
+        if (changeStreamDoc.getTxnNumber() != null) {
+            changeStreamEvent.setTxnNumber(changeStreamDoc.getTxnNumber().longValue());
+        }
+
+        changeStreamEvent.setLsid(BsonConverter.convert(changeStreamDoc.getLsid()));
+
+        return changeStreamEvent;
+    }
+
+    public static class UpdateDescription {
+        private List<String> removedFields;
+        private Document updatedFields;
+
+        public List<String> getRemovedFields() {
+            return removedFields;
+        }
+
+        public void setRemovedFields(List<String> removedFields) {
+            this.removedFields = removedFields;
+        }
+
+        public Document getUpdatedFields() {
+            return updatedFields;
+        }
+
+        public void setUpdatedFields(Document updatedFields) {
+            this.updatedFields = updatedFields;
+        }
+    }
+
+    public Document getResumeToken() {
+        return resumeToken;
+    }
+
+    public void setResumeToken(Document resumeToken) {
+        this.resumeToken = resumeToken;
+    }
+
+    public MongoNamespace getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(MongoNamespace namespace) {
+        this.namespace = namespace;
+    }
+
+    public MongoNamespace getDestinationNamespace() {
+        return destinationNamespace;
+    }
+
+    public void setDestinationNamespace(MongoNamespace destinationNamespace) {
+        this.destinationNamespace = destinationNamespace;
+    }
+
+    public Document getFullDocument() {
+        return fullDocument;
+    }
+
+    public void setFullDocument(Document fullDocument) {
+        this.fullDocument = fullDocument;
+    }
+
+    public Document getDocumentKey() {
+        return documentKey;
+    }
+
+    public void setDocumentKey(Document documentKey) {
+        this.documentKey = documentKey;
+    }
+
+    public BsonTimestamp getClusterTime() {
+        return clusterTime;
+    }
+
+    public void setClusterTime(BsonTimestamp clusterTime) {
+        this.clusterTime = clusterTime;
+    }
+
+    public OperationType getOperationType() {
+        return operationType;
+    }
+
+    public void setOperationType(OperationType operationType) {
+        this.operationType = operationType;
+    }
+
+    public UpdateDescription getUpdateDescription() {
+        return updateDescription;
+    }
+
+    public void setUpdateDescription(UpdateDescription updateDescription) {
+        this.updateDescription = updateDescription;
+    }
+
+    public long getTxnNumber() {
+        return txnNumber;
+    }
+
+    public void setTxnNumber(long txnNumber) {
+        this.txnNumber = txnNumber;
+    }
+
+    public Document getLsid() {
+        return lsid;
+    }
+
+    public void setLsid(Document lsid) {
+        this.lsid = lsid;
+    }
+}

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/dbsync/ChangeStreamEventConverter.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mongodb/dbsync/ChangeStreamEventConverter.java
@@ -1,0 +1,442 @@
+package com.alibaba.otter.canal.parse.inbound.mongodb.dbsync;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.otter.canal.common.AbstractCanalLifeCycle;
+import com.alibaba.otter.canal.filter.aviater.AviaterRegexFilter;
+import com.alibaba.otter.canal.parse.exception.CanalParseException;
+import com.alibaba.otter.canal.parse.inbound.BinlogParser;
+import com.alibaba.otter.canal.protocol.CanalEntry;
+import com.google.common.base.Strings;
+import com.google.protobuf.ByteString;
+import jdk.nashorn.internal.runtime.Undefined;
+import org.bson.BsonDbPointer;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonTimestamp;
+import org.bson.types.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 基于{@linkplain ChangeStreamEvent}转化为Entry对象的处理
+ *
+ * @author jiabao.sun 2020-07-13 15:23:30
+ * @version 1.0.0
+ */
+public class ChangeStreamEventConverter extends AbstractCanalLifeCycle implements BinlogParser<ChangeStreamEvent> {
+
+    private static Logger               logger                     = LoggerFactory.getLogger(ChangeStreamEventConverter.class);
+
+    private static final String         ID_FIELD_NAME              = "_id";
+    private static final String         CLASS_FIELD_NAME           = "_class";
+
+    public  static final String         UTF_8                      = "UTF-8";
+    public  static final String         ISO_8859_1                 = "ISO-8859-1";
+
+    private volatile AviaterRegexFilter nameFilter;
+    private volatile AviaterRegexFilter nameBlackFilter;
+
+    private Map<String, List<String>>   fieldFilterMap             = new HashMap<>();
+    private Map<String, List<String>>   fieldBlackFilterMap        = new HashMap<>();
+
+    @Override
+    public CanalEntry.Entry parse(ChangeStreamEvent logEvent, boolean isSeek) throws CanalParseException {
+        if (logEvent == null) {
+            logger.error("ignored null logEvent , must check!");
+            return null;
+        }
+
+        if (logEvent.getNamespace() == null) {
+            logger.error("ignored logEvent of {}, mongo namespace is not present", logEvent);
+            return null;
+        }
+
+        String fullName = logEvent.getNamespace().getFullName();
+
+        boolean ignore = true;
+        //未命中黑名单，并且命中白名单
+        if (nameBlackFilter == null || !nameBlackFilter.filter(fullName)) {
+            if (nameFilter == null || nameFilter.filter(fullName)) {
+                ignore = false;
+            }
+        }
+
+        if (ignore) {
+            logger.debug("ignored log event of {}", fullName);
+            return null;
+        }
+
+        try {
+            switch (logEvent.getOperationType()) {
+                case INSERT:
+                    return parseInsert(logEvent);
+                case DELETE:
+                    return parseDelete(logEvent);
+                case UPDATE:
+                    return parseUpdate(logEvent);
+                case REPLACE:
+                    return parseReplace(logEvent);
+                case INVALIDATE:
+                    logger.warn("invalidate event received, watch channel will be closed. {}", logEvent);
+                    return null;
+                case DROP:
+                case DROP_DATABASE:
+                case RENAME:
+                case OTHER:
+                default:
+                    logger.debug("ignored opType of {}, {}", logEvent.getOperationType(), logEvent);
+                    return null;
+            }
+        } catch (Exception e) {
+            throw new CanalParseException("parse mongo row data failed.", e);
+        }
+    }
+
+    @Override
+    public void reset() {
+        //do nothing
+    }
+
+    private CanalEntry.Header.Builder commonHeader(ChangeStreamEvent logEvent) {
+        CanalEntry.Header.Builder headerBuilder = CanalEntry.Header.newBuilder();
+        headerBuilder.setSourceType(CanalEntry.Type.MONGODB);
+        headerBuilder.setSchemaName(logEvent.getNamespace().getDatabaseName());
+        headerBuilder.setTableName(logEvent.getNamespace().getCollectionName());
+        headerBuilder.setLogfileName(ChangeStreamEvent.LOG_FILE_COLLECTION);
+        headerBuilder.setServerenCode(UTF_8);// 经过java输出后所有的编码为unicode
+        //BsonTimestamp转毫秒时间戳
+        headerBuilder.setExecuteTime(BsonConverter.convertTime(logEvent.getClusterTime(), TimeUnit.MILLISECONDS));
+        //offset记录完整BsonTimestamp: second(32) inc(32)
+        headerBuilder.setLogfileOffset(logEvent.getClusterTime().getValue());
+
+        return headerBuilder;
+    }
+
+    private CanalEntry.Entry parseInsert(ChangeStreamEvent logEvent) {
+        if (logEvent.getFullDocument() == null) {
+            logger.error("error insert event, the full document is not present!");
+            return null;
+        }
+
+        CanalEntry.Header.Builder headerBuilder = commonHeader(logEvent);
+        headerBuilder.setEventType(CanalEntry.EventType.INSERT);
+
+        CanalEntry.RowChange.Builder rowChangeBuilder = CanalEntry.RowChange.newBuilder();
+        rowChangeBuilder.setEventType(CanalEntry.EventType.INSERT);
+        rowChangeBuilder.setIsDdl(false);
+
+        CanalEntry.RowData.Builder rowDataBuilder = CanalEntry.RowData.newBuilder();
+        for (Map.Entry<String, Object> field : logEvent.getFullDocument().entrySet()) {
+            // 忽略 spring data _class
+            if (CLASS_FIELD_NAME.equals(field.getKey())) {
+                continue;
+            }
+
+            if (needField(logEvent.getNamespace().getFullName(), field.getKey())) {
+                // 变更后列
+                rowDataBuilder.addAfterColumns(extractColumn(field.getKey(), field.getValue(), true));
+            }
+        }
+
+        rowChangeBuilder.addRowDatas(rowDataBuilder);
+
+        return createEntry(headerBuilder.build(), CanalEntry.EntryType.ROWDATA, rowChangeBuilder.build().toByteString());
+    }
+
+    private CanalEntry.Entry parseDelete(ChangeStreamEvent logEvent) {
+        if (logEvent.getDocumentKey() == null || !logEvent.getDocumentKey().containsKey(ID_FIELD_NAME)) {
+            logger.error("invalid delete event, the document key is not present!");
+            return null;
+        }
+
+        Object idVal = logEvent.getDocumentKey().get(ID_FIELD_NAME);
+        if (idVal == null) {
+            logger.error("invalid delete event, has not id field");
+            return null;
+        }
+
+        CanalEntry.Header.Builder headerBuilder = commonHeader(logEvent);
+        headerBuilder.setEventType(CanalEntry.EventType.DELETE);
+
+        CanalEntry.RowChange.Builder rowChangeBuilder = CanalEntry.RowChange.newBuilder();
+        rowChangeBuilder.setEventType(CanalEntry.EventType.DELETE);
+        rowChangeBuilder.setIsDdl(false);
+
+        CanalEntry.RowData.Builder rowDataBuilder = CanalEntry.RowData.newBuilder();
+        rowDataBuilder.addBeforeColumns(extractColumn(ID_FIELD_NAME, idVal, true));
+
+        rowChangeBuilder.addRowDatas(rowDataBuilder);
+
+        return createEntry(headerBuilder.build(), CanalEntry.EntryType.ROWDATA, rowChangeBuilder.build().toByteString());
+    }
+
+    private CanalEntry.Entry parseUpdate(ChangeStreamEvent logEvent) {
+        if (logEvent.getUpdateDescription() == null) {
+            logger.error("invalid update event, the updated description is not present!");
+            return null;
+        }
+
+        if (logEvent.getDocumentKey() == null || !logEvent.getDocumentKey().containsKey(ID_FIELD_NAME)) {
+            logger.error("invalid delete event, the document key is not present!");
+            return null;
+        }
+
+        Object idVal = logEvent.getDocumentKey().get(ID_FIELD_NAME);
+        if (idVal == null) {
+            logger.error("invalid delete event, has not id field");
+            return null;
+        }
+
+        CanalEntry.Header.Builder headerBuilder = commonHeader(logEvent);
+        headerBuilder.setEventType(CanalEntry.EventType.UPDATE);
+
+        CanalEntry.RowChange.Builder rowChangeBuilder = CanalEntry.RowChange.newBuilder();
+        rowChangeBuilder.setEventType(CanalEntry.EventType.UPDATE);
+        rowChangeBuilder.setIsDdl(false);
+
+        CanalEntry.RowData.Builder rowDataBuilder = CanalEntry.RowData.newBuilder();
+
+        // set id
+        rowDataBuilder.addAfterColumns(extractColumn(ID_FIELD_NAME, idVal, true));
+
+        // 处理 $set
+        if (logEvent.getUpdateDescription().getUpdatedFields() != null) {
+            for (Map.Entry<String, Object> field : logEvent.getUpdateDescription().getUpdatedFields().entrySet()) {
+                // 忽略 spring data _class
+                if (CLASS_FIELD_NAME.equals(field.getKey())) {
+                    continue;
+                }
+
+                if (!ID_FIELD_NAME.equals(field.getKey())) {
+                    rowDataBuilder.addBeforeColumns(extractColumn(field.getKey(), field.getValue(), false));
+                }
+
+                // 变更后列
+                rowDataBuilder.addAfterColumns(extractColumn(field.getKey(), field.getValue(), true));
+            }
+        }
+
+        // 处理 删除的field
+        if (CollectionUtils.isEmpty(logEvent.getUpdateDescription().getRemovedFields())) {
+            for (String fieldName : logEvent.getUpdateDescription().getRemovedFields()) {
+                // 忽略 spring data _class
+                if (CLASS_FIELD_NAME.equals(fieldName)) {
+                    continue;
+                }
+
+                CanalEntry.Column.Builder columnBuilder = CanalEntry.Column.newBuilder();
+                columnBuilder.setName(fieldName);
+                columnBuilder.setIsNull(true);
+
+                if (!ID_FIELD_NAME.equals(fieldName)) {
+                    rowDataBuilder.addBeforeColumns(columnBuilder);
+                }
+
+                // 变更后列
+                rowDataBuilder.addAfterColumns(columnBuilder);
+            }
+        }
+
+        rowChangeBuilder.addRowDatas(rowDataBuilder);
+
+        return createEntry(headerBuilder.build(), CanalEntry.EntryType.ROWDATA, rowChangeBuilder.build().toByteString());
+    }
+
+    private CanalEntry.Entry parseReplace(ChangeStreamEvent logEvent) {
+        if (logEvent.getFullDocument() == null) {
+            logger.error("invalid replace event, the replaced document is not present!");
+            return null;
+        }
+
+        CanalEntry.Header.Builder headerBuilder = commonHeader(logEvent);
+        headerBuilder.setEventType(CanalEntry.EventType.UPDATE);
+
+        CanalEntry.RowChange.Builder rowChangeBuilder = CanalEntry.RowChange.newBuilder();
+        rowChangeBuilder.setEventType(CanalEntry.EventType.UPDATE);
+        rowChangeBuilder.setIsDdl(false);
+
+        CanalEntry.RowData.Builder rowDataBuilder = CanalEntry.RowData.newBuilder();
+        for (Map.Entry<String, Object> field : logEvent.getFullDocument().entrySet()) {
+            // 忽略 spring data _class
+            if (CLASS_FIELD_NAME.equals(field.getKey())) {
+                continue;
+            }
+
+            if (needField(logEvent.getNamespace().getFullName(), field.getKey())) {
+                // mongo oplog没有变更前信息，这里mock所有字段，值为空
+                if (!ID_FIELD_NAME.equals(field.getKey())) {
+                    rowDataBuilder.addBeforeColumns(extractColumn(field.getKey(), field.getValue(), false));
+                }
+
+                // 变更后列
+                rowDataBuilder.addAfterColumns(extractColumn(field.getKey(), field.getValue(), true));
+            }
+        }
+
+        rowChangeBuilder.addRowDatas(rowDataBuilder);
+
+        return createEntry(headerBuilder.build(), CanalEntry.EntryType.ROWDATA, rowChangeBuilder.build().toByteString());
+    }
+
+    private CanalEntry.Entry createEntry(CanalEntry.Header header, CanalEntry.EntryType entryType, ByteString storeValue) {
+        CanalEntry.Entry.Builder entryBuilder = CanalEntry.Entry.newBuilder();
+        entryBuilder.setHeader(header);
+        entryBuilder.setEntryType(entryType);
+        entryBuilder.setStoreValue(storeValue);
+        return entryBuilder.build();
+    }
+
+    //字段过滤
+    private boolean needField(String namespace, String columnName) {
+        //获取字段过滤条件
+        List<String> fieldList = fieldFilterMap.get(namespace.toUpperCase());
+        List<String> blackFieldList = fieldBlackFilterMap.get(namespace.toUpperCase());
+
+        if (fieldList == null || fieldList.isEmpty()) {
+            return blackFieldList == null || blackFieldList.isEmpty() || !blackFieldList.contains(columnName.toUpperCase());
+        } else {
+            return fieldList.contains(columnName.toUpperCase());
+        }
+    }
+
+    private CanalEntry.Column.Builder extractColumn(String fieldName, Object fieldVal, boolean isAfter) {
+
+        CanalEntry.Column.Builder columnBuilder = CanalEntry.Column.newBuilder();
+
+        columnBuilder.setName(fieldName);
+        if (ID_FIELD_NAME.equals(fieldName)) {
+            columnBuilder.setIsKey(true);
+        }
+
+        if (isAfter) {
+            columnBuilder.setUpdated(true);
+        }
+
+        if (fieldVal == null || !isAfter) { //mongo oplog无变更前字段信息，在此mock column变更前为空
+            columnBuilder.setIsNull(true);
+        } else {
+            columnBuilder.setIsNull(false);
+
+            if (fieldVal instanceof ObjectId) {
+                columnBuilder.setValue(((ObjectId) fieldVal).toHexString());
+                columnBuilder.setSqlType(Types.VARCHAR);
+            } else if (fieldVal instanceof UUID) {
+                columnBuilder.setValue(fieldVal.toString());
+                columnBuilder.setSqlType(Types.VARCHAR);
+            } else if (fieldVal instanceof String) {
+                columnBuilder.setValue(fieldVal.toString());
+                columnBuilder.setSqlType(Types.VARCHAR);
+            } else if (fieldVal instanceof Integer) {
+                columnBuilder.setValue(String.valueOf(fieldVal));
+                columnBuilder.setSqlType(Types.INTEGER);
+            } else if (fieldVal instanceof Long) {
+                columnBuilder.setValue(String.valueOf(fieldVal));
+                columnBuilder.setSqlType(Types.BIGINT);
+            } else if (fieldVal instanceof Float || fieldVal instanceof Double) {
+                columnBuilder.setValue(String.valueOf(fieldVal));
+                columnBuilder.setSqlType(Types.DECIMAL);
+            } else if (fieldVal instanceof BigInteger) {
+                columnBuilder.setValue(String.valueOf(fieldVal));
+                columnBuilder.setSqlType(Types.BIGINT);
+            } else if (fieldVal instanceof BigDecimal) {
+                columnBuilder.setValue(((BigDecimal) fieldVal).toPlainString());
+                columnBuilder.setSqlType(Types.DECIMAL);
+            } else if (fieldVal instanceof Number) { //Integer, Float, Double, Decimal128
+                columnBuilder.setValue(String.valueOf(fieldVal));
+                columnBuilder.setSqlType(Types.NUMERIC);
+            } else if (fieldVal instanceof Boolean) {
+                columnBuilder.setValue(fieldVal.toString());
+                columnBuilder.setSqlType(Types.BOOLEAN);
+            } else if (fieldVal instanceof Date) {
+                ZonedDateTime dateTime = ZonedDateTime.ofInstant(((Date) fieldVal).toInstant(), ZoneId.systemDefault());
+                columnBuilder.setValue(dateTime.format(DateTimeFormatter.ISO_INSTANT));
+                columnBuilder.setSqlType(Types.TIMESTAMP);
+            } else if (fieldVal instanceof BsonTimestamp) {
+                ZonedDateTime dateTime = ZonedDateTime.ofInstant(
+                        Instant.ofEpochSecond(((BsonTimestamp) fieldVal).getTime()), ZoneId.systemDefault());
+                columnBuilder.setValue(dateTime.format(DateTimeFormatter.ISO_INSTANT));
+                columnBuilder.setSqlType(Types.TIMESTAMP);
+            } else if (fieldVal instanceof BsonDbPointer) {
+                BsonDbPointer dbPointer = (BsonDbPointer) fieldVal;
+                if (dbPointer.getId() != null) {
+                    columnBuilder.setValue(dbPointer.getId().toHexString());
+                } else {
+                    columnBuilder.setIsNull(true);
+                }
+                columnBuilder.setSqlType(Types.VARCHAR);
+            } else if (fieldVal instanceof Symbol) {
+                Symbol symbol = (Symbol) fieldVal;
+                if (symbol.getSymbol() != null) {
+                    columnBuilder.setValue(symbol.getSymbol());
+                } else {
+                    columnBuilder.setIsNull(true);
+                }
+                columnBuilder.setSqlType(Types.VARCHAR);
+            } else if (fieldVal instanceof BsonRegularExpression) {
+                BsonRegularExpression regularExpression = (BsonRegularExpression) fieldVal;
+                if (!Strings.isNullOrEmpty(regularExpression.getPattern())) {
+                    columnBuilder.setValue(regularExpression.getPattern());
+                } else {
+                    columnBuilder.setIsNull(true);
+                }
+                columnBuilder.setSqlType(Types.VARCHAR);
+            } else if (fieldVal instanceof Binary) {
+                Binary binary = (Binary) fieldVal;
+                if (binary.getData() != null) {
+                    try {
+                        columnBuilder.setValue(new String(binary.getData(), ISO_8859_1));
+                    } catch (UnsupportedEncodingException e) {
+                        throw new IllegalArgumentException("illegal encoding ", e);
+                    }
+                } else {
+                    columnBuilder.setIsNull(true);
+                }
+
+                columnBuilder.setSqlType(Types.BLOB);
+            } else if (fieldVal instanceof Iterable) {
+                columnBuilder.setValue(JSON.toJSONString(fieldVal));
+                columnBuilder.setSqlType(Types.VARCHAR);
+            } else if (fieldVal instanceof Map) { //Document is also Map
+                columnBuilder.setValue(JSON.toJSONString(fieldVal));
+                columnBuilder.setSqlType(Types.VARCHAR);
+            } else if (fieldVal instanceof Undefined || fieldVal instanceof MaxKey
+                    || fieldVal instanceof MinKey || fieldVal instanceof Code) {
+                columnBuilder.setIsNull(true);
+                logger.warn("ignored type of : {}", fieldVal.getClass().getName());
+            } else {
+                logger.error("unsupported type of {}", fieldVal);
+                throw new IllegalStateException("unsupported type of {}" + fieldVal);
+            }
+        }
+
+        return columnBuilder;
+    }
+
+    public void setFieldFilterMap(Map<String, List<String>> fieldFilterMap) {
+        this.fieldFilterMap = fieldFilterMap;
+    }
+
+    public void setFieldBlackFilterMap(Map<String, List<String>> fieldBlackFilterMap) {
+        this.fieldBlackFilterMap = fieldBlackFilterMap;
+    }
+
+    public void setNameFilter(AviaterRegexFilter nameFilter) {
+        this.nameFilter = nameFilter;
+    }
+
+    public void setNameBlackFilter(AviaterRegexFilter nameBlackFilter) {
+        this.nameBlackFilter = nameBlackFilter;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -331,6 +331,11 @@
                 <!--<scope>test</scope>-->
             </dependency>
             <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-driver</artifactId>
+                <version>3.12.0</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>3.0.2</version>

--- a/protocol/src/main/java/com/alibaba/otter/canal/protocol/CanalEntry.java
+++ b/protocol/src/main/java/com/alibaba/otter/canal/protocol/CanalEntry.java
@@ -377,6 +377,10 @@ public final class CanalEntry {
      * <code>PGSQL = 3;</code>
      */
     PGSQL(2, 3),
+    /**
+     * <code>MONGODB = 4;</code>
+     */
+    MONGODB(3, 4)
     ;
 
     /**
@@ -391,7 +395,10 @@ public final class CanalEntry {
      * <code>PGSQL = 3;</code>
      */
     public static final int PGSQL_VALUE = 3;
-
+    /**
+     * <code>MONGODB = 4;</code>
+     */
+    public static final int MONGODB_VALUE = 4;
 
     public final int getNumber() { return value; }
 
@@ -400,6 +407,7 @@ public final class CanalEntry {
         case 1: return ORACLE;
         case 2: return MYSQL;
         case 3: return PGSQL;
+        case 4: return MONGODB;
         default: return null;
       }
     }

--- a/protocol/src/main/java/com/alibaba/otter/canal/protocol/EntryProtocol.proto
+++ b/protocol/src/main/java/com/alibaba/otter/canal/protocol/EntryProtocol.proto
@@ -227,4 +227,5 @@ enum Type {
     ORACLE		= 		1;
     MYSQL		= 		2;
     PGSQL		= 		3;
+	MONGODB     =       4;
 }


### PR DESCRIPTION
### MongoDB基于ChangeStream数据同步实现

#### 实现功能
1. 订阅MongoDB ChangeStream，获取数据变更
2. 记录clusterTime作为消费位点，提供消费恢复机制
3. 考虑到ChangeStreamEvent无TransactionBegin、TransactionEnd消息，并且MongoDB事务同步到RDS可能会有问题，因此没有提供按事务刷新数据的机制
4. 因为MongoDB Oplog不能获取变更前数据，CanalEntry.RowData.BeforeColumns中变更字段的值设置成了null

#### instance 配置示例
```properties
canal.instance.mongodb.hosts=127.0.0.1:27017
# 位点:  起始oplog 时间戳
canal.instance.mongodb.timestamp=1595215578550
# 位点:  起始oplog clusterTime( BsonTimestamp value)，position优先级高于timestamp
# Timestamp{value=6851398737579737089, seconds=1595215578, inc=1}
canal.instance.mongodb.position=6851398737579737089

canal.instance.dbUsername=canal
canal.instance.dbPassword=canal
```

#### canal.properties配置
```properties
# 内存位点
#canal.instance.global.spring.xml = classpath:spring/mongo-memory-instance.xml
# zk位点
canal.instance.global.spring.xml = classpath:spring/mongo-instance.xml
```