### PR TITLE
fix destination not encoded

### DIFF
--- a/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/plain/PlainCanalConfigClient.java
+++ b/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/plain/PlainCanalConfigClient.java
@@ -16,6 +16,7 @@ import com.alibaba.otter.canal.common.AbstractCanalLifeCycle;
 import com.alibaba.otter.canal.common.CanalException;
 import com.alibaba.otter.canal.common.CanalLifeCycle;
 import com.alibaba.otter.canal.protocol.SecurityUtil;
+import com.google.common.net.UrlEscapers;
 
 /**
  * 远程配置获取
@@ -84,7 +85,7 @@ public class PlainCanalConfigClient extends AbstractCanalLifeCycle implements Ca
         if (StringUtils.isEmpty(md5)) {
             md5 = "";
         }
-        String url = configURL + "/api/v1/config/instance_polling/" + destination + "?md5=" + md5;
+        String url = configURL + "/api/v1/config/instance_polling/" + UrlEscapers.urlPathSegmentEscaper().escape(destination) + "?md5=" + md5;
         return queryConfig(url);
     }
 


### PR DESCRIPTION
bug fix https://github.com/alibaba/canal/issues/4276 canal instance 名称不能带有空格，带空格会导致canal-server 获取instance.properties 报错 ，无法启动canal instance

问题复现：

创建instance "test inst"
启动instance
查看canal server 日志

![image](https://user-images.githubusercontent.com/39491687/177189259-bfb8ad2c-73e2-4945-89dd-a75206a9adaa.png)

经确认为获取instance.properties 时未对canal instance 名称做url encode 导致

程序位置：
类 PlainCanalConfigClient
方法 public PlainCanal findInstance(String destination, String md5)
程序 String url = configURL + "/api/v1/config/instance_polling/" + destination + "?md5=" + md5;
<img width="737" alt="image" src="https://user-images.githubusercontent.com/39491687/177347423-021f4734-046b-4516-bd0e-933fbe8fcd87.png">

解决：
对destination 做encode

```
String url = configURL + "/api/v1/config/instance_polling/" + UrlEscapers.urlPathSegmentEscaper().escape(destination) + "?md5=" + md5;
```