### PR TITLE
rollback guava version in adapter module

### DIFF
--- a/client-adapter/pom.xml
+++ b/client-adapter/pom.xml
@@ -212,6 +212,12 @@
                 <artifactId>curator-recipes</artifactId>
                 <version>2.10.0</version>
             </dependency>
+            <!-- 单独指定guava版本，兼容curator-client -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>18.0</version>
+            </dependency>
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>


### PR DESCRIPTION
Fix guava version conflicts in adapter module, which might be caused by #3184 

close #3507, close #3510, close #3513

Another choice might be updating curator-recipes to 4.0.0+, as the guava version it depends on has been updated from 4.0.0. 
https://mvnrepository.com/artifact/org.apache.curator/curator-client/4.0.0
