### PR TITLE
fix issue #4291

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/DatabaseTableMeta.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/DatabaseTableMeta.java
@@ -209,6 +209,7 @@ public class DatabaseTableMeta implements TableMetaTSDB {
             for (String schema : schemas) {
                 // filter views
                 packet = connection.query("show full tables from `" + schema + "` where Table_type = 'BASE TABLE'");
+                columnSize = packet.getFieldDescriptors().size();
                 int tableNameColumnIndex = 0; // default index is 0
                 List<String> tables = new ArrayList<>();
                 for (int line = 0; line < packet.getFieldValues().size() / columnSize; line++) {


### PR DESCRIPTION
解决base table的问题： [https://github.com/alibaba/canal/issues/4291](#4291 )

代码执行了查询语句  show full tables from `库名` where Table_type = 'BASE TABLE';  ,该语句返回了两列，但代码中没有更新columnSize这变量，导致读取了错误的表名

![image](https://user-images.githubusercontent.com/10218079/182987907-385e700d-fa8b-4652-bb7e-53af251a21a7.png)

![image](https://user-images.githubusercontent.com/10218079/182987974-9daa79ba-6f34-4466-a1b9-c5cb3c5e5d1c.png)

![image](https://user-images.githubusercontent.com/10218079/182988280-4ef14be9-0d02-4c77-bc09-0d072a44add6.png)
