### PR TITLE
在位点出现问题的时候，清空位点缓存，这样只要修正配置文件就可以获取最新，而不需要重启canal

### DIFF
--- a/meta/src/main/java/com/alibaba/otter/canal/meta/CanalMetaManager.java
+++ b/meta/src/main/java/com/alibaba/otter/canal/meta/CanalMetaManager.java
@@ -90,4 +90,11 @@ public interface CanalMetaManager extends CanalLifeCycle {
      */
     void clearAllBatchs(ClientIdentity clientIdentity) throws CanalMetaManagerException;
 
+    /**
+     * 清楚游标緩存
+     * @param clientIdentity
+     * @throws CanalMetaManagerException
+     */
+   default void removeCursorsCache(ClientIdentity clientIdentity) throws CanalMetaManagerException {};
+
 }

--- a/meta/src/main/java/com/alibaba/otter/canal/meta/MemoryMetaManager.java
+++ b/meta/src/main/java/com/alibaba/otter/canal/meta/MemoryMetaManager.java
@@ -113,6 +113,11 @@ public class MemoryMetaManager extends AbstractCanalLifeCycle implements CanalMe
         batches.get(clientIdentity).clearPositionRanges();
     }
 
+    @Override
+    public void removeCursorsCache(ClientIdentity clientIdentity) throws CanalMetaManagerException {
+        cursors.remove(clientIdentity);
+    }
+
     // ============================
 
     public static class MemoryClientIdentityBatch {

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/AbstractEventParser.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/AbstractEventParser.java
@@ -327,6 +327,7 @@ public abstract class AbstractEventParser<EVENT> extends AbstractCanalLifeCycle 
                     eventSink.interrupt();
                     transactionBuffer.reset();// 重置一下缓冲队列，重新记录数据
                     binlogParser.reset();// 重新置位
+                    removeLogPositionCacheWhenError(destination);
                     if (multiStageCoprocessor != null && multiStageCoprocessor.isStart()) {
                         // 处理 RejectedExecutionException
                         try {
@@ -354,6 +355,8 @@ public abstract class AbstractEventParser<EVENT> extends AbstractCanalLifeCycle 
             runningInfo == null ? null : runningInfo.getAddress()));
         parseThread.start();
     }
+
+
 
     public void stop() {
         super.stop();
@@ -469,6 +472,14 @@ public abstract class AbstractEventParser<EVENT> extends AbstractCanalLifeCycle 
 
     protected void processDumpError(Throwable e) {
         // do nothing
+    }
+
+    /**
+     * 如果是缓存，则清理缓存,允许修改底层的持久化文件的时候无需重启canal
+     * @param destination
+     */
+    protected void removeLogPositionCacheWhenError(String destination) {
+        logPositionManager.removeLogPositionCache(destination);
     }
 
     protected void startHeartBeat(ErosaConnection connection) {

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/MysqlEventParser.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/MysqlEventParser.java
@@ -859,6 +859,14 @@ public class MysqlEventParser extends AbstractMysqlEventParser implements CanalE
         super.processDumpError(e);
     }
 
+    @Override
+    protected void removeLogPositionCacheWhenError(String destination) {
+        if (dumpErrorCount > dumpErrorCountThreshold + 1) {
+            // 这里+1 是允许主从切换的时候重试一下再清缓存
+            logPositionManager.removeLogPositionCache(destination);
+        }
+    }
+
     public void setSupportBinlogFormats(String formatStrs) {
         String[] formats = StringUtils.split(formatStrs, ',');
         if (formats != null) {

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/index/CanalLogPositionManager.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/index/CanalLogPositionManager.java
@@ -13,4 +13,9 @@ public interface CanalLogPositionManager extends CanalLifeCycle {
 
     void persistLogPosition(String destination, LogPosition logPosition) throws CanalParseException;
 
+    /**
+     * 一般使用在异常场景清理缓存，这样持久化的存储更新后能够得到最新的数据，不需要重启机器
+     */
+   default void removeLogPositionCache(String destination){}
+
 }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/index/FailbackLogPositionManager.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/index/FailbackLogPositionManager.java
@@ -80,4 +80,10 @@ public class FailbackLogPositionManager extends AbstractLogPositionManager {
             secondary.persistLogPosition(destination, logPosition);
         }
     }
+
+    @Override
+    public void removeLogPositionCache(String destination) {
+        primary.removeLogPositionCache(destination);
+        secondary.removeLogPositionCache(destination);
+    }
 }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/index/FileMixedLogPositionManager.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/index/FileMixedLogPositionManager.java
@@ -188,4 +188,9 @@ public class FileMixedLogPositionManager extends AbstractLogPositionManager {
             throw new CanalMetaManagerException(e);
         }
     }
+
+    @Override
+    public void removeLogPositionCache(String destination) {
+        memoryLogPositionManager.removeLogPositionCache(destination);
+    }
 }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/index/MemoryLogPositionManager.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/index/MemoryLogPositionManager.java
@@ -40,4 +40,8 @@ public class MemoryLogPositionManager extends AbstractLogPositionManager {
         return positions.keySet();
     }
 
+    @Override
+    public void removeLogPositionCache(String destination) {
+        positions.remove(destination);
+    }
 }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/index/MetaLogPositionManager.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/index/MetaLogPositionManager.java
@@ -75,4 +75,17 @@ public class MetaLogPositionManager extends AbstractLogPositionManager {
         // do nothing
         logger.info("destination [{}] persist LogPosition:{}", destination, logPosition);
     }
+
+    @Override
+    public void removeLogPositionCache(String destination) {
+        List<ClientIdentity> clientIdentities = metaManager.listAllSubscribeInfo(destination);
+        LogPosition result = null;
+        if (CollectionUtils.isEmpty(clientIdentities)) {
+           return;
+        }
+        for (ClientIdentity clientIdentity : clientIdentities) {
+            metaManager.removeCursorsCache(clientIdentity);
+        }
+
+    }
 }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/index/MixedLogPositionManager.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/index/MixedLogPositionManager.java
@@ -81,4 +81,9 @@ public class MixedLogPositionManager extends AbstractLogPositionManager {
             }
         });
     }
+
+    @Override
+    public void removeLogPositionCache(String destination) {
+        memoryLogPositionManager.removeLogPositionCache(destination);
+    }
 }

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/index/PeriodMixedLogPositionManager.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/index/PeriodMixedLogPositionManager.java
@@ -112,4 +112,9 @@ public class PeriodMixedLogPositionManager extends AbstractLogPositionManager {
         persistTasks.add(destination);
         memoryLogPositionManager.persistLogPosition(destination, logPosition);
     }
+
+    @Override
+    public void removeLogPositionCache(String destination) {
+        memoryLogPositionManager.removeLogPositionCache(destination);
+    }
 }


### PR DESCRIPTION
### 背景：
使用非gtid 的模式，当位点出现配置错误或者其他原因导致的位点错误（主从切换等），修正配置文件后需要重启canal才能生效

### 目标
当出现以上问题，系统可以自动清理缓存，获取最新的配置文件信息

### 方案
系统在监听到dum 位点错误的时候，清理位点缓存，下一次自动去获取最新的配置文件