### PR TITLE
支持adapter通过配置修改 rabbitmq的默认端口

### DIFF
--- a/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/consumer/CanalRabbitMQConsumer.java
+++ b/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/consumer/CanalRabbitMQConsumer.java
@@ -90,7 +90,15 @@ public class CanalRabbitMQConsumer implements CanalMsgConsumer {
             factory.setUsername(username);
             factory.setPassword(password);
         }
-        factory.setHost(nameServer);
+        //解析出端口 modified by 16075140
+        if (nameServer != null && nameServer.contains(":")) {
+            String[] serverHostAndPort = nameServer.split(":");
+            factory.setHost(serverHostAndPort[0]);
+            factory.setPort(Integer.parseInt(serverHostAndPort[1]));
+        } else {
+            factory.setHost(nameServer);
+        }
+
         factory.setAutomaticRecoveryEnabled(true);
         factory.setNetworkRecoveryInterval(5000);
         factory.setVirtualHost(vhost);


### PR DESCRIPTION
在adapter的application.yml中
rabbitmq.host: hostname:port
若配置了port则，取配置的port，否则，取RabbitMQ的默认端口