### PR TITLE
解决rdb下有多个配制，会导致配置相互覆盖的问题

### DIFF
--- a/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/YamlUtils.java
+++ b/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/YamlUtils.java
@@ -73,6 +73,9 @@ public class YamlUtils {
             PropertySource<?> propertySource = propertySources.get(0);
 
             Properties properties = new Properties();
+            if (baseProperties != null) {
+                properties.putAll(baseProperties);
+            }
 
             properties.putAll((Map<?, ?>) propertySource.getSource());
 
@@ -82,12 +85,7 @@ public class YamlUtils {
                     entry.setValue(((OriginTrackedValue) value).getValue());
                 }
             }
-
-            if (baseProperties != null) {
-                baseProperties.putAll(properties);
-                properties = baseProperties;
-            }
-
+            
             ConfigurationPropertySource sources = new MapConfigurationPropertySource(properties);
             Binder binder = new Binder(sources);
             return binder.bind(prefix, Bindable.of(clazz)).get();


### PR DESCRIPTION
恩baseProperties这个变量是共享的，不能修改这个变量的属性值。要不后续的配置都会改变。关联issue为4355