### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.4.1

### DIFF
--- a/client-adapter/pom.xml
+++ b/client-adapter/pom.xml
@@ -154,7 +154,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.1.4</version>
+                <version>42.4.1</version>
             </dependency>
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>


### PR DESCRIPTION
### What happened？
There are 5 security vulnerabilities found in org.postgresql:postgresql 42.1.4
- [CVE-2022-31197](https://www.oscs1024.com/hd/CVE-2022-31197)
- [CVE-2022-26520](https://www.oscs1024.com/hd/CVE-2022-26520)
- [CVE-2018-10936](https://www.oscs1024.com/hd/CVE-2018-10936)
- [CVE-2020-13692](https://www.oscs1024.com/hd/CVE-2020-13692)
- [CVE-2022-21724](https://www.oscs1024.com/hd/CVE-2022-21724)


### What did I do？
Upgrade org.postgresql:postgresql from 42.1.4 to 42.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS