### PR TITLE
Fix:Alibaba Coding Guidelines-Object的equals方法容易抛空指针异常，应使用常量或确定有值的对象来调…

### DIFF
--- a/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/config/bind/PropertiesConfigurationFactory.java
+++ b/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/config/bind/PropertiesConfigurationFactory.java
@@ -282,7 +282,7 @@ public class PropertiesConfigurationFactory<T> implements FactoryBean<T>, Applic
             PropertyDescriptor[] descriptors = BeanUtils.getPropertyDescriptors(this.target.getClass());
             for (PropertyDescriptor descriptor : descriptors) {
                 String name = descriptor.getName();
-                if (!name.equals("class")) {
+                if (!"class".equals(name)) {
                     RelaxedNames relaxedNames = RelaxedNames.forCamelCase(name);
                     if (prefixes == null) {
                         for (String relaxedName : relaxedNames) {

--- a/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/JdbcTypeUtil.java
+++ b/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/JdbcTypeUtil.java
@@ -78,7 +78,7 @@ public class JdbcTypeUtil {
 
     public static Object typeConvert(String tableName ,String columnName, String value, int sqlType, String mysqlType) {
         if (value == null
-            || (value.equals("") && !(isText(mysqlType) || sqlType == Types.CHAR || sqlType == Types.VARCHAR || sqlType == Types.LONGVARCHAR))) {
+            || ("".equals(value) && !(isText(mysqlType) || sqlType == Types.CHAR || sqlType == Types.VARCHAR || sqlType == Types.LONGVARCHAR))) {
             return null;
         }
 

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/service/ESSyncService.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/service/ESSyncService.java
@@ -95,11 +95,11 @@ public class ESSyncService {
             long begin = System.currentTimeMillis();
 
             String type = dml.getType();
-            if (type != null && type.equalsIgnoreCase("INSERT")) {
+            if (type != null && "INSERT".equalsIgnoreCase(type)) {
                 insert(config, dml);
-            } else if (type != null && type.equalsIgnoreCase("UPDATE")) {
+            } else if (type != null && "UPDATE".equalsIgnoreCase(type)) {
                 update(config, dml);
-            } else if (type != null && type.equalsIgnoreCase("DELETE")) {
+            } else if (type != null && "DELETE".equalsIgnoreCase(type)) {
                 delete(config, dml);
             } else {
                 return;

--- a/client-adapter/hbase/src/main/java/com/alibaba/otter/canal/client/adapter/hbase/config/MappingConfig.java
+++ b/client-adapter/hbase/src/main/java/com/alibaba/otter/canal/client/adapter/hbase/config/MappingConfig.java
@@ -312,7 +312,7 @@ public class MappingConfig implements AdapterConfig {
                         columnItem.setRowKey(true);
                         rowKeyColumn = columnItem;
                     } else {
-                        if (field == null || field.equals("")) {
+                        if (field == null || "".equals(field)) {
                             columnItem.setFamily(family);
                             columnItem.setQualifier(columnField.getKey());
                         } else {

--- a/client-adapter/hbase/src/main/java/com/alibaba/otter/canal/client/adapter/hbase/service/HbaseSyncService.java
+++ b/client-adapter/hbase/src/main/java/com/alibaba/otter/canal/client/adapter/hbase/service/HbaseSyncService.java
@@ -31,11 +31,11 @@ public class HbaseSyncService {
     public void sync(MappingConfig config, Dml dml) {
         if (config != null) {
             String type = dml.getType();
-            if (type != null && type.equalsIgnoreCase("INSERT")) {
+            if (type != null && "INSERT".equalsIgnoreCase(type)) {
                 insert(config, dml);
-            } else if (type != null && type.equalsIgnoreCase("UPDATE")) {
+            } else if (type != null && "UPDATE".equalsIgnoreCase(type)) {
                 update(config, dml);
-            } else if (type != null && type.equalsIgnoreCase("DELETE")) {
+            } else if (type != null && "DELETE".equalsIgnoreCase(type)) {
                 delete(config, dml);
             }
             if (logger.isDebugEnabled()) {

--- a/client-adapter/kudu/src/main/java/com/alibaba/otter/canal/client/adapter/kudu/service/KuduSyncService.java
+++ b/client-adapter/kudu/src/main/java/com/alibaba/otter/canal/client/adapter/kudu/service/KuduSyncService.java
@@ -47,11 +47,11 @@ public class KuduSyncService {
     public void sync(KuduMappingConfig config, Dml dml) {
         if (config != null) {
             String type = dml.getType();
-            if (type != null && type.equalsIgnoreCase("INSERT")) {
+            if (type != null && "INSERT".equalsIgnoreCase(type)) {
                 insert(config, dml);
-            } else if (type != null && type.equalsIgnoreCase("UPDATE")) {
+            } else if (type != null && "UPDATE".equalsIgnoreCase(type)) {
                 upsert(config, dml);
-            } else if (type != null && type.equalsIgnoreCase("DELETE")) {
+            } else if (type != null && "DELETE".equalsIgnoreCase(type)) {
                 delete(config, dml);
             }
             if (logger.isDebugEnabled()) {

--- a/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/rest/CommonRest.java
+++ b/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/rest/CommonRest.java
@@ -181,11 +181,11 @@ public class CommonRest {
      */
     @PutMapping("/syncSwitch/{destination}/{status}")
     public Result etl(@PathVariable String destination, @PathVariable String status) {
-        if (status.equals("on")) {
+        if ("on".equals(status)) {
             syncSwitch.on(destination);
             logger.info("#Destination: {} sync on", destination);
             return Result.createSuccess("实例: " + destination + " 开启同步成功");
-        } else if (status.equals("off")) {
+        } else if ("off".equals(status)) {
             syncSwitch.off(destination);
             logger.info("#Destination: {} sync off", destination);
             return Result.createSuccess("实例: " + destination + " 关闭同步成功");

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbSyncService.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbSyncService.java
@@ -208,13 +208,13 @@ public class RdbSyncService {
         if (config != null) {
             try {
                 String type = dml.getType();
-                if (type != null && type.equalsIgnoreCase("INSERT")) {
+                if (type != null && "INSERT".equalsIgnoreCase(type)) {
                     insert(batchExecutor, config, dml);
-                } else if (type != null && type.equalsIgnoreCase("UPDATE")) {
+                } else if (type != null && "UPDATE".equalsIgnoreCase(type)) {
                     update(batchExecutor, config, dml);
-                } else if (type != null && type.equalsIgnoreCase("DELETE")) {
+                } else if (type != null && "DELETE".equalsIgnoreCase(type)) {
                     delete(batchExecutor, config, dml);
-                } else if (type != null && type.equalsIgnoreCase("TRUNCATE")) {
+                } else if (type != null && "TRUNCATE".equalsIgnoreCase(type)) {
                     truncate(batchExecutor, config);
                 }
                 if (logger.isDebugEnabled()) {

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
@@ -71,7 +71,7 @@ public class SyncUtil {
                 if (value instanceof Boolean) {
                     pstmt.setBoolean(i, (Boolean) value);
                 } else if (value instanceof String) {
-                    boolean v = !value.equals("0");
+                    boolean v = !"0".equals(value);
                     pstmt.setBoolean(i, v);
                 } else if (value instanceof Number) {
                     boolean v = ((Number) value).intValue() != 0;

--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQMessageUtils.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQMessageUtils.java
@@ -49,7 +49,7 @@ public class MQMessageUtils {
                                                                                      int i = pkHashConfig.lastIndexOf(":");
                                                                                      if (i > 0) {
                                                                                          String pkStr = pkHashConfig.substring(i + 1);
-                                                                                         if (pkStr.equalsIgnoreCase("$pk$")) {
+                                                                                         if ("$pk$".equalsIgnoreCase(pkStr)) {
                                                                                              data.hashMode.autoPkHash = true;
                                                                                          } else {
                                                                                              data.hashMode.pkNames = Lists.newArrayList(StringUtils.split(pkStr,

--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/util/JdbcTypeUtil.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/util/JdbcTypeUtil.java
@@ -78,7 +78,7 @@ public class JdbcTypeUtil {
 
     public static Object typeConvert(String tableName, String columnName, String value, int sqlType, String mysqlType) {
         if (value == null
-            || (value.equals("") && !(isText(mysqlType) || sqlType == Types.CHAR || sqlType == Types.VARCHAR || sqlType == Types.LONGVARCHAR))) {
+            || ("".equals(value) && !(isText(mysqlType) || sqlType == Types.CHAR || sqlType == Types.VARCHAR || sqlType == Types.LONGVARCHAR))) {
             return null;
         }
 

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/MysqlConnection.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/MysqlConnection.java
@@ -522,7 +522,7 @@ public class MysqlConnection implements ErosaConnection {
             rs = query("select @@global.binlog_checksum");
             List<String> columnValues = rs.getFieldValues();
             if (columnValues != null && columnValues.size() >= 1 && columnValues.get(0) != null
-                && columnValues.get(0).toUpperCase().equals("CRC32")) {
+                && "CRC32".equals(columnValues.get(0).toUpperCase())) {
                 binlogChecksum = LogEvent.BINLOG_CHECKSUM_ALG_CRC32;
             } else {
                 binlogChecksum = LogEvent.BINLOG_CHECKSUM_ALG_OFF;

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/rds/request/DescribeBackupPolicyRequest.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/rds/request/DescribeBackupPolicyRequest.java
@@ -31,7 +31,7 @@ public class DescribeBackupPolicyRequest extends AbstractRequest<RdsBackupPolicy
         JSONObject jsonObj = JSON.parseObject(result);
         RdsBackupPolicy policy = new RdsBackupPolicy();
         policy.setBackupRetentionPeriod(jsonObj.getString("BackupRetentionPeriod"));
-        policy.setBackupLog(jsonObj.getString("BackupLog").equalsIgnoreCase("Enable"));
+        policy.setBackupLog("Enable".equalsIgnoreCase(jsonObj.getString("BackupLog")));
         policy.setLogBackupRetentionPeriod(jsonObj.getIntValue("LogBackupRetentionPeriod"));
         policy.setPreferredBackupPeriod(jsonObj.getString("PreferredBackupPeriod"));
         policy.setPreferredBackupTime(jsonObj.getString("PreferredBackupTime"));


### PR DESCRIPTION
Object的equals方法容易抛空指针异常，应使用常量或确定有值的对象来调用equals。 
            
    public void f(String str){
        String inner = "hi";
        if (inner.equals(str)) {
            System.out.println("hello world");
        }
    }