### PR TITLE
Add verification: the user can set a password with a length of less t…

### DIFF
--- a/admin/admin-web/src/main/java/com/alibaba/otter/canal/admin/service/impl/UserServiceImpl.java
+++ b/admin/admin-web/src/main/java/com/alibaba/otter/canal/admin/service/impl/UserServiceImpl.java
@@ -21,6 +21,8 @@ public class UserServiceImpl implements UserService {
 
     private static byte[] seeds = "canal is best!".getBytes();
 
+    private static final Integer PASSWORD_LENGTH = 6;
+
     public User find4Login(String username, String password) {
         if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {
             return null;
@@ -43,6 +45,9 @@ public class UserServiceImpl implements UserService {
     }
 
     public void update(User user) {
+        if (user.getPassword().length() < PASSWORD_LENGTH) {
+            throw new ServiceException("The new password is too short,must more than 6 digits");
+        }
         User userTmp = User.find.query().where().eq("username", user.getUsername()).findOne();
         if (userTmp == null) {
             throw new ServiceException();


### PR DESCRIPTION
Add verification: the user can set a password with a length of less than 6 digits when updating the password, but the password length must be greater than or equal to 6 digits when logging in to canal admin, so the length verification function when updating the login password is added