### PR TITLE
enhance dbAdapter and esAdapter

### DIFF
--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
@@ -319,13 +319,15 @@ public class ES7xTemplate implements ESTemplate {
         Iterator<String> stringIterator = mapping.getTargetColumns().iterator();
         for (FieldItem fieldItem : schemaItem.getSelectFields().values()) {
             if (org.springframework.util.CollectionUtils.isEmpty(fieldItem.getColumnItems())) {
-                logger.info("before fieldItem columnItems={}, targetColumns={}", JSON.toJSONString(fieldItem.getColumnItems()), mapping.getTargetColumns());
+                if (logger.isDebugEnabled())
+                    logger.debug("before fieldItem columnItems={}, targetColumns={}", JSON.toJSONString(fieldItem.getColumnItems()), mapping.getTargetColumns());
                 //匹配不到select field的通过扩展字段填充
                 ColumnItem columnItem = new ColumnItem();
                 columnItem.setColumnName(stringIterator.next());
                 columnItem.setOwner(mapping.getTargetOwner());
                 fieldItem.setColumnItems(Lists.newArrayList(columnItem));
-                logger.info("after fill full fieldItem columnItems={}", JSON.toJSONString(fieldItem.getColumnItems()));
+                if (logger.isDebugEnabled())
+                    logger.debug("after fill full fieldItem columnItems={}", JSON.toJSONString(fieldItem.getColumnItems()));
             }
             ColumnItem columnItem = fieldItem.getColumnItems().iterator().next();
             String columnName = columnItem.getColumnName();

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
@@ -2,16 +2,14 @@ package com.alibaba.otter.canal.client.adapter.es7x.support;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import javax.sql.DataSource;
 
+import com.alibaba.fastjson.JSON;
+import com.google.common.collect.Lists;
 import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
@@ -36,22 +34,23 @@ import com.alibaba.otter.canal.client.adapter.es.core.support.ESTemplate;
 import com.alibaba.otter.canal.client.adapter.es7x.support.ESConnection.ESSearchRequest;
 import com.alibaba.otter.canal.client.adapter.support.DatasourceConfig;
 import com.alibaba.otter.canal.client.adapter.support.Util;
+import org.springframework.cglib.core.CollectionUtils;
 
 public class ES7xTemplate implements ESTemplate {
 
-    private static final Logger                               logger         = LoggerFactory
-        .getLogger(ESTemplate.class);
+    private static final Logger logger = LoggerFactory
+            .getLogger(ESTemplate.class);
 
-    private static final int                                  MAX_BATCH_SIZE = 1000;
+    private static final int MAX_BATCH_SIZE = 1000;
 
-    private ESConnection                                      esConnection;
+    private ESConnection esConnection;
 
-    private ESBulkRequest                                     esBulkRequest;
+    private ESBulkRequest esBulkRequest;
 
     // es 字段类型本地缓存
-    private static ConcurrentMap<String, Map<String, String>> esFieldTypes   = new ConcurrentHashMap<>();
+    private static ConcurrentMap<String, Map<String, String>> esFieldTypes = new ConcurrentHashMap<>();
 
-    public ES7xTemplate(ESConnection esConnection){
+    public ES7xTemplate(ESConnection esConnection) {
         this.esConnection = esConnection;
         this.esBulkRequest = this.esConnection.new ES7xBulkRequest();
     }
@@ -70,14 +69,14 @@ public class ES7xTemplate implements ESTemplate {
             String parentVal = (String) esFieldData.remove("$parent_routing");
             if (mapping.isUpsert()) {
                 ESUpdateRequest updateRequest = esConnection.new ES7xUpdateRequest(mapping.get_index(),
-                    pkVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);
+                        pkVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);
                 if (StringUtils.isNotEmpty(parentVal)) {
                     updateRequest.setRouting(parentVal);
                 }
                 getBulk().add(updateRequest);
             } else {
                 ESIndexRequest indexRequest = esConnection.new ES7xIndexRequest(mapping.get_index(), pkVal.toString())
-                    .setSource(esFieldData);
+                        .setSource(esFieldData);
                 if (StringUtils.isNotEmpty(parentVal)) {
                     indexRequest.setRouting(parentVal);
                 }
@@ -86,13 +85,13 @@ public class ES7xTemplate implements ESTemplate {
             commitBulk();
         } else {
             ESSearchRequest esSearchRequest = this.esConnection.new ESSearchRequest(mapping.get_index())
-                .setQuery(QueryBuilders.termQuery(mapping.getPk(), pkVal))
-                .size(10000);
+                    .setQuery(QueryBuilders.termQuery(mapping.getPk(), pkVal))
+                    .size(10000);
             SearchResponse response = esSearchRequest.getResponse();
 
             for (SearchHit hit : response.getHits()) {
                 ESUpdateRequest esUpdateRequest = this.esConnection.new ES7xUpdateRequest(mapping.get_index(),
-                    hit.getId()).setDoc(esFieldData);
+                        hit.getId()).setDoc(esFieldData);
                 getBulk().add(esUpdateRequest);
                 commitBulk();
             }
@@ -150,17 +149,17 @@ public class ES7xTemplate implements ESTemplate {
     public void delete(ESMapping mapping, Object pkVal, Map<String, Object> esFieldData) {
         if (mapping.get_id() != null) {
             ESDeleteRequest esDeleteRequest = this.esConnection.new ES7xDeleteRequest(mapping.get_index(),
-                pkVal.toString());
+                    pkVal.toString());
             getBulk().add(esDeleteRequest);
             commitBulk();
         } else {
             ESSearchRequest esSearchRequest = this.esConnection.new ESSearchRequest(mapping.get_index())
-                .setQuery(QueryBuilders.termQuery(mapping.getPk(), pkVal))
-                .size(10000);
+                    .setQuery(QueryBuilders.termQuery(mapping.getPk(), pkVal))
+                    .size(10000);
             SearchResponse response = esSearchRequest.getResponse();
             for (SearchHit hit : response.getHits()) {
                 ESUpdateRequest esUpdateRequest = this.esConnection.new ES7xUpdateRequest(mapping.get_index(),
-                    hit.getId()).setDoc(esFieldData);
+                        hit.getId()).setDoc(esFieldData);
                 getBulk().add(esUpdateRequest);
                 commitBulk();
             }
@@ -214,7 +213,7 @@ public class ES7xTemplate implements ESTemplate {
             }
 
             if (!fieldItem.getFieldName().equals(mapping.get_id())
-                && !mapping.getSkips().contains(fieldItem.getFieldName())) {
+                    && !mapping.getSkips().contains(fieldItem.getFieldName())) {
                 esFieldData.put(Util.cleanColumn(fieldItem.getFieldName()), value);
             }
         }
@@ -254,9 +253,9 @@ public class ES7xTemplate implements ESTemplate {
 
             for (ColumnItem columnItem : fieldItem.getColumnItems()) {
                 if (dmlOld.containsKey(columnItem.getColumnName())
-                    && !mapping.getSkips().contains(fieldItem.getFieldName())) {
+                        && !mapping.getSkips().contains(fieldItem.getFieldName())) {
                     esFieldData.put(Util.cleanColumn(fieldItem.getFieldName()),
-                        getValFromRS(mapping, resultSet, fieldItem.getFieldName(), fieldItem.getFieldName()));
+                            getValFromRS(mapping, resultSet, fieldItem.getFieldName(), fieldItem.getFieldName()));
                     break;
                 }
             }
@@ -301,7 +300,7 @@ public class ES7xTemplate implements ESTemplate {
             }
 
             if (!fieldItem.getFieldName().equals(mapping.get_id())
-                && !mapping.getSkips().contains(fieldItem.getFieldName())) {
+                    && !mapping.getSkips().contains(fieldItem.getFieldName())) {
                 esFieldData.put(Util.cleanColumn(fieldItem.getFieldName()), value);
             }
         }
@@ -317,8 +316,19 @@ public class ES7xTemplate implements ESTemplate {
         SchemaItem schemaItem = mapping.getSchemaItem();
         String idFieldName = mapping.get_id() == null ? mapping.getPk() : mapping.get_id();
         Object resultIdVal = null;
+        Iterator<String> stringIterator = mapping.getTargetColumns().iterator();
         for (FieldItem fieldItem : schemaItem.getSelectFields().values()) {
-            String columnName = fieldItem.getColumnItems().iterator().next().getColumnName();
+            if (org.springframework.util.CollectionUtils.isEmpty(fieldItem.getColumnItems())) {
+                logger.info("before fieldItem columnItems={}, targetColumns={}", JSON.toJSONString(fieldItem.getColumnItems()), mapping.getTargetColumns());
+                //匹配不到select field的通过扩展字段填充
+                ColumnItem columnItem = new ColumnItem();
+                columnItem.setColumnName(stringIterator.next());
+                columnItem.setOwner(mapping.getTargetOwner());
+                fieldItem.setColumnItems(Lists.newArrayList(columnItem));
+                logger.info("after fill full fieldItem columnItems={}", JSON.toJSONString(fieldItem.getColumnItems()));
+            }
+            ColumnItem columnItem = fieldItem.getColumnItems().iterator().next();
+            String columnName = columnItem.getColumnName();
 
             if (fieldItem.getFieldName().equals(idFieldName)) {
                 resultIdVal = getValFromData(mapping, dmlData, fieldItem.getFieldName(), columnName);
@@ -349,14 +359,14 @@ public class ES7xTemplate implements ESTemplate {
             String parentVal = (String) esFieldData.remove("$parent_routing");
             if (mapping.isUpsert()) {
                 ESUpdateRequest esUpdateRequest = this.esConnection.new ES7xUpdateRequest(mapping.get_index(),
-                    pkVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);
+                        pkVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);
                 if (StringUtils.isNotEmpty(parentVal)) {
                     esUpdateRequest.setRouting(parentVal);
                 }
                 getBulk().add(esUpdateRequest);
             } else {
                 ESUpdateRequest esUpdateRequest = this.esConnection.new ES7xUpdateRequest(mapping.get_index(),
-                    pkVal.toString()).setDoc(esFieldData);
+                        pkVal.toString()).setDoc(esFieldData);
                 if (StringUtils.isNotEmpty(parentVal)) {
                     esUpdateRequest.setRouting(parentVal);
                 }
@@ -364,12 +374,12 @@ public class ES7xTemplate implements ESTemplate {
             }
         } else {
             ESSearchRequest esSearchRequest = this.esConnection.new ESSearchRequest(mapping.get_index())
-                .setQuery(QueryBuilders.termQuery(mapping.getPk(), pkVal))
-                .size(10000);
+                    .setQuery(QueryBuilders.termQuery(mapping.getPk(), pkVal))
+                    .size(10000);
             SearchResponse response = esSearchRequest.getResponse();
             for (SearchHit hit : response.getHits()) {
                 ESUpdateRequest esUpdateRequest = this.esConnection.new ES7xUpdateRequest(mapping.get_index(),
-                    hit.getId()).setDoc(esFieldData);
+                        hit.getId()).setDoc(esFieldData);
                 getBulk().add(esUpdateRequest);
             }
         }
@@ -378,7 +388,7 @@ public class ES7xTemplate implements ESTemplate {
     /**
      * 获取es mapping中的属性类型
      *
-     * @param mapping mapping配置
+     * @param mapping   mapping配置
      * @param fieldName 属性名
      * @return 类型
      */
@@ -425,9 +435,9 @@ public class ES7xTemplate implements ESTemplate {
                     Object parentVal;
                     try {
                         parentVal = getValFromRS(mapping,
-                            resultSet,
-                            parentFieldItem.getFieldName(),
-                            parentFieldItem.getFieldName());
+                                resultSet,
+                                parentFieldItem.getFieldName(),
+                                parentFieldItem.getFieldName());
                     } catch (SQLException e) {
                         throw new RuntimeException(e);
                     }

--- a/client-adapter/escore/pom.xml
+++ b/client-adapter/escore/pom.xml
@@ -22,6 +22,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/ESSyncConfig.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/ESSyncConfig.java
@@ -113,6 +113,16 @@ public class ESSyncConfig implements AdapterConfig {
         private Long                         syncInterval;                           // 同步时间间隔
 
         private SchemaItem                   schemaItem;                             // sql解析结果模型
+        private String                       targetOwner;  //目标表别名
+        private List<String>                 targetColumns;//目标表扩展字段
+
+        public String getTargetOwner() {
+            return targetOwner;
+        }
+
+        public void setTargetOwner(String targetOwner) {
+            this.targetOwner = targetOwner;
+        }
 
         public String get_index() {
             return _index;
@@ -224,6 +234,14 @@ public class ESSyncConfig implements AdapterConfig {
 
         public void setSchemaItem(SchemaItem schemaItem) {
             this.schemaItem = schemaItem;
+        }
+
+        public List<String> getTargetColumns() {
+            return targetColumns;
+        }
+
+        public void setTargetColumns(List<String> targetColumns) {
+            this.targetColumns = targetColumns;
         }
     }
 

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/SchemaItem.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/SchemaItem.java
@@ -435,5 +435,13 @@ public class SchemaItem {
         public void setColumnName(String columnName) {
             this.columnName = columnName;
         }
+
+        @Override
+        public String toString() {
+            return "ColumnItem{" +
+                    "owner='" + owner + '\'' +
+                    ", columnName='" + columnName + '\'' +
+                    '}';
+        }
     }
 }

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/MappingConfig.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/config/MappingConfig.java
@@ -1,6 +1,7 @@
 package com.alibaba.otter.canal.client.adapter.rdb.config;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
@@ -15,15 +16,15 @@ import com.alibaba.otter.canal.client.adapter.support.AdapterConfig;
  */
 public class MappingConfig implements AdapterConfig {
 
-    private String    dataSourceKey;      // 数据源key
+    private String dataSourceKey;      // 数据源key
 
-    private String    destination;        // canal实例或MQ的topic
+    private String destination;        // canal实例或MQ的topic
 
-    private String    groupId;            // groupId
+    private String groupId;            // groupId
 
-    private String    outerAdapterKey;    // 对应适配器的key
+    private String outerAdapterKey;    // 对应适配器的key
 
-    private boolean   concurrent = false; // 是否并行同步
+    private boolean concurrent = false; // 是否并行同步
 
     private DbMapping dbMapping;          // db映射配置
 
@@ -93,23 +94,24 @@ public class MappingConfig implements AdapterConfig {
 
     public static class DbMapping implements AdapterMapping {
 
-        private boolean             mirrorDb        = false;                 // 是否镜像库
-        private String              database;                                // 数据库名或schema名
-        private String              table;                                   // 表名
-        private Map<String, String> targetPk        = new LinkedHashMap<>(); // 目标表主键字段
-        private boolean             mapAll          = false;                 // 映射所有字段
-        private String              targetDb;                                // 目标库名
-        private String              targetTable;                             // 目标表名
+        private boolean mirrorDb = false;                 // 是否镜像库
+        private String database;                                // 数据库名或schema名
+        private String table;                                   // 表名
+        private Map<String, String> targetPk = new LinkedHashMap<>(); // 目标表主键字段
+        private boolean mapAll = false;                 // 映射所有字段
+        private String targetDb;                                // 目标库名
+        private String targetTable;                             // 目标表名
         private Map<String, String> targetColumns;                           // 目标表字段映射
 
-        private boolean             caseInsensitive = false;                 // 目标表不区分大小写，默认是否
+        private boolean caseInsensitive = false;                 // 目标表不区分大小写，默认是否
 
-        private String              etlCondition;                            // etl条件sql
+        private String etlCondition;                            // etl条件sql
 
-        private int                 readBatch       = 5000;
-        private int                 commitBatch     = 5000;                  // etl等批量提交大小
+        private int readBatch = 5000;
+        private int commitBatch = 5000;                  // etl等批量提交大小
 
         private Map<String, String> allMapColumns;
+        private List<String> ignoreDdlTables;              //忽略ddl同步的表
 
         public boolean getMirrorDb() {
             return mirrorDb;
@@ -220,6 +222,14 @@ public class MappingConfig implements AdapterConfig {
 
         public void setAllMapColumns(Map<String, String> allMapColumns) {
             this.allMapColumns = allMapColumns;
+        }
+
+        public List<String> getIgnoreDdlTables() {
+            return ignoreDdlTables;
+        }
+
+        public void setIgnoreDdlTables(List<String> ignoreDdlTables) {
+            this.ignoreDdlTables = ignoreDdlTables;
         }
     }
 }


### PR DESCRIPTION
1. support difference database name for mirror sync
```
#### Mirror schema synchronize config
dataSourceKey: defaultDS
destination: example
groupId: g1
outerAdapterKey: mysql2
concurrent: true
dbMapping:
   mirrorDb: true
   #原始库名称
   database: test01
   #目标库名称，不填默认同步原始库同名库
   targetDb: test02
```
3. support complex sql with single table query for es7
```
#### es config
dataSourceKey: defaultDS
destination: example
outerAdapterKey: exampleKey1
groupId: g1
esMapping:
  _index: enterprise_index
  _type: _doc
  pk: id
  sql: "SELECT
        ent.*,
        (select GROUP_CONCAT(ekc.econ_name SEPARATOR ',@#&,') from t_econ ekc where ent.econ_kind_code = ekc.econ_code ) as econKind,
        (select GROUP_CONCAT(ea.name SEPARATOR ',@#&,') from t_emp ea where ea.eid=ent.eid and ea.is_history=0) as allNames,
        (select GROUP_CONCAT(ema.value SEPARATOR ',@#&,') from t_ema ema where ema.eid=ent.eid) as emails
     FROM t_abs ent"
  etlCondition: "where ent.local_row_update_time>={0}"
  commitBatch: 1000
  #目标表别名，单表复杂sql必填
  targetOwner: ent
 #非ddl语句的字段，单表复杂sql必填
  targetColumns:
    - econKind
    - allNames
    - emails
```
