### PR TITLE
fix(sec): upgrade org.apache.pulsar:pulsar-client to 2.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
             <dependency>
                 <groupId>org.apache.pulsar</groupId>
                 <artifactId>pulsar-client</artifactId>
-                <version>2.8.1</version>
+                <version>2.10.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.pulsar</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.pulsar:pulsar-client 2.8.1
- [CVE-2022-33684](https://www.oscs1024.com/hd/CVE-2022-33684)


### What did I do？
Upgrade org.apache.pulsar:pulsar-client from 2.8.1 to 2.10.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS