### PR TITLE
fix(sec): upgrade org.elasticsearch:elasticsearch to 8.2.1

### DIFF
--- a/client-adapter/es6x/pom.xml
+++ b/client-adapter/es6x/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>6.8.22</version>
+            <version>8.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.elasticsearch:elasticsearch 6.8.22
- [CVE-2022-23710](https://www.oscs1024.com/hd/CVE-2022-23710)


### What did I do？
Upgrade org.elasticsearch:elasticsearch from 6.8.22 to 8.2.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>