### PR TITLE
fix information disclosure security vulnerability.

### DIFF
--- a/admin/admin-web/src/main/java/com/alibaba/otter/canal/admin/config/WebConfig.java
+++ b/admin/admin-web/src/main/java/com/alibaba/otter/canal/admin/config/WebConfig.java
@@ -84,7 +84,7 @@ public class WebConfig implements WebMvcConfigurer {
             }
         })
             .addPathPatterns("/api/**")
-            .excludePathPatterns("/api/**/config/**")
+            .excludePathPatterns("/api/*/config/**")
             .excludePathPatterns("/api/**/user/login")
             .excludePathPatterns("/api/**/user/logout")
             .excludePathPatterns("/api/**/user/info");


### PR DESCRIPTION
```excludePathPatterns("/api/**/config/**")```的意图是排除```com.alibaba.otter.canal.admin.controller.PollingConfigController```相关接口的api认证，走其内部的
```
private boolean auth(String user, String passwd) {
        // 如果user/passwd密码为空,则任何用户账户都能登录
        if ((StringUtils.isEmpty(this.user) || StringUtils.equals(this.user, user))) {
            if (StringUtils.isEmpty(this.passwd)) {
                return true;
            } else if (StringUtils.isEmpty(passwd)) {
                // 如果server密码有配置,客户端密码为空,则拒绝
                return false;
            }

            try {
                // manager这里保存了原始密码，反过来和canal发送过来的进行校验
                byte[] passForClient = SecurityUtil.scramble411(this.passwd.getBytes(), seeds);
                return SecurityUtil.scrambleServerAuth(passForClient, SecurityUtil.hexStr2Bytes(passwd), seeds);
            } catch (NoSuchAlgorithmException e) {
                return false;
            }
        }

        return false;
}
```
然而，两个**星号，导致```com.alibaba.otter.canal.admin.controller.CanalConfigController```中的接口```/api/{env}/canal/config/template```也被匹配上了，造成信息泄露。