### PR TITLE
修复集群模式下，多个 server 不能添加配置的bug

### DIFF
--- a/admin/admin-web/src/main/resources/canal_manager.sql
+++ b/admin/admin-web/src/main/resources/canal_manager.sql
@@ -62,7 +62,7 @@ CREATE TABLE `canal_instance_config` (
   `content_md5` varchar(128) DEFAULT NULL,
   `modified_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `name_UNIQUE` (`name`)
+  UNIQUE KEY `name_cluster_server_UNIQUE` (`name`,`cluster_id`,`server_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ----------------------------


### PR DESCRIPTION
因为 name 字段（即 destination）唯一，集群中多个 server 只能给 一个 server 添加配置，此为 bug。
因集群中多个 server 的 destination 应保持一致，用 server_id 进行区别，故修改唯一键约束为 `name`,`cluster_id`,`server_id` 三个字段的联合唯一索引。