### PR TITLE
fix(client-adapter):  ETL执行时 task not found 异常问题

### DIFF
--- a/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/rest/CommonRest.java
+++ b/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/rest/CommonRest.java
@@ -63,7 +63,7 @@ public class CommonRest {
      * @param task 任务名对应配置文件名 mytest_user.yml
      * @param params etl where条件参数, 为空全部导入
      */
-    @PostMapping("/etl/{type}/{key}/{task}")
+    @PostMapping("/etl/{type}/{key}/{task:.+}")
     public EtlResult etl(@PathVariable String type, @PathVariable String key, @PathVariable String task,
                          @RequestParam(name = "params", required = false) String params) {
         OuterAdapter adapter = loader.getExtension(type, key);
@@ -117,7 +117,7 @@ public class CommonRest {
      * @param task 任务名对应配置文件名 mytest_person2.yml
      * @param params etl where条件参数, 为空全部导入
      */
-    @PostMapping("/etl/{type}/{task}")
+    @PostMapping("/etl/{type}/{task:.+}")
     public EtlResult etl(@PathVariable String type, @PathVariable String task,
                          @RequestParam(name = "params", required = false) String params) {
         return etl(type, null, task, params);


### PR DESCRIPTION
## 环境
* canal version : v1.1.5-alpha-2

## 问题描述
执行ETL curl请求时，将会出现偶发性的 task not found异常
```
curl http://localhost:8081/etl/es6/es6Yinhua/hea_anls_field_data_raw__hea_anls_field_data_raw.yml -X POST
```
## Debug
在CommonRest代码中发现
```
//1、SpringMVC中此处 {task} 默认情况下获取小数点后的数据将会导致截取，也就是发送 my_person.yml时，此处的task获取到的最终数据是my_person
@PostMapping("/etl/{type}/{key}/{task}")
    public EtlResult etl(@PathVariable String type, @PathVariable String key, @PathVariable String task,
                         @RequestParam(name = "params", required = false) String params) {
        OuterAdapter adapter = loader.getExtension(type, key);
        //2、此处代码执行后得到的 destination 必然是空的数据
        String destination = adapter.getDestination(task);
       //3、此处的这个判断则是导致偶发的诱因
        String lockKey = destination == null ? task : destination;

        boolean locked = etlLock.tryLock(ETL_LOCK_ZK_NODE + type + "-" + lockKey);
        if (!locked) {
            EtlResult result = new EtlResult();
            result.setSucceeded(false);
            result.setErrorMessage(task + " 有其他进程正在导入中, 请稍后再试");
            return result;
        }
        try {

            boolean oriSwitchStatus;
            if (destination != null) {
                oriSwitchStatus = syncSwitch.status(destination);
                if (oriSwitchStatus) {
                    syncSwitch.off(destination);
                }
            } else {
                // task可能为destination，直接锁task
                oriSwitchStatus = syncSwitch.status(task);
                if (oriSwitchStatus) {
                    syncSwitch.off(task);
                }
            }
            try {
                List<String> paramArray = null;
                if (params != null) {
                    paramArray = Arrays.asList(params.trim().split(";"));
                }
                //4、开始调用对应的适配器etl方法；此处以ES6xAdapter下的ETL举例
                return adapter.etl(task, paramArray);
            } finally {
                if (destination != null && oriSwitchStatus) {
                    syncSwitch.on(destination);
                } else if (destination == null && oriSwitchStatus) {
                    syncSwitch.on(task);
                }
            }
        } finally {
            etlLock.unlock(ETL_LOCK_ZK_NODE + type + "-" + lockKey);
        }
    }
```
ES6xAdapter下ETL代码
```
public EtlResult etl(String task, List<String> params) {
        EtlResult etlResult = new EtlResult();
        //5、此处根据task值获取对应的ESSyncConfig 结果必然为空，因为esSyncConfig中所存储的key是文件名：my_person.yml
        ESSyncConfig config = esSyncConfig.get(task);
        if (config != null) {
            DataSource dataSource = DatasourceConfig.DATA_SOURCES.get(config.getDataSourceKey());
            ESEtlService esEtlService = new ESEtlService(esConnection, config);
            if (dataSource != null) {
                return esEtlService.importData(params);
            } else {
                etlResult.setSucceeded(false);
                etlResult.setErrorMessage("DataSource not found");
                return etlResult;
            }
        } else {
            StringBuilder resultMsg = new StringBuilder();
            boolean resSuccess = true;
            //6、代码中config 为空后，试图通过循环esSyncConfig所有数据的方式进行配对，
            for (ESSyncConfig configTmp : esSyncConfig.values()) {
                // 取所有的destination为task的配置
               //7、此时便会出现一个重要问题：如果此时某个*.yml配置文件中所配置的Destination刚好和此时的task对应时，将会获取到对应的configTmp，那么后续则便会一错再错；当然也存在第二种情况：此处的my_person.yml中所配置的destination和当前的文件名刚好对应，及：destination = my_person，那么此时将会获取到正确的configTmp，也导致整个ETL是可以完整运行的，但是对于 yml文件中所配置的destination和文件名不一致的情况，则会出现task not found 的异常提示，导致该块代码变的相对具有偶发性；
                if (configTmp.getDestination().equals(task)) {
                    ESEtlService esEtlService = new ESEtlService(esConnection, configTmp);
                    EtlResult etlRes = esEtlService.importData(params);
                    if (!etlRes.getSucceeded()) {
                        resSuccess = false;
                        resultMsg.append(etlRes.getErrorMessage()).append("\n");
                    } else {
                        resultMsg.append(etlRes.getResultMessage()).append("\n");
                    }
                }
            }
            if (resultMsg.length() > 0) {
                etlResult.setSucceeded(resSuccess);
                if (resSuccess) {
                    etlResult.setResultMessage(resultMsg.toString());
                } else {
                    etlResult.setErrorMessage(resultMsg.toString());
                }
                return etlResult;
            }
        }
        etlResult.setSucceeded(false);
        etlResult.setErrorMessage("Task not found");
        return etlResult;
    }
```
## 修复方式

1、整体代码流程上各种else判断并非无用，所以此处最便捷的修复方式则是直接在源头上修改
直接将对应的{task}修复为 {task:.+}即可，使其可以顺利的获取到 . 后续的内容即可修复该问题。
```
@PostMapping("/etl/{type}/{key}/{task:.+}")
    public EtlResult etl(@PathVariable String type, @PathVariable String key, @PathVariable String task,
                         @RequestParam(name = "params", required = false) String params) {
}
```