### PR TITLE
Connection is already closed  fix

### DIFF
--- a/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
+++ b/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
@@ -175,8 +175,8 @@ public class CanalRabbitMQProducer extends AbstractMQProducer implements CanalMQ
     public void stop() {
         logger.info("## Stop RabbitMQ producer##");
         try {
-            this.connect.close();
             this.channel.close();
+            this.connect.close();
             super.stop();
         } catch (AlreadyClosedException ex) {
             logger.error("Connection is already closed", ex);


### PR DESCRIPTION
```
ERROR c.a.o.c.c.rabbitmq.producer.CanalRabbitMQProducer - Connection is already closed
com.rabbitmq.client.AlreadyClosedException: connection is already closed due to clean connection shutdown; protocol method: #method<connection.close>(reply-code=200, reply-text=OK, class-id=0, method-id=0)
```
> Connection: A network connection, e.g. a TCP/IP socket connection.Channel:   A   bi-directional   stream   of   communications   between   two   AMQP   peers.   Channels   aremultiplexed so that a single network connection can carry multiple channels.


应该先关闭channel 
再关闭connection 
否则一定会抛出异常