### PR TITLE
修复fastjson2的兼容问题

### DIFF
--- a/common/src/main/java/com/alibaba/otter/canal/common/utils/JsonUtils.java
+++ b/common/src/main/java/com/alibaba/otter/canal/common/utils/JsonUtils.java
@@ -7,11 +7,8 @@ import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.List;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONFactory;
-import com.alibaba.fastjson2.TypeReference;
+import com.alibaba.fastjson2.*;
 import com.alibaba.fastjson2.filter.PropertyFilter;
-import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.writer.ObjectWriter;
 
 
@@ -32,11 +29,11 @@ public class JsonUtils {
     }
 
     public static <T> T unmarshalFromByte(byte[] bytes, Class<T> targetClass) {
-        return (T) JSON.parseObject(bytes, targetClass);// 默认为UTF-8
+        return (T) JSON.parseObject(bytes, targetClass, JSONReader.Feature.SupportAutoType);// 默认为UTF-8
     }
 
     public static <T> T unmarshalFromByte(byte[] bytes, TypeReference<T> type) {
-        return (T) JSON.parseObject(bytes, type.getType());
+        return (T) JSON.parseObject(bytes, type.getType(), JSONReader.Feature.SupportAutoType);
     }
 
     public static byte[] marshalToByte(Object obj) {
@@ -48,11 +45,11 @@ public class JsonUtils {
     }
 
     public static <T> T unmarshalFromString(String json, Class<T> targetClass) {
-        return (T) JSON.parseObject(json, targetClass);// 默认为UTF-8
+        return (T) JSON.parseObject(json, targetClass, JSONReader.Feature.SupportAutoType);// 默认为UTF-8
     }
 
     public static <T> T unmarshalFromString(String json, TypeReference<T> type) {
-        return (T) JSON.parseObject(json, type);// 默认为UTF-8
+        return (T) JSON.parseObject(json, type, JSONReader.Feature.SupportAutoType);// 默认为UTF-8
     }
 
     public static String marshalToString(Object obj) {

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
             <dependency>
                 <groupId>com.alibaba.fastjson2</groupId>
                 <artifactId>fastjson2</artifactId>
-                <version>2.0.2</version>
+                <version>2.0.3</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
             <dependency>
                 <groupId>com.alibaba.fastjson2</groupId>
                 <artifactId>fastjson2</artifactId>
-                <version>2.0.3</version>
+                <version>2.0.4</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -262,7 +262,7 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>druid</artifactId>
-                <version>1.2.8</version>
+                <version>1.2.10</version>
             </dependency>
             <dependency>
                 <groupId>com.lmax</groupId>


### PR DESCRIPTION
1.1.6升级了fastjson版本，从1.x升级到2.x，其中对autotype行为有不同，默认全部禁止，需要选项打开。