### PR TITLE
feature:mirrorDb优化

### DIFF
--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbMirrorDbSyncService.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/service/RdbMirrorDbSyncService.java
@@ -120,6 +120,7 @@ public class RdbMirrorDbSyncService {
      */
     private void initMappingConfig(String key, MappingConfig baseConfigMap, MirrorDbConfig mirrorDbConfig, Dml dml) {
         MappingConfig mappingConfig = mirrorDbConfig.getTableConfig().get(key);
+        MappingConfig.DbMapping defaultDbMapping = mirrorDbConfig.getMappingConfig().getDbMapping();
         if (mappingConfig == null) {
             // 构造表配置
             mappingConfig = new MappingConfig();
@@ -132,7 +133,11 @@ public class RdbMirrorDbSyncService {
             mappingConfig.setDbMapping(dbMapping);
             dbMapping.setDatabase(dml.getDatabase());
             dbMapping.setTable(dml.getTable());
-            dbMapping.setTargetDb(dml.getDatabase());
+            if(StringUtils.isNotBlank(defaultDbMapping.getTargetDb())){
+                dbMapping.setTargetDb(defaultDbMapping.getTargetDb());
+            }else {
+                dbMapping.setTargetDb(dml.getDatabase());
+            }
             dbMapping.setTargetTable(dml.getTable());
             dbMapping.setMapAll(true);
             List<String> pkNames = dml.getPkNames();


### PR DESCRIPTION
在实际生产中 mirror的表名可能发生变化
例如 schema A-> schema B这种情况暂时未在mirror中支持
通过TargetDb特殊设置不同的schema实现同步