### PR TITLE
fix(sec): upgrade commons-collections:commons-collections to 3.2.2

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -94,7 +95,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2</version>
+			<version>3.2.2</version>
 		</dependency>
 
 		<!-- test dependency -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in commons-collections:commons-collections 3.2
- [MPS-2022-12767](https://www.oscs1024.com/hd/MPS-2022-12767)


### What did I do？
Upgrade commons-collections:commons-collections from 3.2 to 3.2.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS