### PR TITLE
修复bug  client-adapter 项目本地启动报错: Config dir not found

### DIFF
--- a/client-adapter/pom.xml
+++ b/client-adapter/pom.xml
@@ -26,12 +26,12 @@
         <module>common</module>
         <module>logger</module>
         <module>hbase</module>
-        <module>launcher</module>
         <module>rdb</module>
         <module>es6x</module>
         <module>es7x</module>
         <module>escore</module>
         <module>kudu</module>
+        <module>launcher</module>
     </modules>
 
     <licenses>


### PR DESCRIPTION
bug原因: 项目打包时没有将es6 es7等项目下的配置文件打包到launcher项目中
解决方案: 调整pom文件中的module依赖顺序解决