### PR TITLE
ESAdapter Support the same instance cross -library query

### DIFF
--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/ESAdapter.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/ESAdapter.java
@@ -152,7 +152,6 @@ public abstract class ESAdapter implements OuterAdapter {
         if (!matcher.find()) {
             throw new RuntimeException("Not found the schema of jdbc-url: " + config.getDataSourceKey());
         }
-        String schema = matcher.group(2);
 
         schemaItem.getAliasTableItems()
             .values()
@@ -163,14 +162,14 @@ public abstract class ESAdapter implements OuterAdapter {
                                                                           + "-"
                                                                           + StringUtils.trimToEmpty(config.getGroupId())
                                                                           + "_"
-                                                                          + schema
+                                                                          + tableItem.getSchema()
                                                                           + "-"
                                                                           + tableItem.getTableName(),
                         k -> new ConcurrentHashMap<>());
                 } else {
                     esSyncConfigMap = dbTableEsSyncConfig.computeIfAbsent(StringUtils.trimToEmpty(config.getDestination())
                                                                           + "_"
-                                                                          + schema
+                                                                          + tableItem.getSchema()
                                                                           + "-"
                                                                           + tableItem.getTableName(),
                         k -> new ConcurrentHashMap<>());

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/ESAdapter.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/ESAdapter.java
@@ -152,6 +152,7 @@ public abstract class ESAdapter implements OuterAdapter {
         if (!matcher.find()) {
             throw new RuntimeException("Not found the schema of jdbc-url: " + config.getDataSourceKey());
         }
+        String schema = matcher.group(2);
 
         schemaItem.getAliasTableItems()
             .values()
@@ -162,14 +163,14 @@ public abstract class ESAdapter implements OuterAdapter {
                                                                           + "-"
                                                                           + StringUtils.trimToEmpty(config.getGroupId())
                                                                           + "_"
-                                                                          + tableItem.getSchema()
+                                                                          + tableItem.getSchema() == null ? schema : tableItem.getSchema()
                                                                           + "-"
                                                                           + tableItem.getTableName(),
                         k -> new ConcurrentHashMap<>());
                 } else {
                     esSyncConfigMap = dbTableEsSyncConfig.computeIfAbsent(StringUtils.trimToEmpty(config.getDestination())
                                                                           + "_"
-                                                                          + tableItem.getSchema()
+                                                                          + tableItem.getSchema() == null ? schema : tableItem.getSchema()
                                                                           + "-"
                                                                           + tableItem.getTableName(),
                         k -> new ConcurrentHashMap<>());


### PR DESCRIPTION
ESAdapter 支持跨库查询，(跨库联表查询sql场景)防止left join中的表在构建dbTableEsSyncConfig、取主库schema存入Map,最终被过滤。 
close https://github.com/alibaba/canal/issues/3160 
close https://github.com/alibaba/canal/issues/3159