### PR TITLE
fix bug BASE TABLE as table name

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/DatabaseTableMeta.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/DatabaseTableMeta.java
@@ -209,6 +209,7 @@ public class DatabaseTableMeta implements TableMetaTSDB {
             for (String schema : schemas) {
                 // filter views
                 packet = connection.query("show full tables from `" + schema + "` where Table_type = 'BASE TABLE'");
+                columnSize = packet.getFieldDescriptors().size();
                 int tableNameColumnIndex = 0; // default index is 0
                 List<String> tables = new ArrayList<>();
                 for (int line = 0; line < packet.getFieldValues().size() / columnSize; line++) {


### PR DESCRIPTION
fix bug 

com.alibaba.otter.canal.parse.exception.CanalParseException: java.io.IOException: ErrorPacket [errorNumber=1146, fieldCount=-1, message=Table 'mysql.BASE TABLE' doesn't exist, sqlState=42S02, sqlStateMarker=#]
