### PR TITLE
fix: v1.1.5-snapshot rdb-adapter 由关键字引起的异常 (#3026 #2783)

### DIFF
--- a/client-adapter/README.md
+++ b/client-adapter/README.md
@@ -310,7 +310,7 @@ dbMapping:
     role_id:
     c_time:
     test1:
-  keywordsIdentifier:           # 关键字、保留字标识符
+  targetKeywordsIdentifier:     # 关键字、保留字标识符
     prefix: '`'                 # 前缀，默认值为 `
     suffix: '`'                 # 后缀，默认值为 `
 ```

--- a/client-adapter/README.md
+++ b/client-adapter/README.md
@@ -292,7 +292,7 @@ adapter将会自动加载 conf/rdb 下的所有.yml结尾的表映射配置文�
 
 ### 4.2 适配器表映射文件
 修改 conf/rdb/mytest_user.yml文件:
-```
+``` yml
 dataSourceKey: defaultDS        # 源数据源的key, 对应上面配置的srcDataSources中的值
 destination: example            # cannal的instance或者MQ的topic
 outerAdapterKey: oracle1        # adapter key, 对应上面配置outAdapters中的key
@@ -309,7 +309,10 @@ dbMapping:
     name:
     role_id:
     c_time:
-    test1: 
+    test1:
+  keywordsIdentifier:           # 关键字、保留字标识符
+    prefix: '`'                 # 前缀，默认值为 `
+    suffix: '`'                 # 后缀，默认值为 `
 ```
 导入的类型以目标表的元类型为准, 将自动转换
 

--- a/client-adapter/pom.xml
+++ b/client-adapter/pom.xml
@@ -177,7 +177,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.1.4</version>
+                <version>42.2.16</version>
             </dependency>
             <dependency>
                 <groupId>com.oracle</groupId>

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/MappingConfig.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/MappingConfig.java
@@ -93,30 +93,29 @@ public class MappingConfig implements AdapterConfig {
 
     public static class DbMapping implements AdapterMapping {
 
-        private boolean             mirrorDb            = false;                            // 是否镜像库
-        private String              database;                                               // 数据库名或schema名
-        private String              table;                                                  // 表名
-        private Map<String, String> targetPk            = new LinkedHashMap<>();            // 目标表主键字段
-        private boolean             mapAll              = false;                            // 映射所有字段
-        private String              targetDb;                                               // 目标库名
-        private String              targetTable;                                            // 目标表名
-        private Map<String, String> targetColumns;                                          // 目标表字段映射
+        private boolean             mirrorDb                 = false;                  // 是否镜像库
+        private String              database;                                          // 数据库名或schema名
+        private String              table;                                             // 表名
+        private Map<String, String> targetPk                 = new LinkedHashMap<>();  // 目标表主键字段
+        private boolean             mapAll                   = false;                  // 映射所有字段
+        private String              targetDb;                                          // 目标库名
+        private String              targetTable;                                       // 目标表名
+        private Map<String, String> targetColumns;                                     // 目标表字段映射
+        private Map<String, String> targetKeywordsIdentifier = new LinkedHashMap<>(2); // 目标库保留字标识符
 
-        private boolean             caseInsensitive     = false;                            // 目标表不区分大小写，默认是否
+        private boolean             caseInsensitive          = false;                  // 目标表不区分大小写，默认是否
 
-        private String              etlCondition;                                           // etl条件sql
+        private String              etlCondition;                                      // etl条件sql
 
-        private int                 readBatch           = 5000;
-        private int                 commitBatch         = 5000;                             // etl等批量提交大小
-
-        private Map<String, String> keywordsIdentifier  = new LinkedHashMap<>(2);  // 保留字标识符前缀
+        private int                 readBatch                = 5000;
+        private int                 commitBatch              = 5000;                   // etl等批量提交大小
 
         private Map<String, String> allMapColumns;
 
-        public DbMapping() {
+        public DbMapping(){
             // 默认值为"`", 兼容老代码
-            this.keywordsIdentifier.put(RDBConstants.KEYWORDS_IDENTIFIER_PREFIX, "`");
-            this.keywordsIdentifier.put(RDBConstants.KEYWORDS_IDENTIFIER_SUFFIX, "`");
+            this.targetKeywordsIdentifier.put(RDBConstants.KEYWORDS_IDENTIFIER_PREFIX, "`");
+            this.targetKeywordsIdentifier.put(RDBConstants.KEYWORDS_IDENTIFIER_SUFFIX, "`");
         }
 
         public boolean getMirrorDb() {
@@ -227,14 +226,15 @@ public class MappingConfig implements AdapterConfig {
          * mysql: <code>select `name`,`date` from user</code><br>
          * postgresql: <code>select "name","date" from user</code><br>
          * mssql: <code>select [name],[date] from user</code><br>
+         * 
          * @return 标识符
          */
-        public Map<String, String> getKeywordsIdentifier() {
-            return keywordsIdentifier;
+        public Map<String, String> getTargetKeywordsIdentifier() {
+            return targetKeywordsIdentifier;
         }
 
-        public void setKeywordsIdentifier(Map<String, String> keywordsIdentifier) {
-            this.keywordsIdentifier = keywordsIdentifier;
+        public void setTargetKeywordsIdentifier(Map<String, String> targetKeywordsIdentifier) {
+            this.targetKeywordsIdentifier = targetKeywordsIdentifier;
         }
 
         public Map<String, String> getAllMapColumns() {

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/MappingConfig.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/MappingConfig.java
@@ -1,11 +1,11 @@
 package com.alibaba.otter.canal.client.adapter.rdb.config;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+import com.alibaba.otter.canal.client.adapter.support.AdapterConfig;
 
 import org.apache.commons.lang.StringUtils;
 
-import com.alibaba.otter.canal.client.adapter.support.AdapterConfig;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * RDB表映射配置
@@ -93,23 +93,31 @@ public class MappingConfig implements AdapterConfig {
 
     public static class DbMapping implements AdapterMapping {
 
-        private boolean             mirrorDb        = false;                 // 是否镜像库
-        private String              database;                                // 数据库名或schema名
-        private String              table;                                   // 表名
-        private Map<String, String> targetPk        = new LinkedHashMap<>(); // 目标表主键字段
-        private boolean             mapAll          = false;                 // 映射所有字段
-        private String              targetDb;                                // 目标库名
-        private String              targetTable;                             // 目标表名
-        private Map<String, String> targetColumns;                           // 目标表字段映射
+        private boolean             mirrorDb            = false;                            // 是否镜像库
+        private String              database;                                               // 数据库名或schema名
+        private String              table;                                                  // 表名
+        private Map<String, String> targetPk            = new LinkedHashMap<>();            // 目标表主键字段
+        private boolean             mapAll              = false;                            // 映射所有字段
+        private String              targetDb;                                               // 目标库名
+        private String              targetTable;                                            // 目标表名
+        private Map<String, String> targetColumns;                                          // 目标表字段映射
 
-        private boolean             caseInsensitive = false;                 // 目标表不区分大小写，默认是否
+        private boolean             caseInsensitive     = false;                            // 目标表不区分大小写，默认是否
 
-        private String              etlCondition;                            // etl条件sql
+        private String              etlCondition;                                           // etl条件sql
 
-        private int                 readBatch       = 5000;
-        private int                 commitBatch     = 5000;                  // etl等批量提交大小
+        private int                 readBatch           = 5000;
+        private int                 commitBatch         = 5000;                             // etl等批量提交大小
+
+        private Map<String, String> keywordsIdentifier  = new LinkedHashMap<>(2);  // 保留字标识符前缀
 
         private Map<String, String> allMapColumns;
+
+        public DbMapping() {
+            // 默认值为"`", 兼容老代码
+            this.keywordsIdentifier.put(RDBConstants.KEYWORDS_IDENTIFIER_PREFIX, "`");
+            this.keywordsIdentifier.put(RDBConstants.KEYWORDS_IDENTIFIER_SUFFIX, "`");
+        }
 
         public boolean getMirrorDb() {
             return mirrorDb;
@@ -212,6 +220,21 @@ public class MappingConfig implements AdapterConfig {
 
         public void setCommitBatch(int commitBatch) {
             this.commitBatch = commitBatch;
+        }
+
+        /**
+         * 保留字标识符前缀 [prefix]:前缀 [suffix]:后缀<br>
+         * mysql: <code>select `name`,`date` from user</code><br>
+         * postgresql: <code>select "name","date" from user</code><br>
+         * mssql: <code>select [name],[date] from user</code><br>
+         * @return 标识符
+         */
+        public Map<String, String> getKeywordsIdentifier() {
+            return keywordsIdentifier;
+        }
+
+        public void setKeywordsIdentifier(Map<String, String> keywordsIdentifier) {
+            this.keywordsIdentifier = keywordsIdentifier;
         }
 
         public Map<String, String> getAllMapColumns() {

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/RDBConstants.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/RDBConstants.java
@@ -1,0 +1,17 @@
+package com.alibaba.otter.canal.client.adapter.rdb.config;
+
+/**
+ * @author XuDaojie
+ * @since 2020/9/11
+ */
+public class RDBConstants {
+
+    /**
+     * 保留字标识符前缀
+     */
+    public static final String KEYWORDS_IDENTIFIER_PREFIX = "prefix";
+    /**
+     * 保留字标识符后缀
+     */
+    public static final String KEYWORDS_IDENTIFIER_SUFFIX = "suffix";
+}

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbSyncService.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbSyncService.java
@@ -243,7 +243,7 @@ public class RdbSyncService {
 
         DbMapping dbMapping = config.getDbMapping();
 
-        Map<String, String> keywordsIdentifier = dbMapping.getKeywordsIdentifier();
+        Map<String, String> keywordsIdentifier = dbMapping.getTargetKeywordsIdentifier();
         Map<String, String> columnsMap = SyncUtil.getColumnsMap(dbMapping, data);
 
         StringBuilder insertSql = new StringBuilder();
@@ -316,7 +316,7 @@ public class RdbSyncService {
 
         DbMapping dbMapping = config.getDbMapping();
 
-        Map<String, String> keywordsIdentifier = dbMapping.getKeywordsIdentifier();
+        Map<String, String> keywordsIdentifier = dbMapping.getTargetKeywordsIdentifier();
         Map<String, String> columnsMap = SyncUtil.getColumnsMap(dbMapping, data);
 
         Map<String, Integer> ctype = getTargetColumnType(batchExecutor.getConn(), config);
@@ -451,7 +451,7 @@ public class RdbSyncService {
 
     private void appendCondition(MappingConfig.DbMapping dbMapping, StringBuilder sql, Map<String, Integer> ctype,
                                  List<Map<String, ?>> values, Map<String, Object> d, Map<String, Object> o) {
-        Map<String, String> keywordsIdentifier = dbMapping.getKeywordsIdentifier();
+        Map<String, String> keywordsIdentifier = dbMapping.getTargetKeywordsIdentifier();
 
         // 拼接主键
         for (Map.Entry<String, String> entry : dbMapping.getTargetPk().entrySet()) {

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/BatchExecutor.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/BatchExecutor.java
@@ -1,5 +1,8 @@
 package com.alibaba.otter.canal.client.adapter.rdb.support;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Closeable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -10,9 +13,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.sql.DataSource;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * sql批量执行器
@@ -60,6 +60,9 @@ public class BatchExecutor implements Closeable {
             SyncUtil.setPStmt(type, pstmt, value, i + 1);
         }
 
+        if (logger.isDebugEnabled()) {
+            logger.debug("DML: {}", pstmt.toString());
+        }
         pstmt.execute();
         idx.incrementAndGet();
         pstmt.close();

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
@@ -1,5 +1,10 @@
 package com.alibaba.otter.canal.client.adapter.rdb.support;
 
+import com.alibaba.otter.canal.client.adapter.rdb.config.MappingConfig;
+import com.alibaba.otter.canal.client.adapter.support.Util;
+
+import org.apache.commons.lang.StringUtils;
+
 import java.io.Reader;
 import java.io.StringReader;
 import java.math.BigDecimal;
@@ -15,11 +20,6 @@ import java.sql.Types;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import org.apache.commons.lang.StringUtils;
-
-import com.alibaba.otter.canal.client.adapter.rdb.config.MappingConfig;
-import com.alibaba.otter.canal.client.adapter.support.Util;
 
 public class SyncUtil {
 
@@ -262,9 +262,9 @@ public class SyncUtil {
     public static String getDbTableName(MappingConfig.DbMapping dbMapping) {
         String result = "";
         if (StringUtils.isNotEmpty(dbMapping.getTargetDb())) {
-            result += dbMapping.getTargetDb() + ".";
+            result += "`" + dbMapping.getTargetDb() + "`.";
         }
-        result += dbMapping.getTargetTable();
+        result += "`" + dbMapping.getTargetTable() + "`";
         return result;
     }
 }

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
@@ -262,9 +262,9 @@ public class SyncUtil {
     public static String getDbTableName(MappingConfig.DbMapping dbMapping) {
         String result = "";
         if (StringUtils.isNotEmpty(dbMapping.getTargetDb())) {
-            result += "`" + dbMapping.getTargetDb() + "`.";
+            result += dbMapping.getTargetDb() + ".";
         }
-        result += "`" + dbMapping.getTargetTable() + "`";
+        result += dbMapping.getTargetTable();
         return result;
     }
 }

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
@@ -2,9 +2,8 @@ package com.alibaba.otter.canal.client.adapter.rdb.support;
 
 import com.alibaba.otter.canal.client.adapter.rdb.config.MappingConfig;
 import com.alibaba.otter.canal.client.adapter.support.Util;
+
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Reader;
 import java.io.StringReader;
@@ -22,13 +21,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
-
-import com.alibaba.otter.canal.client.adapter.rdb.config.MappingConfig;
-import com.alibaba.otter.canal.client.adapter.support.Util;
-
 public class SyncUtil {
-    private static final Logger logger  = LoggerFactory.getLogger(SyncUtil.class);
 
     public static Map<String, String> getColumnsMap(MappingConfig.DbMapping dbMapping, Map<String, Object> data) {
         return getColumnsMap(dbMapping, data.keySet());
@@ -66,10 +59,10 @@ public class SyncUtil {
     /**
      * 设置 preparedStatement
      *
-     * @param type sqlType
+     * @param type  sqlType
      * @param pstmt 需要设置的preparedStatement
      * @param value 值
-     * @param i 索引号
+     * @param i     索引号
      */
     public static void setPStmt(int type, PreparedStatement pstmt, Object value, int i) throws SQLException {
         switch (type) {


### PR DESCRIPTION
fix #3026 
fix #2783 

## 问题描述 
- ~~#3019 问题已关闭，第一个commit原本是解决这个问题的，后面发现可以通过调整配置解决~~
- postgres 驱动不兼容 `postgres:12.4`  升级驱动为`42.2.16`
- #3026 #2783 
  此pull request最初是想解决#3019，后经@yansheng105 提醒这种实现不能兼容postgres，查看文档后发现rdb-adapter原本设计的是支持多种rdb数据库，#2358中兼容了mysql关键字后导致rdb-adapter只能兼容MySQL

## 解决过程
1. 关键字处理主要涉及表名、字段名，对于表名可以通过在配置yml文件时直接加上标识符解决，而字段名存在关键字并且mapAll=true的话则目前代码无法处理，目前代码主要是处理的**字段名关键字标识符**的问题
2. 不同数据库处理保留字的标识符不同，第一种方案是通过判断数据库连接自动确定标识符，第二种是通过增加配置项，
目前选的第二种方案，主要考虑不同数据库标识符不同，出现了未知的数据库也可以自行配置
```sql
mysql: select `name`,`date` from user;
postgresql: select "name","date" from user;
mssql: select [name],[date] from user;
```
## 新增配置

```yml
# postgres
dbMapping:
  database: retl
  table: xdual
  targetTable: '"a-b"'       # 处理表名包含关键字或`-`，直接引号通过声明表名即可解决
  targetPk:
    id: id
  targetKeywordsIdentifier:  # 新增配置项 关键字、保留字标识符(对表名无效)
    prefix: '"'              # 默认值为 `
    suffix: '"'              # 默认值为 `
  mapAll: true
  commitBatch: 3000

```
