### PR TITLE
fix_ETL同步mysql关键字报错

### DIFF
--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/support/SyncUtil.java
@@ -281,6 +281,7 @@ public class SyncUtil {
         // 只有当dbType为MySQL/MariaDB或OceanBase时返回反引号
         switch (dbType) {
             case mysql:
+                return "`";
             case mariadb:
             case oceanbase:
                 return "`";


### PR DESCRIPTION
使用1.1.6版本的时候，手动etl带有mysql关键字的表时候报错，发现RdbEtlService没有在关键字上加入``。 #4241 