### PR TITLE
fix destination not encoded

### DIFF
--- a/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/plain/PlainCanalConfigClient.java
+++ b/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/plain/PlainCanalConfigClient.java
@@ -2,6 +2,8 @@ package com.alibaba.otter.canal.instance.manager.plain;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
@@ -84,7 +86,12 @@ public class PlainCanalConfigClient extends AbstractCanalLifeCycle implements Ca
         if (StringUtils.isEmpty(md5)) {
             md5 = "";
         }
-        String url = configURL + "/api/v1/config/instance_polling/" + destination + "?md5=" + md5;
+        String url = null;
+        try {
+            url = configURL + "/api/v1/config/instance_polling/" + URLEncoder.encode(destination, "UTF-8") + "?md5=" + md5;
+        } catch (UnsupportedEncodingException e) {
+            throw new CanalException("encode destination failed", e);
+        }
         return queryConfig(url);
     }
 


### PR DESCRIPTION
bug fix https://github.com/alibaba/canal/issues/4276 canal instance 名称不能带有空格，带空格会导致canal-server 获取instance.properties 报错 ，无法启动canal instance

问题复现：

创建instance "test inst"
启动instance
查看canal server 日志

![image](https://user-images.githubusercontent.com/39491687/177154387-68b7359f-de1a-422d-89fc-832c72f6489b.png)

经确认为获取instance.properties 时未对canal instance 名称做url encode 导致

程序位置：
类 PlainCanalConfigClient
方法 public PlainCanal findInstance(String destination, String md5)
程序 String url = configURL + "/api/v1/config/instance_polling/" + destination + "?md5=" + md5;