### PR TITLE
fix issue #4267 old和data长度不一样而产生的下标越界异常

### DIFF
--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQMessageUtils.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQMessageUtils.java
@@ -432,9 +432,7 @@ public class MQMessageUtils {
                             }
                         }
                         // update操作将记录修改前的值
-                        if (!rowOld.isEmpty()) {
-                            old.add(rowOld);
-                        }
+                        old.add(rowOld);
                     }
                 }
                 if (!sqlType.isEmpty()) {


### PR DESCRIPTION
2022-11-23 14:34:00.914 [pool-2-thread-3] ERROR c.a.o.canal.connector.kafka.producer.CanalKafkaProducer - Index: 8, Size: 8
java.lang.IndexOutOfBoundsException: Index: 8, Size: 8
        at java.util.ArrayList.rangeCheck(ArrayList.java:653) ~[na:1.8.0_111]
        at java.util.ArrayList.get(ArrayList.java:429) ~[na:1.8.0_111]
        at com.alibaba.otter.canal.connector.core.producer.MQMessageUtils.messagePartition(MQMessageUtils.java:542) ~[connector.core-1.1.6.jar:na]
        at com.alibaba.otter.canal.connector.kafka.producer.CanalKafkaProducer.send(CanalKafkaProducer.java:243) ~[na:na]
        at com.alibaba.otter.canal.connector.kafka.producer.CanalKafkaProducer.send(CanalKafkaProducer.java:168) ~[na:na]
        at com.alibaba.otter.canal.server.CanalMQStarter.worker(CanalMQStarter.java:181) [canal.server-1.1.6.jar:na]
        at com.alibaba.otter.canal.server.CanalMQStarter.access$100(CanalMQStarter.java:24) [canal.server-1.1.6.jar:na]
        at com.alibaba.otter.canal.server.CanalMQStarter$CanalMQRunnable.run(CanalMQStarter.java:223) [canal.server-1.1.6.jar:na]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_111]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_111]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_111]