### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         </argline>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+    	<closeTestReports>true</closeTestReports>
     </properties>
 
     <modules>
@@ -422,6 +423,7 @@
                     </systemProperties>
                 	<parallel>classes</parallel>
                 	<useUnlimitedThreads>true</useUnlimitedThreads>
+                	<disableXmlReport>${closeTestReports}</disableXmlReport>
 
                 </configuration>
             </plugin>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
