### PR TITLE
fix(sec): upgrade org.elasticsearch:elasticsearch to 7.14.0

### DIFF
--- a/client-adapter/es6x/pom.xml
+++ b/client-adapter/es6x/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>6.8.22</version>
+            <version>7.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
@@ -85,7 +85,7 @@
                             <tasks>
                                 <copy todir="${project.basedir}/../launcher/target/classes/es6" overwrite="true">
                                     <fileset dir="${project.basedir}/target/classes/es6" erroronmissingdir="true">
-                                        <include name="*.yml" />
+                                        <include name="*.yml"/>
                                     </fileset>
                                 </copy>
                             </tasks>

--- a/client-adapter/es7x/pom.xml
+++ b/client-adapter/es7x/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>7.3.0</version>
+            <version>7.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
@@ -85,7 +85,7 @@
                             <tasks>
                                 <copy todir="${project.basedir}/../launcher/target/classes/es7" overwrite="true">
                                     <fileset dir="${project.basedir}/target/classes/es7" erroronmissingdir="true">
-                                        <include name="*.yml" />
+                                        <include name="*.yml"/>
                                     </fileset>
                                 </copy>
                             </tasks>


### PR DESCRIPTION
### What happened？
There are 8 security vulnerabilities found in org.elasticsearch:elasticsearch 7.3.0
- [CVE-2019-7619](https://www.oscs1024.com/hd/CVE-2019-7619)
- [CVE-2020-7020](https://www.oscs1024.com/hd/CVE-2020-7020)
- [CVE-2020-7009](https://www.oscs1024.com/hd/CVE-2020-7009)
- [CVE-2020-7014](https://www.oscs1024.com/hd/CVE-2020-7014)
- [CVE-2021-22144](https://www.oscs1024.com/hd/CVE-2021-22144)
- [CVE-2020-7021](https://www.oscs1024.com/hd/CVE-2020-7021)
- [CVE-2021-22137](https://www.oscs1024.com/hd/CVE-2021-22137)
- [CVE-2021-22135](https://www.oscs1024.com/hd/CVE-2021-22135)


### What did I do？
Upgrade org.elasticsearch:elasticsearch from 7.3.0 to 7.14.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS