### PR TITLE
修复 CanalController 和 ServerRunningMonitor stop 方法

### DIFF
--- a/deployer/src/main/java/com/alibaba/otter/canal/deployer/CanalController.java
+++ b/deployer/src/main/java/com/alibaba/otter/canal/deployer/CanalController.java
@@ -558,6 +558,11 @@ public class CanalController {
         }
 
         ZkClientx.clearClients();
+
+        // 需要释放 CanalServerWithEmbedded 否则主线程退出后，进程无法自动完整退出...
+        if (embededCanalServer != null) {
+            embededCanalServer.stop();
+        }
     }
 
     private void initCid(String path) {


### PR DESCRIPTION
公司项目基于 canal 二开发现的问题（望大佬审阅）：
1. CanalController 执行 stop 方法，需要执行 embededCanalServer.stop  否则主线程退出后，进程无法自动完整退出...
2. ServerRunningMonitor 线程池未正常回收，同时 delayExecutor 线程池管理需要和 start/stop 保持一致（canal.properties 配置修改，会触发canal-server 重启，因为 delayExecutor 线程池未回收，通过 arthas 会发现 jvm 有多个 ServerRunningMonitor 实例，jvm 无法 GC 回收）
arthas: `vmtool --action getInstances --className com.alibaba.otter.canal.common.zookeeper.running.ServerRunningMonitor  --limit 10`