### PR TITLE
抽象一个通用的线程池集合，优化sendMQ的并行线程处理

### DIFF
--- a/common/src/main/java/com/alibaba/otter/canal/common/utils/ExecutorTemplatePool.java
+++ b/common/src/main/java/com/alibaba/otter/canal/common/utils/ExecutorTemplatePool.java
@@ -1,0 +1,84 @@
+package com.alibaba.otter.canal.common.utils;
+
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 将ExecutorTemplate和线程池一起做一层封装，为的是能支持多级业务并发（为避免嵌套等待）
+ * <p>
+ * 该类的名字虽是模板池，但其实并没有缓存模板对象本身。因为模板对象是轻量级的，无需缓存。 每次调用getExecutorTemplate()方法时都会new一个新的模板对象，这样还可以避免因使用不当而出现wait失效的风险。
+ * <p>
+ * 该类中维护了一个线程池集合，通过将name参数传入getExecutorTemplate()方法来指定模板使用哪个线程池。 若指定的线程池不存在，则会自动新建一个。
+ * <p>
+ * 默认情况下，新建线程池的线程数为8，排队队列为线程数的2倍。使用者可通过调用setDefaultThreadNum()方法来变更默认值。
+ * 也可以在调用getExecutorTemplate()方法时通过threadNum参数指定本次新建的线程池大小（只有name不存在时才会新建）。
+ * <p>
+ * 注意，本模板池在使用完毕后需要调用其close方法，以释放其中的线程池资源
+ */
+public class ExecutorTemplatePool {
+
+    /**
+     * 默认线程池核心线程数
+     */
+    private int defaultThreadNum = 8;
+
+    /**
+     * 线程池集合
+     */
+    private Map<String, ThreadPoolExecutor> executorMap = new ConcurrentHashMap<>();
+
+    /**
+     * 变更默认线程池核心线程数 后续创建的线程池将会使用新的默认数值
+     */
+    public void setDefaultThreadNum(int defaultThreadNum) {
+        this.defaultThreadNum = defaultThreadNum;
+    }
+
+    /**
+     * 获得一个ExecutorTemplate模板对象
+     *
+     * @param name 指定该模板对象所对应的线程池
+     */
+    public ExecutorTemplate getExecutorTemplate(String name) {
+        return getExecutorTemplate(name, 0);
+    }
+
+    /**
+     * 获得一个ExecutorTemplate模板对象
+     *
+     * @param name      指定该模板对象所对应的线程池
+     * @param threadNum 指定首次创建线程池时的池大小
+     */
+    public ExecutorTemplate getExecutorTemplate(String name, int threadNum) {
+        final int _threadNum;
+        if (threadNum <= 0) {
+            _threadNum = defaultThreadNum;
+        } else {
+            _threadNum = threadNum;
+        }
+        ThreadPoolExecutor executor = executorMap.computeIfAbsent(name, key ->
+                new ThreadPoolExecutor(_threadNum,
+                        _threadNum,
+                        0,
+                        TimeUnit.SECONDS,
+                        new ArrayBlockingQueue<Runnable>(_threadNum * 2),
+                        new NamedThreadFactory("MQParallel_" + name),
+                        new ThreadPoolExecutor.CallerRunsPolicy()));
+
+        return new ExecutorTemplate(executor);
+
+    }
+
+    public void close() {
+        if (!executorMap.isEmpty()) {
+            for (ThreadPoolExecutor executor : executorMap.values()) {
+                executor.shutdownNow();
+            }
+            executorMap.clear();
+        }
+    }
+
+}

