### PR TITLE
Some tweaks for pulsarmq-connector

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -138,6 +138,11 @@
 			<artifactId>pulsar-client</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.pulsar</groupId>
+			<artifactId>pulsar-client-admin</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
 		<!-- junit -->
 		<dependency>

--- a/connector/pulsarmq-connector/pom.xml
+++ b/connector/pulsarmq-connector/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.apache.pulsar</groupId>
             <artifactId>pulsar-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.pulsar</groupId>
+            <artifactId>pulsar-client-admin</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/connector/pulsarmq-connector/src/main/java/com/alibaba/otter/canal/connector/pulsarmq/config/PulsarMQConstants.java
+++ b/connector/pulsarmq-connector/src/main/java/com/alibaba/otter/canal/connector/pulsarmq/config/PulsarMQConstants.java
@@ -57,6 +57,10 @@ public class PulsarMQConstants {
      * 最大重试次数
      */
     public static final String PULSARMQ_MAX_REDELIVERY_COUNT = ROOT + "." + "maxRedeliveryCount";
+    /**
+     * Pulsar admin服务器地址
+     */
+    public static final String PULSARMQ_ADMIN_SERVER_URL = ROOT + "." + "adminServerUrl";
 
 
 }

--- a/connector/pulsarmq-connector/src/main/java/com/alibaba/otter/canal/connector/pulsarmq/config/PulsarMQProducerConfig.java
+++ b/connector/pulsarmq-connector/src/main/java/com/alibaba/otter/canal/connector/pulsarmq/config/PulsarMQProducerConfig.java
@@ -30,6 +30,10 @@ public class PulsarMQProducerConfig extends MQProperties {
      * 生产者角色权限，请确保该角色有canal使用的所有topic生产者权限（最低要求）
      */
     private String roleToken;
+    /**
+     * admin服务器地址
+     */
+    private String adminServerUrl;
 
     public String getServerUrl() {
         return serverUrl;
@@ -53,5 +57,13 @@ public class PulsarMQProducerConfig extends MQProperties {
 
     public void setTopicTenantPrefix(String topicTenantPrefix) {
         this.topicTenantPrefix = topicTenantPrefix;
+    }
+
+    public String getAdminServerUrl() {
+        return adminServerUrl;
+    }
+
+    public void setAdminServerUrl(String adminServerUrl) {
+        this.adminServerUrl = adminServerUrl;
     }
 }

--- a/connector/pulsarmq-connector/src/main/java/com/alibaba/otter/canal/connector/pulsarmq/producer/CanalPulsarMQProducer.java
+++ b/connector/pulsarmq-connector/src/main/java/com/alibaba/otter/canal/connector/pulsarmq/producer/CanalPulsarMQProducer.java
@@ -289,19 +289,19 @@ public class CanalPulsarMQProducer extends AbstractMQProducer implements CanalMQ
      * 发送原始消息，需要做分区处理
      *
      * @param topic        topic
-     * @param partition 目标分区
+     * @param partitionNum 目标分区
      * @param msg          原始消息内容
      * @return void
      * @date 2021/9/10 17:55
      * @author chad
      * @since 1 by chad at 2021/9/10 新增
      */
-    private void sendMessage(String topic, int partition, com.alibaba.otter.canal.protocol.Message msg) {
+    private void sendMessage(String topic, int partitionNum, com.alibaba.otter.canal.protocol.Message msg) {
         Producer<byte[]> producer = PRODUCERS.get(topic);
         byte[] msgBytes = CanalMessageSerializerUtil.serializer(msg, mqProperties.isFilterTransactionEntry());
         try {
             MessageId msgResultId = producer.newMessage()
-                    .property(MSG_PROPERTY_PARTITION_NAME, String.valueOf(partition))
+                    .property(MSG_PROPERTY_PARTITION_NAME, String.valueOf(partitionNum))
                     .value(msgBytes).send();
             // todo 判断发送结果
             if (logger.isDebugEnabled()) {

--- a/connector/pulsarmq-connector/src/main/java/com/alibaba/otter/canal/connector/pulsarmq/producer/CanalPulsarMQProducer.java
+++ b/connector/pulsarmq-connector/src/main/java/com/alibaba/otter/canal/connector/pulsarmq/producer/CanalPulsarMQProducer.java
@@ -289,19 +289,19 @@ public class CanalPulsarMQProducer extends AbstractMQProducer implements CanalMQ
      * 发送原始消息，需要做分区处理
      *
      * @param topic        topic
-     * @param partitionNum 目标分区
+     * @param partition 目标分区
      * @param msg          原始消息内容
      * @return void
      * @date 2021/9/10 17:55
      * @author chad
      * @since 1 by chad at 2021/9/10 新增
      */
-    private void sendMessage(String topic, int partitionNum, com.alibaba.otter.canal.protocol.Message msg) {
-        Producer<byte[]> producer = getProducer(topic,null);
+    private void sendMessage(String topic, int partition, com.alibaba.otter.canal.protocol.Message msg) {
+        Producer<byte[]> producer = PRODUCERS.get(topic);
         byte[] msgBytes = CanalMessageSerializerUtil.serializer(msg, mqProperties.isFilterTransactionEntry());
         try {
             MessageId msgResultId = producer.newMessage()
-                    .property(MSG_PROPERTY_PARTITION_NAME, String.valueOf(partitionNum))
+                    .property(MSG_PROPERTY_PARTITION_NAME, String.valueOf(partition))
                     .value(msgBytes).send();
             // todo 判断发送结果
             if (logger.isDebugEnabled()) {
@@ -322,13 +322,13 @@ public class CanalPulsarMQProducer extends AbstractMQProducer implements CanalMQ
      * @author chad
      * @since 1 by chad at 2021/9/10 新增
      */
-    private void sendMessage(String topic, int targetPartitionNum, List<FlatMessage> flatMessages) {
-        Producer<byte[]> producer = getProducer(topic,null);
+    private void sendMessage(String topic, int partition, List<FlatMessage> flatMessages) {
+        Producer<byte[]> producer = PRODUCERS.get(topic);
         for (FlatMessage f : flatMessages) {
             try {
                 MessageId msgResultId = producer
                         .newMessage()
-                        .property(MSG_PROPERTY_PARTITION_NAME, String.valueOf(targetPartitionNum))
+                        .property(MSG_PROPERTY_PARTITION_NAME, String.valueOf(partition))
                         .value(JSON.toJSONBytes(f, SerializerFeature.WriteMapNullValue))
                         .send()
                         //

--- a/connector/pulsarmq-connector/src/main/resources/META-INF/canal/com.alibaba.otter.canal.connector.core.spi.CanalMsgConsumer
+++ b/connector/pulsarmq-connector/src/main/resources/META-INF/canal/com.alibaba.otter.canal.connector.core.spi.CanalMsgConsumer
@@ -1,0 +1,1 @@
+pulsarmq=com.alibaba.otter.canal.connector.pulsarmq.consumer.CanalPulsarMQConsumer

--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>druid</artifactId>
-                <version>1.2.6</version>
+                <version>1.2.8</version>
             </dependency>
             <dependency>
                 <groupId>com.lmax</groupId>
@@ -344,6 +344,11 @@
             <dependency>
                 <groupId>org.apache.pulsar</groupId>
                 <artifactId>pulsar-client</artifactId>
+                <version>2.8.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.pulsar</groupId>
+                <artifactId>pulsar-client-admin</artifactId>
                 <version>2.8.1</version>
             </dependency>
         </dependencies>


### PR DESCRIPTION
1. Add the com.alibaba.otter.canal.connector.core.spi.CanalMsgConsumer file to the META-INF/canal directory under the pulsarmq-connector project
2. Introduce pulsar-client-admin for Canal to automatically create multi-partition topics
3. Add the judgment that roleToken is null
4. The disconnect method in CanalPulsarMQConsumer removes this.pulsarMQConsumer.unsubscribe();, this code will cause data loss during stop
5. When getting Pulsar messages, they are all processed as flat messages, because CanalMessageSerializerUtil.deserializer(data) will deserialize exceptions
6. Use groupId as subscriptName, without the pulsarmq.subscriptName parameter, the entire adapter will be the same subscriber name using pulsarmq.subscriptName