### PR TITLE
新增topic重名可通过配置前缀来区分

### DIFF
--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQDestination.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQDestination.java
@@ -16,6 +16,7 @@ public class MQDestination {
     private String  dynamicTopic;
     private String  dynamicTopicPartitionNum;
     private Boolean enableDynamicQueuePartition;
+    private String topicPrefix;
 
     public String getCanalDestination() {
         return canalDestination;
@@ -80,4 +81,7 @@ public class MQDestination {
     public void setEnableDynamicQueuePartition(Boolean enableDynamicQueuePartition) {
         this.enableDynamicQueuePartition = enableDynamicQueuePartition;
     }
+    public String getTopicPrefix() {return topicPrefix;}
+
+    public void setTopicPrefix(String topicPrefix) {this.topicPrefix = topicPrefix;}
 }

--- a/connector/kafka-connector/src/main/java/com/alibaba/otter/canal/connector/kafka/producer/CanalKafkaProducer.java
+++ b/connector/kafka-connector/src/main/java/com/alibaba/otter/canal/connector/kafka/producer/CanalKafkaProducer.java
@@ -149,13 +149,18 @@ public class CanalKafkaProducer extends AbstractMQProducer implements CanalMQPro
                     mqDestination.getTopic(),
                     mqDestination.getDynamicTopic());
 
+                // 获取topic前缀
+                String topicPrefix = mqDestination.getTopicPrefix() == null ? "" : mqDestination.getTopicPrefix();;
+
                 // 针对不同的topic,引入多线程提升效率
                 for (Map.Entry<String, Message> entry : messageMap.entrySet()) {
                     final String topicName = entry.getKey().replace('.', '_');
+                    // 拼接前缀后的topic名称,如果前缀为空字符串则为topicName
+                    final String topicNameWithPrefix = topicPrefix + topicName;
                     final Message messageSub = entry.getValue();
                     template.submit((Callable) () -> {
                         try {
-                            return send(mqDestination, topicName, messageSub, mqProperties.isFlatMessage());
+                            return send(mqDestination, topicNameWithPrefix, messageSub, mqProperties.isFlatMessage());
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }

--- a/deployer/src/main/resources/example/instance.properties
+++ b/deployer/src/main/resources/example/instance.properties
@@ -51,6 +51,8 @@ canal.mq.topic=example
 # dynamic topic route by schema or table regex
 #canal.mq.dynamicTopic=mytest1.user,topic2:mytest2\\..*,.*\\..*
 canal.mq.partition=0
+# topic prefix
+canal.mq.topic.prefix=
 # hash partition config
 #canal.mq.enableDynamicQueuePartition=false
 #canal.mq.partitionsNum=3

--- a/deployer/src/main/resources/spring/default-instance.xml
+++ b/deployer/src/main/resources/spring/default-instance.xml
@@ -207,5 +207,6 @@
 		<property name="partitionHash" value="${canal.mq.partitionHash}" />
 		<property name="dynamicTopicPartitionNum" value="${canal.mq.dynamicTopicPartitionNum}" />
 		<property name="enableDynamicQueuePartition" value="${canal.mq.enableDynamicQueuePartition}" />
+		<property name="topicPrefix" value="${canal.mq.topic.prefix}" />
 	</bean>
 </beans>

--- a/deployer/src/main/resources/spring/file-instance.xml
+++ b/deployer/src/main/resources/spring/file-instance.xml
@@ -193,5 +193,6 @@
         <property name="partitionHash" value="${canal.mq.partitionHash}" />
 		<property name="dynamicTopicPartitionNum" value="${canal.mq.dynamicTopicPartitionNum}" />
 		<property name="enableDynamicQueuePartition" value="${canal.mq.enableDynamicQueuePartition}" />
+		<property name="topicPrefix" value="${canal.mq.topic.prefix}" />
 	</bean>
 </beans>

--- a/deployer/src/main/resources/spring/group-instance.xml
+++ b/deployer/src/main/resources/spring/group-instance.xml
@@ -288,5 +288,6 @@
         <property name="partitionHash" value="${canal.mq.partitionHash}" />
 		<property name="dynamicTopicPartitionNum" value="${canal.mq.dynamicTopicPartitionNum}" />
 		<property name="enableDynamicQueuePartition" value="${canal.mq.enableDynamicQueuePartition}" />
+		<property name="topicPrefix" value="${canal.mq.topic.prefix}" />
     </bean>
 </beans>

--- a/deployer/src/main/resources/spring/memory-instance.xml
+++ b/deployer/src/main/resources/spring/memory-instance.xml
@@ -181,5 +181,6 @@
 		<property name="partitionHash" value="${canal.mq.partitionHash}" />
 		<property name="dynamicTopicPartitionNum" value="${canal.mq.dynamicTopicPartitionNum}" />
 		<property name="enableDynamicQueuePartition" value="${canal.mq.enableDynamicQueuePartition}" />
+		<property name="topicPrefix" value="${canal.mq.topic.prefix}" />
 	</bean>
 </beans>

--- a/instance/core/src/main/java/com/alibaba/otter/canal/instance/core/CanalMQConfig.java
+++ b/instance/core/src/main/java/com/alibaba/otter/canal/instance/core/CanalMQConfig.java
@@ -9,6 +9,7 @@ public class CanalMQConfig {
     private String  dynamicTopic;
     private String  dynamicTopicPartitionNum;
     private Boolean enableDynamicQueuePartition;
+    private String topicPrefix;
 
     public String getTopic() {
         return topic;
@@ -65,4 +66,7 @@ public class CanalMQConfig {
     public void setEnableDynamicQueuePartition(Boolean enableDynamicQueuePartition) {
         this.enableDynamicQueuePartition = enableDynamicQueuePartition;
     }
+    public String getTopicPrefix() {return topicPrefix;}
+
+    public void setTopicPrefix(String topicPrefix) {this.topicPrefix = topicPrefix;}
 }

--- a/server/src/main/java/com/alibaba/otter/canal/server/CanalMQStarter.java
+++ b/server/src/main/java/com/alibaba/otter/canal/server/CanalMQStarter.java
@@ -157,6 +157,7 @@ public class CanalMQStarter {
                 canalDestination.setPartitionHash(mqConfig.getPartitionHash());
                 canalDestination.setDynamicTopicPartitionNum(mqConfig.getDynamicTopicPartitionNum());
                 canalDestination.setEnableDynamicQueuePartition(mqConfig.getEnableDynamicQueuePartition());
+                canalDestination.setTopicPrefix(mqConfig.getTopicPrefix());
 
                 canalServer.subscribe(clientIdentity);
                 logger.info("## the MQ producer: {} is running now ......", destination);


### PR DESCRIPTION
由于历史原因MySQL存在相同库名表名，并且使用的是一套kafka，为了区分监听不同实例下同schema名同表名的表和flink通过前缀动态监听，新增一个前缀区分