### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -70,7 +70,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.48</version>
+                <version>8.0.28</version>
             </dependency>
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>

--- a/client-adapter/kudu/pom.xml
+++ b/client-adapter/kudu/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.48</version>
+            <version>8.0.28</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -71,7 +71,7 @@
                             <tasks>
                                 <copy todir="${project.basedir}/../launcher/target/classes/kudu" overwrite="true">
                                     <fileset dir="${project.basedir}/target/classes/kudu" erroronmissingdir="true">
-                                        <include name="*.yml" />
+                                        <include name="*.yml"/>
                                     </fileset>
                                 </copy>
                             </tasks>

--- a/client-adapter/pom.xml
+++ b/client-adapter/pom.xml
@@ -149,7 +149,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.48</version>
+                <version>8.0.28</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alibaba.otter</groupId>
@@ -329,7 +330,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.48</version>
+                <version>8.0.28</version>
                 <!--<scope>test</scope>-->
             </dependency>
             <dependency>


### PR DESCRIPTION
### What happened？
There are 4 security vulnerabilities found in mysql:mysql-connector-java 5.1.48
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)
- [CVE-2021-2471](https://www.oscs1024.com/hd/CVE-2021-2471)
- [CVE-2018-3258](https://www.oscs1024.com/hd/CVE-2018-3258)
- [CVE-2019-2692](https://www.oscs1024.com/hd/CVE-2019-2692)


### What did I do？
Upgrade mysql:mysql-connector-java from 5.1.48 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS