### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka_2.11 to 2.1.1

### DIFF
--- a/connector/kafka-connector/pom.xml
+++ b/connector/kafka-connector/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.11</artifactId>
-            <version>1.1.1</version>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka_2.11 1.1.1
- [CVE-2018-17196](https://www.oscs1024.com/hd/CVE-2018-17196)


### What did I do？
Upgrade org.apache.kafka:kafka_2.11 from 1.1.1 to 2.1.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS

Signed-off-by:pen4<948453219@qq.com>