### PR TITLE
fix: bug 使Client-Adapter中的rdb组件可以同步unsigned 类型数据

### DIFF
--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
@@ -1,27 +1,22 @@
 package com.alibaba.otter.canal.client.adapter.rdb.support;
 
+import com.alibaba.otter.canal.client.adapter.rdb.config.MappingConfig;
+import com.alibaba.otter.canal.client.adapter.support.Util;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Reader;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.sql.Blob;
-import java.sql.Clob;
-import java.sql.Date;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.sql.Types;
+import java.sql.*;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
-
-import com.alibaba.otter.canal.client.adapter.rdb.config.MappingConfig;
-import com.alibaba.otter.canal.client.adapter.support.Util;
-
 public class SyncUtil {
+    private static final Logger logger  = LoggerFactory.getLogger(SyncUtil.class);
 
     public static Map<String, String> getColumnsMap(MappingConfig.DbMapping dbMapping, Map<String, Object> data) {
         return getColumnsMap(dbMapping, data.keySet());
@@ -93,15 +88,7 @@ public class SyncUtil {
                 }
                 break;
             case Types.TINYINT:
-                if (value instanceof Number) {
-                    pstmt.setByte(i, ((Number) value).byteValue());
-                } else if (value instanceof String) {
-                    pstmt.setByte(i, Byte.parseByte((String) value));
-                } else {
-                    pstmt.setNull(i, type);
-                }
-                break;
-            case Types.SMALLINT:
+                // 向上提升一级，处理unsigned情况
                 if (value instanceof Number) {
                     pstmt.setShort(i, ((Number) value).shortValue());
                 } else if (value instanceof String) {
@@ -110,7 +97,7 @@ public class SyncUtil {
                     pstmt.setNull(i, type);
                 }
                 break;
-            case Types.INTEGER:
+            case Types.SMALLINT:
                 if (value instanceof Number) {
                     pstmt.setInt(i, ((Number) value).intValue());
                 } else if (value instanceof String) {
@@ -119,11 +106,20 @@ public class SyncUtil {
                     pstmt.setNull(i, type);
                 }
                 break;
-            case Types.BIGINT:
+            case Types.INTEGER:
                 if (value instanceof Number) {
                     pstmt.setLong(i, ((Number) value).longValue());
                 } else if (value instanceof String) {
                     pstmt.setLong(i, Long.parseLong((String) value));
+                } else {
+                    pstmt.setNull(i, type);
+                }
+                break;
+            case Types.BIGINT:
+                if (value instanceof Number) {
+                    pstmt.setBigDecimal(i, new BigDecimal(value.toString()));
+                } else if (value instanceof String) {
+                    pstmt.setBigDecimal(i, new BigDecimal(value.toString()));
                 } else {
                     pstmt.setNull(i, type);
                 }


### PR DESCRIPTION
## 解决了什么问题
close #3060 

由于在Java中没有`unsigned`数据类型，所以当数据库类型为`unsigned`时，我们需要向上提升一个数量级来存储数据，比如`mysql int`用`java long`来存。在Canal-Server中是这样处理的，[ref](https://github.com/alibaba/canal/blob/8ed82caaefd515187cdaea0bb180a448d93437a6/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvert.java#L770)。

但是在Client-Adapter的rdb组件中，通过Jdbc获得了下游数据库对应的字段类型，并没有对上游的数值进行对应的处理，[ref](https://github.com/alibaba/canal/blob/8ed82caaefd515187cdaea0bb180a448d93437a6/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/LogEventConvert.java#L770)，这会导致当canal中的值为`unsigned`类型的数据，并且数据超过对应的`signed`类型数据能表示的最大值时（比如2^31这样的数据），那么到下游时就会变成负数，同步错误。
## 如何解决的
在Client-Adapter中的rdb的类型转换处理中，用更高一级的数据类型去处理值。