### PR TITLE
通过ES索引别名获取mapping，返回数据为真实索引，而不是别名，导致mappings.get(index).get(type)报空指针异常

### DIFF
--- a/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ESConnection.java
+++ b/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ESConnection.java
@@ -150,7 +150,13 @@ public class ESConnection {
                 logger.error(e.getMessage(), e);
                 return null;
             }
-            mappingMetaData = mappings.get(index).get(type);
+
+            //通过别名查询mapping返回的是真实索引名称，mappings.get(index)返回null，为兼容别名情况修改如下：
+            ImmutableOpenMap<String, MappingMetaData> esIndex = mappings.get(index);
+            if(esIndex == null){
+                esIndex = mappings.valuesIt().next();
+            }
+            mappingMetaData = esIndex.get(type);
         }
         return mappingMetaData;
     }


### PR DESCRIPTION
bug fix #4121 通过ES索引别名获取maping后mappings.get(index).get(type)空指针异常

问题复现：
1. 当canal-es服务重启后，首次触发获取ES索引mapping：
> 程序位置：
    类    ESConnection
    方法 public MappingMetaData getMapping(String index, String type)
    程序 response = RestHighLevelClientExt.getMapping(restHighLevelClient, request, RequestOptions.DEFAULT);

```
http://xxxxxx.elasticsearch.aliyuncs.com:9200/order_pos/_mappings，其中order_pos为别名，返回数据：
{
    "order_pos_2022.03-000011":{
        "mappings":{
            "_doc":{
                "properties":{
                    "createdTime":{
                        "type":"keyword",
                        "index":false
                    },
                    "customerId":{
                        "type":"long"
                    },
                    ......
                    "ver":{
                        "type":"integer",
                        "index":false
                    }
                }
            }
        }
    }
}
````
返回结果中索引名order_pos_2022.03-000011为真正的索引。
2. 当执行mappings.get(index).get(type)代码时，入参index为配置的别名order_pos，mappings.get(order_pos)返回null
3. 引起NullPointException异常

处理办法：
因为是写入数据，通过索引获取mapping只能有1个mapping数据，取到即可：
```
mappings.get(index)换成 mappings.valuesIt().next();
```
