### PR TITLE
[Imp] RdbSyncService sync mappingConfigCache judge

### DIFF
--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/RdbAdapter.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/RdbAdapter.java
@@ -165,7 +165,9 @@ public class RdbAdapter implements OuterAdapter {
             return;
         }
         try {
-            rdbSyncService.sync(mappingConfigCache, dmls, envProperties);
+            if (!mappingConfigCache.isEmpty()) {
+                rdbSyncService.sync(mappingConfigCache, dmls, envProperties);
+            }
             rdbMirrorDbSyncService.sync(dmls);
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
If config only for rdbMirrorDb,  mappingConfigCache is empty, so we can ignore before rdbSyncService.sync