### PR TITLE
fix: issue restart.sh 在非bin目录执行时报No such file or directory (#3076)

### DIFF
--- a/admin/admin-web/src/main/bin/restart.sh
+++ b/admin/admin-web/src/main/bin/restart.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
-sh stop.sh
+case $(uname) in
+Linux)
+  bin_abs_path=$(readlink -f $(dirname $0))
+  ;;
+*)
+  bin_abs_path=$(cd $(dirname $0) ||exit ; pwd)
+  ;;
+esac
 
-sh startup.sh
+sh "$bin_abs_path"/stop.sh
+sh "$bin_abs_path"/startup.sh

--- a/client-adapter/launcher/src/main/bin/restart.sh
+++ b/client-adapter/launcher/src/main/bin/restart.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
-sh stop.sh
+case $(uname) in
+Linux)
+  bin_abs_path=$(readlink -f $(dirname $0))
+  ;;
+*)
+  bin_abs_path=$(cd $(dirname $0) ||exit ; pwd)
+  ;;
+esac
 
-sh startup.sh
+sh "$bin_abs_path"/stop.sh
+sh "$bin_abs_path"/startup.sh

--- a/deployer/src/main/bin/restart.sh
+++ b/deployer/src/main/bin/restart.sh
@@ -2,5 +2,14 @@
 
 args=$@
 
-sh stop.sh $args
-sh startup.sh $args
+case $(uname) in
+Linux)
+  bin_abs_path=$(readlink -f $(dirname $0))
+  ;;
+*)
+  bin_abs_path=$(cd $(dirname $0) ||exit ; pwd)
+  ;;
+esac
+
+sh "$bin_abs_path"/stop.sh $args
+sh "$bin_abs_path"/startup.sh $args


### PR DESCRIPTION
fix #3076 

```shell
#!/bin/bash

sh stop.sh
sh startup.sh
```
   改为   
```shell
#!/bin/bash

case $(uname) in
Linux)
  bin_abs_path=$(readlink -f $(dirname $0))
  ;;
*)
  bin_abs_path=$(cd $(dirname $0) ||exit ; pwd)
  ;;
esac

sh "$bin_abs_path"/stop.sh
sh "$bin_abs_path"/startup.sh
```