### PR TITLE
解决ClickHouse物化视图导入数据json适配问题

### DIFF
--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/config/CanalConstants.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/config/CanalConstants.java
@@ -16,6 +16,8 @@ public class CanalConstants {
     public static final String CANAL_MQ_CANAL_BATCH_SIZE      = ROOT + "." + "mq.canalBatchSize";
     public static final String CANAL_MQ_CANAL_GET_TIMEOUT     = ROOT + "." + "mq.canalGetTimeout";
     public static final String CANAL_MQ_FLAT_MESSAGE          = ROOT + "." + "mq.flatMessage";
+    public static final String CANAL_MQ_FLAT_MESSAGE_ONLYDATA = ROOT + "." + "mq.flatMessage.onlyData";
+    public static final String CANAL_MQ_FLAT_MESSAGE_SQLTYPE  = ROOT + "." + "mq.flatMessage.onlyData.sqlType";
 
     public static final String CANAL_MQ_DATABASE_HASH         = ROOT + "." + "mq.database.hash";
     public static final String CANAL_MQ_BUILD_THREAD_SIZE     = ROOT + "." + "mq.build.thread.size";

--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/config/MQProperties.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/config/MQProperties.java
@@ -9,6 +9,7 @@ package com.alibaba.otter.canal.connector.core.config;
 public class MQProperties {
 
     private boolean flatMessage             = true;
+    private boolean flatMessageOnlyData     = false;
     private boolean databaseHash            = true;
     private boolean filterTransactionEntry  = true;
     private Integer parallelBuildThreadSize = 8;
@@ -16,6 +17,7 @@ public class MQProperties {
     private Integer fetchTimeout            = 100;
     private Integer batchSize               = 50;
     private String  accessChannel           = "local";
+    private String  flatMessageSqlType      = "INSERT";
 
     private String  aliyunAccessKey         = "";
     private String  aliyunSecretKey         = "";
@@ -27,6 +29,22 @@ public class MQProperties {
 
     public void setFlatMessage(boolean flatMessage) {
         this.flatMessage = flatMessage;
+    }
+
+    public boolean isFlatMessageOnlyData() {
+        return flatMessageOnlyData;
+    }
+
+    public void setFlatMessageOnlyData(boolean flatMessageOnlyData) {
+        this.flatMessageOnlyData = flatMessageOnlyData;
+    }
+
+    public void setFlatMessageSqlType(String flatMessageSqlType) {
+        this.flatMessageSqlType = flatMessageSqlType;
+    }
+
+    public String getFlatMessageSqlType() {
+        return this.flatMessageSqlType;
     }
 
     public boolean isDatabaseHash() {

--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/AbstractMQProducer.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/AbstractMQProducer.java
@@ -85,6 +85,14 @@ public abstract class AbstractMQProducer implements CanalMQProducer {
         if (!StringUtils.isEmpty(flatMessage)) {
             mqProperties.setFlatMessage(Boolean.parseBoolean(flatMessage));
         }
+        String flatMessageOnlyData = properties.getProperty(CanalConstants.CANAL_MQ_FLAT_MESSAGE_ONLYDATA);
+        if (!StringUtils.isEmpty(flatMessageOnlyData)) {
+            mqProperties.setFlatMessageOnlyData(Boolean.parseBoolean(flatMessageOnlyData));
+        }
+        String flatMessageSqlType = properties.getProperty(CanalConstants.CANAL_MQ_FLAT_MESSAGE_SQLTYPE);
+        if (!StringUtils.isEmpty(flatMessageSqlType)) {
+            mqProperties.setFlatMessageSqlType(flatMessageSqlType);
+        }
 
         String databaseHash = properties.getProperty(CanalConstants.CANAL_MQ_DATABASE_HASH);
         if (!StringUtils.isEmpty(databaseHash)) {


### PR DESCRIPTION
【问题描述】
canal通过订阅binlog 写入kafka，再写入ClickHouse物化视图时，存在json适配的问题。
为了方便数据类型转换，只把binlog中 data部分 转换成json写入kafka，并且只关注INSERT语句的变更。

【解决方法】
新增canal.mq.flatMessage.onlyData 和 canal.mq.flatMessage.onlyData.sqlType参数
分别控制是否开启此功能和type的过滤字符，默认值为 false和INSERT。

样例:
canal.mq.flatMessage.onlyData 为false时：
{"data":[{"emp_no":"22321","birth_date":"2020-03-10","first_name":"f","last_name":"kkk","gender":"1","hire_date":"2020-08-09"}],"database":"empdb_1","es":1599208662000,"id":2,"isDdl":false,"mysqlType":{"emp_no":"int(11)","birth_date":"date","first_name":"varchar(14)","last_name":"varchar(16)","gender":"enum('M','F')","hire_date":"date"},"old":null,"pkNames":["emp_no"],"sql":"","sqlType":{"emp_no":4,"birth_date":91,"first_name":12,"last_name":12,"gender":4,"hire_date":91},"table":"employees_20200802","ts":1599208662778,"type":"INSERT"}

canal.mq.flatMessage.onlyData 为true时：
{"emp_no":"22321","birth_date":"2020-03-10","first_name":"f","last_name":"kkk","gender":"1","hire_date":"2020-08-09"}

mysql建表语句：
CREATE TABLE `employees_20200802` (
  `emp_no` int(11) NOT NULL,
  `birth_date` date NOT NULL,
  `first_name` varchar(14) NOT NULL,
  `last_name` varchar(16) NOT NULL,
  `gender` enum('M','F') NOT NULL,
  `hire_date` date NOT NULL,
  PRIMARY KEY (`emp_no`)
);

clickhouse建表语句：
CREATE DATABASE testckdb;

CREATE TABLE IF NOT EXISTS testckdb.ck_employees (`emp_no` Int32, `birth_date` String, `first_name` String, `last_name` String, `gender` String, `hire_date` String) ENGINE=MergeTree() ORDER BY (emp_no) SETTINGS index_granularity = 8192;

CREATE TABLE IF NOT EXISTS testckdb.ck_employees_stream (`emp_no` Int32, `birth_date` String, `first_name` String, `last_name` String, `gender` String, `hire_date` String) ENGINE = Kafka() SETTINGS kafka_broker_list = '172.21.48.11:9092', kafka_topic_list = 'employees_topic', kafka_group_name = 'employees_group', kafka_format = 'JSONEachRow', kafka_skip_broken_messages = 1024, kafka_num_consumers = 1;

CREATE MATERIALIZED VIEW IF NOT EXISTS testckdb.ck_employees_mv TO testckdb.ck_employees(`emp_no` Int32, `birth_date` String, `first_name` String, `last_name` String, `gender` String, `hire_date` String) AS SELECT `emp_no`, `birth_date`, `first_name`, `last_name`, `gender`, `hire_date` FROM testckdb.ck_employees_stream; 