--- a/common/src/test/java/com/alibaba/otter/canal/common/ExecutorTemplatePoolTest.java
+++ b/common/src/test/java/com/alibaba/otter/canal/common/ExecutorTemplatePoolTest.java
@@ -1,0 +1,62 @@
+package com.alibaba.otter.canal.common;
+
+import com.alibaba.otter.canal.common.utils.ExecutorTemplate;
+import com.alibaba.otter.canal.common.utils.ExecutorTemplatePool;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+public class ExecutorTemplatePoolTest {
+
+    ExecutorTemplatePool executorTemplatePool = new ExecutorTemplatePool();
+
+    @Test
+    public void baseTest(){
+        System.out.println("Begin!");
+        AtomicInteger sum = new AtomicInteger(0);
+        ExecutorTemplate executorTemplate = executorTemplatePool.getExecutorTemplate("root");
+        for (int i=0; i<100; i++){
+            final int _i = i;
+            executorTemplate.submit(new Runnable() {
+                @Override
+                public void run() {
+                    int n = sum.incrementAndGet();
+//          System.out.println("i="+_i+", n="+n);
+                }
+            });
+        }
+        executorTemplate.waitForResult();
+        System.out.println("sum="+sum.get());
+        executorTemplatePool.close();
+        System.out.println("End!");
+    }
+
+    @Test
+    public void multiLevelTest(){
+        System.out.println("Begin!");
+        AtomicInteger rootSum = new AtomicInteger(0);
+        AtomicInteger subSum = new AtomicInteger(0);
+
+        ExecutorTemplate executorTemplate = executorTemplatePool.getExecutorTemplate("root");
+        for (int i=0; i<100; i++){
+            final int _i = i;
+            executorTemplate.submit(() -> {
+                int n = rootSum.incrementAndGet();
+//        System.out.println("i=" + _i + ", n=" + n);
+
+                ExecutorTemplate executorTemplate2 = executorTemplatePool.getExecutorTemplate("sub");
+                for (int j = 0; j < 10; j++) {
+                    final int _j = j;
+                    executorTemplate2.submit(() -> {
+                        int m = subSum.incrementAndGet();
+//            System.out.println("[sub] j=" + _j + ", m=" + m);
+                    });
+                }
+                executorTemplate2.waitForResult();
+            });
+        }
+        executorTemplate.waitForResult();
+        System.out.println("rootSum="+rootSum.get()+", subSum="+subSum.get());
+        executorTemplatePool.close();
+        System.out.println("End!");
+    }
+}

--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQMessageUtils.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQMessageUtils.java
@@ -198,8 +198,7 @@ public class MQMessageUtils {
      * 多线程构造message的rowChanged对象，比如为partition/flastMessage转化等处理 </br>
      * 因为protobuf对象的序列化和反序列化是cpu密集型，串行执行会有代价
      */
-    public static EntryRowData[] buildMessageData(Message message, ThreadPoolExecutor executor) {
-        ExecutorTemplate template = new ExecutorTemplate(executor);
+    public static EntryRowData[] buildMessageData(Message message, ExecutorTemplate template) {
         if (message.isRaw()) {
             List<ByteString> rawEntries = message.getRawEntries();
             final EntryRowData[] datas = new EntryRowData[rawEntries.size()];

--- a/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
+++ b/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
@@ -108,7 +108,7 @@ public class CanalRabbitMQProducer extends AbstractMQProducer implements CanalMQ
 
     @Override
     public void send(final MQDestination destination, Message message, Callback callback) {
-        ExecutorTemplate template = new ExecutorTemplate(sendExecutor);
+        ExecutorTemplate template = executorTemplatePool.getExecutorTemplate("send", mqProperties.getParallelSendThreadSize());
         try {
             if (!StringUtils.isEmpty(destination.getDynamicTopic())) {
                 // 动态topic
@@ -151,7 +151,8 @@ public class CanalRabbitMQProducer extends AbstractMQProducer implements CanalMQ
             sendMessage(topicName, message);
         } else {
             // 并发构造
-            MQMessageUtils.EntryRowData[] datas = MQMessageUtils.buildMessageData(messageSub, buildExecutor);
+            ExecutorTemplate buildTemplate = executorTemplatePool.getExecutorTemplate("build", mqProperties.getParallelBuildThreadSize());
+            MQMessageUtils.EntryRowData[] datas = MQMessageUtils.buildMessageData(messageSub, buildTemplate);
             // 串行分区
             List<FlatMessage> flatMessages = MQMessageUtils.messageConverter(datas, messageSub.getId());
             for (FlatMessage flatMessage : flatMessages) {


### PR DESCRIPTION
原逻辑中虽然使用sendExecutor和buildExecutor两个线程池解决了多级线程嵌套等待的问题，但仍然存在下面两个缺陷：
1. 并非所有的程序分支都需要这两个线程池。在一些场合下，可能一个线程池也不需要。比如不做动态topic也不分partition时。因此，这两个线程池并不是必须的，应该在需要的时候创建才更合理。
2. 在CanalRocketMQProducer中，sendExecutor仍存在线程嵌套等待的风险。应该为内层partition循环另建一个线程池。
除了上面两个问题外，将Executor与ExecutorTemplate分开管理，也使得代码不够简洁，影响可读性。

基于以上，本次改动从高内聚，灵活易扩展的角度对代码进行了优化。同时也做到了使用中创建，消除了RocketMQ场景潜在风险。