### PR TITLE
fix #3119 通过数据库修改hbase-adapter配置文件无效

### DIFF
--- a/client-adapter/hbase/src/main/java/com/alibaba/otter/canal/client/adapter/hbase/monitor/HbaseConfigMonitor.java
+++ b/client-adapter/hbase/src/main/java/com/alibaba/otter/canal/client/adapter/hbase/monitor/HbaseConfigMonitor.java
@@ -1,9 +1,10 @@
 package com.alibaba.otter.canal.client.adapter.hbase.monitor;
 
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
+import com.alibaba.otter.canal.client.adapter.config.YmlConfigBinder;
+import com.alibaba.otter.canal.client.adapter.hbase.HbaseAdapter;
+import com.alibaba.otter.canal.client.adapter.hbase.config.MappingConfig;
+import com.alibaba.otter.canal.client.adapter.support.MappingConfigsLoader;
+import com.alibaba.otter.canal.client.adapter.support.Util;
 
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
@@ -13,11 +14,10 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.alibaba.otter.canal.client.adapter.config.YmlConfigBinder;
-import com.alibaba.otter.canal.client.adapter.hbase.HbaseAdapter;
-import com.alibaba.otter.canal.client.adapter.hbase.config.MappingConfig;
-import com.alibaba.otter.canal.client.adapter.support.MappingConfigsLoader;
-import com.alibaba.otter.canal.client.adapter.support.Util;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 
 public class HbaseConfigMonitor {
 
@@ -125,8 +125,8 @@ public class HbaseConfigMonitor {
         private void addConfigToCache(File file, MappingConfig config) {
             hbaseAdapter.getHbaseMapping().put(file.getName(), config);
             Map<String, MappingConfig> configMap = hbaseAdapter.getMappingConfigCache()
-                .computeIfAbsent(StringUtils.trimToEmpty(config.getDestination()) + "."
-                                 + config.getHbaseMapping().getDatabase() + "." + config.getHbaseMapping().getTable(),
+                .computeIfAbsent(StringUtils.trimToEmpty(config.getDestination()) + "_"
+                                 + config.getHbaseMapping().getDatabase() + "-" + config.getHbaseMapping().getTable(),
                     k1 -> new HashMap<>());
             configMap.put(file.getName(), config);
         }


### PR DESCRIPTION
fix #3119
原因是将配置存入缓存时，缓存key错误导致刷新配置后无法获取新的的配置

- 存入配置 
``` java
// HbaseConfigMonitor.java
private void addConfigToCache(File file, MappingConfig config) {
    hbaseAdapter.getHbaseMapping().put(file.getName(), config);
    Map<String, MappingConfig> configMap = hbaseAdapter.getMappingConfigCache()
        .computeIfAbsent(StringUtils.trimToEmpty(config.getDestination()) + "."
                         + config.getHbaseMapping().getDatabase() + "." + config.getHbaseMapping().getTable(),
            k1 -> new HashMap<>());
    configMap.put(file.getName(), config);
}
```

- 获取配置
```java
// HbaseAdapter.java
private void sync(Dml dml) {
    // ......
    if (envProperties != null && !"tcp".equalsIgnoreCase(envProperties.getProperty("canal.conf.mode"))) {
        configMap = mappingConfigCache.get(destination + "-" + groupId + "_" + database + "-" + table);
    } else {
        configMap = mappingConfigCache.get(destination + "_" + database + "-" + table);
    }
    // ......
}
```