### PR TITLE
RdbConfigMonitor.java修复mappingConfigCache map key字符串拼接错误，导致Rdb yml配置文件变更不生效

### DIFF
--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/monitor/RdbConfigMonitor.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/monitor/RdbConfigMonitor.java
@@ -143,7 +143,8 @@ public class RdbConfigMonitor {
             rdbAdapter.getRdbMapping().put(file.getName(), mappingConfig);
             if (!mappingConfig.getDbMapping().getMirrorDb()) {
                 Map<String, MappingConfig> configMap = rdbAdapter.getMappingConfigCache()
-                    .computeIfAbsent(StringUtils.trimToEmpty(mappingConfig.getDestination()) + "_"
+                    .computeIfAbsent(StringUtils.trimToEmpty(mappingConfig.getDestination()) + "-"
+                                     + mappingConfig.getGroupId() + "_"
                                      + mappingConfig.getDbMapping().getDatabase() + "-"
                                      + mappingConfig.getDbMapping().getTable(),
                         k1 -> new HashMap<>());


### PR DESCRIPTION
修复mappingConfigCache map key字符串拼接错误，导致Rdb配置文件变更不生效的问题