### PR TITLE
ES adapter 拼接sql条件时防止最后出现group by

### DIFF
--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/support/ESSyncUtil.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/support/ESSyncUtil.java
@@ -311,7 +311,15 @@ public class ESSyncUtil {
     }
 
     public static String appendCondition(String sql, String condition) {
-        return sql + " WHERE " + condition + " ";
+        //防止最后出现group by,拼接 group by
+        String[] sqlSplit = sql.split("GROUP\\ BY(?!(.*)ON)");
+        String sqlNoWhere = sqlSplit[0];
+        StringBuilder builder = new StringBuilder(sqlNoWhere).append("where ").append(condition).append(" ");
+        if (sqlSplit.length > 1) {
+            builder.append("GROUP BY ").append(sqlSplit[1]);
+        }
+        return builder.toString();
+
     }
 
     public static void appendCondition(StringBuilder sql, Object value, String owner, String columnName) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16585875/99357266-97d77100-28e6-11eb-8b0d-a5c8b2ad81bd.png)
这个是我遇到的问题，因为我adapter-es7配置的sql是带group by的 ，然后发现最后条件直接拼接再后面。导致业务报错。

原以为是不支持group by。但是源码里发现有做这种考虑处理。
![image](https://user-images.githubusercontent.com/16585875/99357836-93f81e80-28e7-11eb-9097-2de138ae2fa6.png)
所以觉得有必要在拼接where条件时也考虑下这种情况

这样修改已经验证没问题