### PR TITLE
need process exit when not mine

### DIFF
--- a/common/src/main/java/com/alibaba/otter/canal/common/zookeeper/running/ServerRunningMonitor.java
+++ b/common/src/main/java/com/alibaba/otter/canal/common/zookeeper/running/ServerRunningMonitor.java
@@ -55,7 +55,9 @@ public class ServerRunningMonitor extends AbstractCanalLifeCycle {
                 MDC.put("destination", destination);
                 ServerRunningData runningData = JsonUtils.unmarshalFromByte((byte[]) data, ServerRunningData.class);
                 if (!isMine(runningData.getAddress())) {
+                    release = true;
                     mutex.set(false);
+                    processActiveExit();
                 }
 
                 if (!runningData.isActive() && isMine(runningData.getAddress())) { // 说明出现了主动释放的操作，并且本机之前是active


### PR DESCRIPTION
当网络抖动等引起zk连接超时，恢复后running节点发生变化且已经不是当前节点，需要停止执行当前的destination