### PR TITLE
fix issue:#3039 canal adapter远程配置情况下，修改application.yml的内容导致适配器无限重启，修改…

### DIFF
--- a/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/config/BootstrapConfiguration.java
+++ b/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/config/BootstrapConfiguration.java
@@ -1,13 +1,12 @@
 package com.alibaba.otter.canal.adapter.launcher.config;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
+import com.alibaba.otter.canal.adapter.launcher.monitor.remote.RemoteConfigLoader;
+import com.alibaba.otter.canal.adapter.launcher.monitor.remote.RemoteConfigLoaderFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 
-import com.alibaba.otter.canal.adapter.launcher.monitor.remote.RemoteConfigLoader;
-import com.alibaba.otter.canal.adapter.launcher.monitor.remote.RemoteConfigLoaderFactory;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 /**
  * Bootstrap级别配置加载
@@ -22,13 +21,20 @@ public class BootstrapConfiguration {
 
     private RemoteConfigLoader remoteConfigLoader = null;
 
+    // 通过此变量控制此类的loadRemoteConfig方法只被执行一次
+    // 防止远程配置环境下执行contextRefresher.refresh()时调用到loadRemoteConfig再次触发文件更改事件，造成死循环
+    private volatile boolean inited = false;
+
     @PostConstruct
     public void loadRemoteConfig() {
-        remoteConfigLoader = RemoteConfigLoaderFactory.getRemoteConfigLoader(env);
-        if (remoteConfigLoader != null) {
-            remoteConfigLoader.loadRemoteConfig();
-            remoteConfigLoader.loadRemoteAdapterConfigs();
-            remoteConfigLoader.startMonitor(); // 启动监听
+        if (!inited) {
+            remoteConfigLoader = RemoteConfigLoaderFactory.getRemoteConfigLoader(env);
+            if (remoteConfigLoader != null) {
+                remoteConfigLoader.loadRemoteConfig();
+                remoteConfigLoader.loadRemoteAdapterConfigs();
+                remoteConfigLoader.startMonitor(); // 启动监听
+                inited = true;
+            }
         }
     }
 


### PR DESCRIPTION
### 场景：
canal adapter 配置为从数据库中加载配置文件

### 遇到的问题：
1. 修改数据库中application.yml的内容，适配器将无限重启
2. 修改数据库中rdb配置内容，适配器打印已加载远端配置，但实际上未生效

### 问题成因：
**问题1：文件更改监听事件中的contextRefresher.refresh()将重新创建一个springboot环境，创建过程中会再次调用到BootstrapConfiguration类的loadRemoteConfig方法，loadRemoteConfig方法将会触发文件更改事件，然后就死循环了。**

部分源码如下：
com.alibaba.otter.canal.adapter.launcher.monitor.ApplicationConfigMonitor
```
    public void onFileChange(File file) {
            super.onFileChange(file);
            try {
                // 检查yml格式
                new Yaml().loadAs(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8), Map.class);

                canalAdapterService.destroy();
                // refresh context
                contextRefresher.refresh();
                try {
                    Thread.sleep(2000);
                } catch (InterruptedException e) {
                    // ignore
                }
                canalAdapterService.init();
                logger.info("## adapter application config reloaded.");
            } catch (Exception e) {
                logger.error(e.getMessage(), e);
            }
        }
```
com.alibaba.otter.canal.adapter.launcher.config.BootstrapConfiguration
```
    @PostConstruct
    public void loadRemoteConfig() {
        if (!inited) {
            remoteConfigLoader = RemoteConfigLoaderFactory.getRemoteConfigLoader(env);
            if (remoteConfigLoader != null) {
                remoteConfigLoader.loadRemoteConfig();
                remoteConfigLoader.loadRemoteAdapterConfigs();
                remoteConfigLoader.startMonitor(); // 启动监听
                inited = true;
            }
        }
    }
```

**问题2：通过debug发现文件更改事件中addConfigToCache方法，加载新配置时没有判断使用的时tcp还是mq模式，导致生成的key与原配置在内存中的key不一致，实际上没有正确执行覆盖操作。**

部分源码如下：
com.alibaba.otter.canal.client.adapter.rdb.service.RdbSyncService
```
                Map<String, MappingConfig> configMap;
                if (envProperties != null && !"tcp".equalsIgnoreCase(envProperties.getProperty("canal.conf.mode"))) {
                    configMap = mappingConfig.get(destination + "-" + groupId + "_" + database + "-" + table);
                } else {
                    configMap = mappingConfig.get(destination + "_" + database + "-" + table);
                }
```
com.alibaba.otter.canal.client.adapter.rdb.monitor.RdbConfigMonitor
```
private void addConfigToCache(File file, MappingConfig mappingConfig) {
            if (mappingConfig == null || mappingConfig.getDbMapping() == null) {
                return;
            }
            rdbAdapter.getRdbMapping().put(file.getName(), mappingConfig);
            if (!mappingConfig.getDbMapping().getMirrorDb()) {
                Map<String, MappingConfig> configMap = rdbAdapter.getMappingConfigCache()
                    .computeIfAbsent(StringUtils.trimToEmpty(mappingConfig.getDestination()) + "_"
                                     + mappingConfig.getDbMapping().getDatabase() + "-"
                                     + mappingConfig.getDbMapping().getTable(),
                        k1 -> new HashMap<>());
                configMap.put(file.getName(), mappingConfig);
            } else {
                Map<String, MirrorDbConfig> mirrorDbConfigCache = rdbAdapter.getMirrorDbConfigCache();
                mirrorDbConfigCache.put(StringUtils.trimToEmpty(mappingConfig.getDestination()) + "."
                                        + mappingConfig.getDbMapping().getDatabase(),
                    MirrorDbConfig.create(file.getName(), mappingConfig));
            }
        }
```

本PR主要解决以上两个问题。

如有错漏敬请指正！！！
如有错漏敬请指正！！！
如有错漏敬请指正！！！