### PR TITLE
fix(sec): upgrade com.google.protobuf:protobuf-java to 3.16.1

### DIFF
--- a/client-adapter/phoenix/pom.xml
+++ b/client-adapter/phoenix/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>2.5.0</version>
+            <version>3.16.1</version>
         </dependency>
 
         <dependency>
@@ -120,17 +120,17 @@
                             <tasks>
                                 <copy todir="${project.basedir}/../launcher/target/canal-adapter/conf/phoenix" overwrite="true">
                                     <fileset dir="${project.basedir}/target/classes/phoenix" erroronmissingdir="true">
-                                        <include name="*.yml" />
+                                        <include name="*.yml"/>
                                     </fileset>
                                 </copy>
                                 <copy todir="${project.basedir}/../launcher/target/canal-adapter/plugin" overwrite="true">
                                     <fileset dir="${project.basedir}/target/" erroronmissingdir="true">
-                                        <include name="*with-dependencies.jar" />
+                                        <include name="*with-dependencies.jar"/>
                                     </fileset>
                                 </copy>
                                 <copy todir="${project.basedir}/../launcher/target/classes/phoenix" overwrite="true">
                                     <fileset dir="${project.basedir}/target/classes/phoenix" erroronmissingdir="true">
-                                        <include name="*.yml" />
+                                        <include name="*.yml"/>
                                     </fileset>
                                 </copy>
                             </tasks>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alibaba.otter</groupId>
@@ -247,7 +248,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.6.1</version>
+                <version>3.16.1</version>
             </dependency>
             <dependency>
                 <groupId>org.mybatis</groupId>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in com.google.protobuf:protobuf-java 2.5.0
- [CVE-2015-5237](https://www.oscs1024.com/hd/CVE-2015-5237)
- [CVE-2021-22569](https://www.oscs1024.com/hd/CVE-2021-22569)


### What did I do？
Upgrade com.google.protobuf:protobuf-java from 2.5.0 to 3.16.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS