### PR TITLE
fix: v1.1.5 client-adapter配置高可用后启动时抛异常 (#2649 #3073)

### DIFF
--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/spi/URLClassExtensionLoader.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/spi/URLClassExtensionLoader.java
@@ -20,6 +20,7 @@ public class URLClassExtensionLoader extends URLClassLoader {
         }
 
         if (name.startsWith("java.") || name.startsWith("org.slf4j.") || name.startsWith("org.apache.logging")
+            || name.startsWith("org.apache.zookeeper.") || name.startsWith("org.I0Itec.zkclient.")
             || name.startsWith("org.apache.commons.logging.")) {
             // || name.startsWith("org.apache.hadoop."))
             // {

--- a/connector/tcp-connector/src/main/java/com/alibaba/otter/canal/connector/tcp/consumer/CanalTCPConsumer.java
+++ b/connector/tcp-connector/src/main/java/com/alibaba/otter/canal/connector/tcp/consumer/CanalTCPConsumer.java
@@ -1,11 +1,5 @@
 package com.alibaba.otter.canal.connector.tcp.consumer;
 
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-
 import com.alibaba.otter.canal.client.CanalConnector;
 import com.alibaba.otter.canal.client.impl.ClusterCanalConnector;
 import com.alibaba.otter.canal.client.impl.ClusterNodeAccessStrategy;
@@ -18,11 +12,21 @@ import com.alibaba.otter.canal.connector.core.util.MessageUtil;
 import com.alibaba.otter.canal.connector.tcp.config.TCPConstants;
 import com.alibaba.otter.canal.protocol.Message;
 
+import org.apache.commons.lang.StringUtils;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
 /**
  * TCP 消费者连接器, 一个destination对应一个SPI实例
- * 
+ *
  * @author rewerma 2020-01-30
- * @version 1.0.0
+ * @author XuDaojie
+ * @version 1.1.5
+ * @since 1.1.5
  */
 @SPI("tcp")
 public class CanalTCPConsumer implements CanalMsgConsumer {
@@ -42,7 +46,7 @@ public class CanalTCPConsumer implements CanalMsgConsumer {
         if (batchSizePro != null) {
             batchSize = Integer.parseInt(batchSizePro);
         }
-        if (host != null) {
+        if (StringUtils.isNotBlank(host)) {
             String[] ipPort = host.split(":");
             SocketAddress sa = new InetSocketAddress(ipPort[0], Integer.parseInt(ipPort[1]));
             this.canalConnector = new SimpleCanalConnector(sa, username, password, destination);


### PR DESCRIPTION
fix #3073 
fix #2649 

## 问题描述
- #2649 zookeeper相关jar在默认`ClassLoader`和`URLClassExtensionLoader`都进行了加载，导致在`ClientRunningMonitor`初始化client的`Zookeeper`节点出现冲突
- #3073 

## 问题解决
- #2649 在`URLClassExtensionLoader`排除zookeeper相关jar包
- #3073 当`canal.conf.consumer-properties.canal.tcp.server.host`为空字符串或null时，以集群模式启动
