### PR TITLE
修复FileMixedMetaManager最新位置被remove掉，导致重复消息的问题

### DIFF
--- a/meta/src/main/java/com/alibaba/otter/canal/meta/FileMixedMetaManager.java
+++ b/meta/src/main/java/com/alibaba/otter/canal/meta/FileMixedMetaManager.java
@@ -91,6 +91,8 @@ public class FileMixedMetaManager extends MemoryMetaManager implements CanalMeta
             for (ClientIdentity clientIdentity : tasks) {
                 MDC.put("destination", String.valueOf(clientIdentity.getDestination()));
                 try {
+                    updateCursorTasks.remove(clientIdentity);
+
                     // 定时将内存中的最新值刷到file中，多次变更只刷一次
                     if (logger.isInfoEnabled()) {
                         LogPosition cursor = (LogPosition) getCursor(clientIdentity);
@@ -100,7 +102,6 @@ public class FileMixedMetaManager extends MemoryMetaManager implements CanalMeta
                                 cursor.getIdentity().getSourceAddress().toString());
                     }
                     flushDataToFile(clientIdentity.getDestination());
-                    updateCursorTasks.remove(clientIdentity);
                 } catch (Throwable e) {
                     // ignore
                     logger.error("period update" + clientIdentity.toString() + " curosr failed!", e);

--- a/meta/src/main/java/com/alibaba/otter/canal/meta/PeriodMixedMetaManager.java
+++ b/meta/src/main/java/com/alibaba/otter/canal/meta/PeriodMixedMetaManager.java
@@ -79,9 +79,10 @@ public class PeriodMixedMetaManager extends MemoryMetaManager implements CanalMe
             List<ClientIdentity> tasks = new ArrayList<>(updateCursorTasks);
             for (ClientIdentity clientIdentity : tasks) {
                 try {
+                    updateCursorTasks.remove(clientIdentity);
+
                     // 定时将内存中的最新值刷到zookeeper中，多次变更只刷一次
                     zooKeeperMetaManager.updateCursor(clientIdentity, getCursor(clientIdentity));
-                    updateCursorTasks.remove(clientIdentity);
                 } catch (Throwable e) {
                     // ignore
                     logger.error("period update" + clientIdentity.toString() + " curosr failed!", e);


### PR DESCRIPTION
```
// 启动定时工作任务
executor.scheduleAtFixedRate(() -> {
	List<ClientIdentity> tasks = new ArrayList<>(updateCursorTasks);
	for (ClientIdentity clientIdentity : tasks) {
		MDC.put("destination", String.valueOf(clientIdentity.getDestination()));
		try {
			// 定时将内存中的最新值刷到file中，多次变更只刷一次
			if (logger.isInfoEnabled()) {
				LogPosition cursor = (LogPosition) getCursor(clientIdentity);
				logger.info("clientId:{} cursor:[{},{},{},{},{}] address[{}]", clientIdentity.getClientId(), cursor.getPostion().getJournalName(),
						cursor.getPostion().getPosition(), cursor.getPostion().getTimestamp(),
						cursor.getPostion().getServerId(), cursor.getPostion().getGtid(),
						cursor.getIdentity().getSourceAddress().toString());
			}
			flushDataToFile(clientIdentity.getDestination());
			updateCursorTasks.remove(clientIdentity);
		} catch (Throwable e) {
			// ignore
			logger.error("period update" + clientIdentity.toString() + " curosr failed!", e);
		}
	}
},
	period,
	period,
	TimeUnit.MILLISECONDS);
```
场景：当第一次ack时，触发flushDataToFile，然后在flushDataToFile期间又产生了多次ack，产生了最新的位置信息，但接着被remove掉了，所以最新的位置不会被刷新，此时进行重启由于没有保存最新的位置，所以会产生重复消息
