### PR TITLE
Fix  #3259 使用es索引别名时,报错Not found the mapping info of index

### DIFF
--- a/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ESConnection.java
+++ b/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ESConnection.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpHost;
@@ -11,6 +12,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -26,6 +28,7 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
+import org.elasticsearch.client.GetAliasesResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
@@ -133,9 +136,20 @@ public class ESConnection {
 
         } else {
             ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappings;
+            AtomicReference<String> writeIndex = new AtomicReference<>();
             try {
+
+                GetAliasesRequest aliasesRequest = new GetAliasesRequest();
+                aliasesRequest.indices(index);
+                GetAliasesResponse aliasesResponse = RestHighLevelClientExt.getAlias(restHighLevelClient, aliasesRequest, RequestOptions.DEFAULT);
+                aliasesResponse.getAliases().forEach((key, aliasMetaDataSet) -> aliasMetaDataSet.forEach(aliasMetaData -> {
+                    if (aliasMetaData.getAlias().equals(index) && aliasMetaData.writeIndex()) {
+                        writeIndex.set(key);
+                    }
+                }));
+
                 GetMappingsRequest request = new GetMappingsRequest();
-                request.indices(index);
+                request.indices(writeIndex.get());
                 GetMappingsResponse response;
                 // try {
                 // response = restHighLevelClient
@@ -154,7 +168,7 @@ public class ESConnection {
                 logger.error(e.getMessage(), e);
                 return null;
             }
-            mappingMetaData = mappings.get(index).get(type);
+            mappingMetaData = mappings.get(writeIndex.get()).get(type);
         }
         return mappingMetaData;
     }

--- a/client-adapter/es6x/src/main/java/org/elasticsearch/client/RequestConvertersExt.java
+++ b/client-adapter/es6x/src/main/java/org/elasticsearch/client/RequestConvertersExt.java
@@ -3,6 +3,7 @@ package org.elasticsearch.client;
 import java.io.IOException;
 
 import org.apache.http.client.methods.HttpGet;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.common.Strings;
 
@@ -26,5 +27,13 @@ public class RequestConvertersExt {
         String[] types = getMappingsRequest.types() == null ? Strings.EMPTY_ARRAY : getMappingsRequest.types();
 
         return new Request(HttpGet.METHOD_NAME, RequestConverters.endpoint(indices, "_mapping", types));
+    }
+
+
+    static Request getAlias(GetAliasesRequest getAliasesRequest) throws IOException {
+        String[] indices = getAliasesRequest.indices() == null ? Strings.EMPTY_ARRAY : getAliasesRequest.indices();
+        String[] aliases = getAliasesRequest.aliases() == null ? Strings.EMPTY_ARRAY : getAliasesRequest.aliases();
+
+        return new Request(HttpGet.METHOD_NAME, RequestConverters.endpoint(indices, "_alias", aliases));
     }
 }

--- a/client-adapter/es6x/src/main/java/org/elasticsearch/client/RestHighLevelClientExt.java
+++ b/client-adapter/es6x/src/main/java/org/elasticsearch/client/RestHighLevelClientExt.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptySet;
 
 import java.io.IOException;
 
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 
@@ -23,6 +24,17 @@ public class RestHighLevelClientExt {
             options,
             GetMappingsResponse::fromXContent,
             emptySet());
+
+    }
+
+    public static GetAliasesResponse getAlias(RestHighLevelClient restHighLevelClient,
+                                               GetAliasesRequest getAliasesRequest,
+                                                 RequestOptions options) throws IOException {
+        return restHighLevelClient.performRequestAndParseEntity(getAliasesRequest,
+                RequestConvertersExt::getAlias,
+                options,
+                GetAliasesResponse::fromXContent,
+                emptySet());
 
     }
 

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ESConnection.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ESConnection.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpHost;
@@ -11,6 +12,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
@@ -24,6 +26,7 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
+import org.elasticsearch.client.GetAliasesResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
@@ -129,12 +132,21 @@ public class ESConnection {
             }
         } else {
             Map<String, MappingMetaData> mappings;
+            AtomicReference<String> writeIndex = new AtomicReference<>();
             try {
-                GetMappingsRequest request = new GetMappingsRequest();
-                request.indices(index);
-                GetMappingsResponse response = restHighLevelClient.indices()
-                    .getMapping(request, RequestOptions.DEFAULT);
+                GetAliasesRequest aliasesRequest = new GetAliasesRequest();
+                aliasesRequest.indices(index);
+                GetAliasesResponse aliasesResponse = restHighLevelClient.indices().getAlias(aliasesRequest, RequestOptions.DEFAULT);
+                aliasesResponse.getAliases().forEach((key, aliasMetaDataSet) -> aliasMetaDataSet.forEach(aliasMetaData -> {
+                    if (aliasMetaData.getAlias().equals(index) && aliasMetaData.writeIndex()) {
+                        writeIndex.set(key);
+                    }
+                }));
 
+                GetMappingsRequest mappingsRequest = new GetMappingsRequest();
+                mappingsRequest.indices(writeIndex.get());
+                GetMappingsResponse response = restHighLevelClient.indices()
+                        .getMapping(mappingsRequest, RequestOptions.DEFAULT);
                 mappings = response.mappings();
             } catch (NullPointerException e) {
                 throw new IllegalArgumentException("Not found the mapping info of index: " + index);
@@ -142,7 +154,7 @@ public class ESConnection {
                 logger.error(e.getMessage(), e);
                 return null;
             }
-            mappingMetaData = mappings.get(index);
+            mappingMetaData = mappings.get(writeIndex.get());
         }
         return mappingMetaData;
     }


### PR DESCRIPTION
通过索引别名名称查询mapping信息返回的是其对应的真实索引列表信息, 故无法通过索引别名取得mapping信息.