### PR TITLE
1.修改当配置pk，没有配置_id的时候ES6和ES7没有删除对应数据的bug(原先只是把除了id以外的属性置为null了)

### DIFF
--- a/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ES6xTemplate.java
+++ b/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ES6xTemplate.java
@@ -161,10 +161,10 @@ public class ES6xTemplate implements ESTemplate {
                 mapping.get_type()).setQuery(QueryBuilders.termQuery(mapping.getPk(), pkVal)).size(10000);
             SearchResponse response = esSearchRequest.getResponse();
             for (SearchHit hit : response.getHits()) {
-                ESUpdateRequest esUpdateRequest = this.esConnection.new ES6xUpdateRequest(mapping.get_index(),
+                ESDeleteRequest esDeleteRequest = this.esConnection.new ES6xDeleteRequest(mapping.get_index(),
                     mapping.get_type(),
-                    hit.getId()).setDoc(esFieldData);
-                getBulk().add(esUpdateRequest);
+                    hit.getId());
+                getBulk().add(esDeleteRequest);
                 commitBulk();
             }
         }

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
@@ -159,9 +159,9 @@ public class ES7xTemplate implements ESTemplate {
                 .size(10000);
             SearchResponse response = esSearchRequest.getResponse();
             for (SearchHit hit : response.getHits()) {
-                ESUpdateRequest esUpdateRequest = this.esConnection.new ES7xUpdateRequest(mapping.get_index(),
-                    hit.getId()).setDoc(esFieldData);
-                getBulk().add(esUpdateRequest);
+                ESDeleteRequest esDeleteRequest = this.esConnection.new ES7xDeleteRequest(mapping.get_index(),
+                    hit.getId());
+                getBulk().add(esDeleteRequest);
                 commitBulk();
             }
         }


### PR DESCRIPTION
修复issue这个问题 
Fixes #3145 