### PR TITLE
修复admin停止server实例，连接已关闭异常；

### DIFF
--- a/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
+++ b/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 
+import com.rabbitmq.client.AlreadyClosedException;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -176,6 +177,8 @@ public class CanalRabbitMQProducer extends AbstractMQProducer implements CanalMQ
             this.connect.close();
             this.channel.close();
             super.stop();
+        } catch (AlreadyClosedException ex) {
+            logger.error("Connection is already closed", ex);
         } catch (IOException | TimeoutException ex) {
             throw new CanalException("Stop RabbitMQ producer error", ex);
         }


### PR DESCRIPTION
**Canal admin 操作停止Server实例时，会出现连接connection is already closed due to clean connection shutdown异常；**
2021-01-26 11:17:39.878 [canal-server-scan-0] INFO  c.a.o.c.c.rabbitmq.producer.CanalRabbitMQProducer - ## Stop RabbitMQ producer##
2021-01-26 11:17:39.879 [canal-server-scan-0] ERROR com.alibaba.otter.canal.deployer.CanalLauncher - scan failed
com.rabbitmq.client.AlreadyClosedException: connection is already closed due to clean connection shutdown; protocol method: #method<connection.close>(reply-code=200, reply-text=OK, class-id=0, method-id=0)
	at com.rabbitmq.client.impl.AMQConnection.startShutdown(AMQConnection.java:923) ~[na:na]
	at com.rabbitmq.client.impl.AMQConnection.close(AMQConnection.java:1038) ~[na:na]
	at com.rabbitmq.client.impl.AMQConnection.close(AMQConnection.java:967) ~[na:na]
	at com.rabbitmq.client.impl.AMQConnection.close(AMQConnection.java:951) ~[na:na]
	at com.rabbitmq.client.impl.AMQConnection.close(AMQConnection.java:943) ~[na:na]
	at com.rabbitmq.client.impl.recovery.AutorecoveringConnection.close(AutorecoveringConnection.java:273) ~[na:na]
	at com.alibaba.otter.canal.connector.rabbitmq.producer.CanalRabbitMQProducer.stop(CanalRabbitMQProducer.java:182) ~[na:na]
	at com.alibaba.otter.canal.server.CanalMQStarter.destroy(CanalMQStarter.java:104) ~[canal.server-1.1.5-SNAPSHOT.jar:na]
	at com.alibaba.otter.canal.deployer.CanalStarter.stop(CanalStarter.java:167) ~[canal.deployer-1.1.5-SNAPSHOT.jar:na]
	at com.alibaba.otter.canal.deployer.CanalStarter.stop(CanalStarter.java:144) ~[canal.deployer-1.1.5-SNAPSHOT.jar:na]
	at com.alibaba.otter.canal.deployer.CanalLauncher$1.run(CanalLauncher.java:93) ~[canal.deployer-1.1.5-SNAPSHOT.jar:na]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_181]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [na:1.8.0_181]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_181]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [na:1.8.0_181]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_181]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_181]
	at java.lang.Thread.run(Thread.java:748) [na:1.8.0_181]