### PR TITLE
解决本地配置了属性A，远程再配置属性A不会生效的问题。

### DIFF
--- a/deployer/src/main/java/com/alibaba/otter/canal/deployer/CanalLauncher.java
+++ b/deployer/src/main/java/com/alibaba/otter/canal/deployer/CanalLauncher.java
@@ -74,8 +74,8 @@ public class CanalLauncher {
                 }
                 Properties managerProperties = canalConfig.getProperties();
                 // merge local
-                managerProperties.putAll(properties);
-                int scanIntervalInSecond = Integer.valueOf(CanalController.getProperty(managerProperties,
+                properties.putAll( managerProperties );
+                int scanIntervalInSecond = Integer.valueOf(CanalController.getProperty(properties,
                     CanalConstants.CANAL_AUTO_SCAN_INTERVAL,
                     "5"));
                 executor.scheduleWithFixedDelay(new Runnable() {
@@ -93,8 +93,8 @@ public class CanalLauncher {
                                     canalStater.stop();
                                     Properties managerProperties = newCanalConfig.getProperties();
                                     // merge local
-                                    managerProperties.putAll(properties);
-                                    canalStater.setProperties(managerProperties);
+                                    properties.putAll( managerProperties );
+                                    canalStater.setProperties(properties);
                                     canalStater.start();
 
                                     lastCanalConfig = newCanalConfig;
@@ -107,10 +107,8 @@ public class CanalLauncher {
                     }
 
                 }, 0, scanIntervalInSecond, TimeUnit.SECONDS);
-                canalStater.setProperties(managerProperties);
-            } else {
-                canalStater.setProperties(properties);
             }
+            canalStater.setProperties(properties);
 
             canalStater.start();
             runningLatch.await();


### PR DESCRIPTION
用远程配置覆盖本地配置，这样远程配置的配置即可生效。