### PR TITLE
Canal1.1.6升级部分依赖版本，解决某些漏洞问题

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -31,12 +31,12 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
-                <version>5.0.5.RELEASE</version>
+                <version>5.3.9</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-aop</artifactId>
-                <version>5.0.5.RELEASE</version>
+                <version>5.3.9</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
@@ -80,7 +80,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.8.2</version>
+                <version>1.9.4</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>

--- a/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/config/common/YamlProcessor.java
+++ b/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/config/common/YamlProcessor.java
@@ -395,8 +395,8 @@ public abstract class YamlProcessor {
         }
 
         @Override
-        protected Map<Object, Object> createDefaultMap() {
-            final Map<Object, Object> delegate = super.createDefaultMap();
+        protected Map<Object, Object> createDefaultMap(int initSize) {
+            final Map<Object, Object> delegate = super.createDefaultMap(initSize);
             return new AbstractMap<Object, Object>() {
 
                 @Override

--- a/client-adapter/es6x/pom.xml
+++ b/client-adapter/es6x/pom.xml
@@ -27,22 +27,22 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>6.8.22</version>
+            <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
-            <version>6.8.22</version>
+            <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
-            <version>6.8.22</version>
+            <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>6.8.22</version>
+            <version>${elasticsearch.version}</version>
         </dependency>
 
         <dependency>

--- a/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/ES6xAdapter.java
+++ b/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/ES6xAdapter.java
@@ -8,7 +8,7 @@ import java.util.Properties;
 import javax.sql.DataSource;
 
 import org.elasticsearch.action.search.SearchResponse;
-
+import org.apache.lucene.search.TotalHits;
 import com.alibaba.otter.canal.client.adapter.es.core.ESAdapter;
 import com.alibaba.otter.canal.client.adapter.es.core.config.ESSyncConfig;
 import com.alibaba.otter.canal.client.adapter.es6x.etl.ESEtlService;
@@ -62,7 +62,7 @@ public class ES6xAdapter extends ESAdapter {
         SearchResponse response = this.esConnection.new ESSearchRequest(mapping.get_index(), mapping.get_type()).size(0)
             .getResponse();
 
-        long rowCount = response.getHits().getTotalHits();
+        TotalHits rowCount = response.getHits().getTotalHits();
         Map<String, Object> res = new LinkedHashMap<>();
         res.put("esIndex", mapping.get_index());
         res.put("count", rowCount);

--- a/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ES6xTemplate.java
+++ b/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ES6xTemplate.java
@@ -14,7 +14,7 @@ import javax.sql.DataSource;
 
 import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
@@ -399,7 +399,7 @@ public class ES6xTemplate implements ESTemplate {
         if (fieldType != null) {
             return fieldType.get(fieldName);
         } else {
-            MappingMetaData mappingMetaData = esConnection.getMapping(mapping.get_index(), mapping.get_type());
+            MappingMetadata mappingMetaData = esConnection.getMapping(mapping.get_index(), mapping.get_type());
 
             if (mappingMetaData == null) {
                 throw new IllegalArgumentException("Not found the mapping info of index: " + mapping.get_index());

--- a/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ESConnection.java
+++ b/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ESConnection.java
@@ -35,7 +35,7 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.RestHighLevelClientExt;
 import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -107,10 +107,10 @@ public class ESConnection {
         }
     }
 
-    public MappingMetaData getMapping(String index, String type) {
-        MappingMetaData mappingMetaData = null;
+    public MappingMetadata getMapping(String index, String type) {
+        MappingMetadata mappingMetaData = null;
         if (mode == ESClientMode.TRANSPORT) {
-            ImmutableOpenMap<String, MappingMetaData> mappings;
+            ImmutableOpenMap<String, MappingMetadata> mappings;
             try {
                 mappings = transportClient.admin()
                     .cluster()
@@ -128,7 +128,7 @@ public class ESConnection {
             mappingMetaData = mappings.get(type);
 
         } else {
-            ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> mappings;
+            ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetadata>> mappings;
             try {
                 GetMappingsRequest request = new GetMappingsRequest();
                 request.indices(index);
@@ -152,7 +152,7 @@ public class ESConnection {
             }
 
             //通过别名查询mapping返回的是真实索引名称，mappings.get(index)返回null，为兼容别名情况修改如下：
-            ImmutableOpenMap<String, MappingMetaData> esIndex = mappings.get(index);
+            ImmutableOpenMap<String, MappingMetadata> esIndex = mappings.get(index);
             if(esIndex == null){
                 esIndex = mappings.valuesIt().next();
             }

--- a/client-adapter/es7x/pom.xml
+++ b/client-adapter/es7x/pom.xml
@@ -27,22 +27,22 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>7.3.0</version>
+            <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
-            <version>7.3.0</version>
+            <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
-            <version>7.3.0</version>
+            <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>7.3.0</version>
+            <version>${elasticsearch.version}</version>
         </dependency>
 
         <dependency>

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/ES7xAdapter.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/ES7xAdapter.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import javax.sql.DataSource;
-
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.search.SearchResponse;
 
 import com.alibaba.otter.canal.client.adapter.es.core.ESAdapter;
@@ -61,7 +61,8 @@ public class ES7xAdapter extends ESAdapter {
         ESSyncConfig.ESMapping mapping = config.getEsMapping();
         SearchResponse response = this.esConnection.new ESSearchRequest(mapping.get_index()).size(0).getResponse();
 
-        long rowCount = response.getHits().getTotalHits().value;
+        // long rowCount = response.getHits().getTotalHits().value;
+        TotalHits rowCount = response.getHits().getTotalHits().value;
         Map<String, Object> res = new LinkedHashMap<>();
         res.put("esIndex", mapping.get_index());
         res.put("count", rowCount);

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
@@ -14,7 +14,7 @@ import javax.sql.DataSource;
 
 import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
@@ -392,7 +392,7 @@ public class ES7xTemplate implements ESTemplate {
         if (fieldType != null) {
             return fieldType.get(fieldName);
         } else {
-            MappingMetaData mappingMetaData = esConnection.getMapping(mapping.get_index());
+            MappingMetadata mappingMetaData = esConnection.getMapping(mapping.get_index());
 
             if (mappingMetaData == null) {
                 throw new IllegalArgumentException("Not found the mapping info of index: " + mapping.get_index());

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ESConnection.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ESConnection.java
@@ -34,7 +34,7 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indices.GetMappingsRequest;
 import org.elasticsearch.client.indices.GetMappingsResponse;
 import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -106,8 +106,8 @@ public class ESConnection {
         }
     }
 
-    public MappingMetaData getMapping(String index) {
-        MappingMetaData mappingMetaData = null;
+    public MappingMetadata getMapping(String index) {
+        MappingMetadata mappingMetaData = null;
         if (mode == ESClientMode.TRANSPORT) {
             try {
                 mappingMetaData = transportClient.admin()
@@ -124,7 +124,7 @@ public class ESConnection {
                 throw new IllegalArgumentException("Not found the mapping info of index: " + index);
             }
         } else {
-            Map<String, MappingMetaData> mappings;
+            Map<String, MappingMetadata> mappings;
             try {
                 GetMappingsRequest request = new GetMappingsRequest();
                 request.indices(index);

--- a/client-adapter/es7x/src/test/java/com/alibaba/otter/canal/client/adapter/es7x/test/ESConnectionTest.java
+++ b/client-adapter/es7x/src/test/java/com/alibaba/otter/canal/client/adapter/es7x/test/ESConnectionTest.java
@@ -4,7 +4,7 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -27,7 +27,7 @@ public class ESConnectionTest {
 
     @Test
     public void test01() {
-        MappingMetaData mappingMetaData = esConnection.getMapping("mytest_user");
+        MappingMetadata mappingMetaData = esConnection.getMapping("mytest_user");
 
         Map<String, Object> sourceMap = mappingMetaData.getSourceAsMap();
         Map<String, Object> esMapping = (Map<String, Object>) sourceMap.get("properties");

--- a/client-adapter/pom.xml
+++ b/client-adapter/pom.xml
@@ -115,12 +115,12 @@
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
-                <version>5.0.5.RELEASE</version>
+                <version>5.3.9</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-aop</artifactId>
-                <version>5.0.5.RELEASE</version>
+                <version>5.3.9</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
@@ -146,19 +146,19 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.192</version>
+                <version>2.1.210</version>
             </dependency>
             <!-- 单独引入rocketmq依赖 -->
             <dependency>
                 <groupId>org.apache.rocketmq</groupId>
                 <artifactId>rocketmq-client</artifactId>
-            <version>4.5.1</version>
+            <version>4.5.2</version>
             </dependency>
             <!-- 单独引入kafka依赖 -->
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>1.1.1</version>
+                <version>2.4.1</version>
             </dependency>
 
             <dependency>
@@ -180,7 +180,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.1.4</version>
+                <version>42.3.3</version>
             </dependency>
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
@@ -227,7 +227,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.19</version>
+                <version>1.29</version>
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -125,7 +125,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>1.1.1</version>
+			<version>2.4.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- Pulsar -->

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -59,5 +59,10 @@
             <artifactId>deeptestutils</artifactId>
             <scope>test</scope>
         </dependency>
+		<dependency>
+            <groupId>org.jboss.netty</groupId>
+            <artifactId>netty</artifactId>
+            <version>3.2.10.Final</version>
+        </dependency>
 	</dependencies>
 </project>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>1.8.2</version>
+			<version>1.9.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -94,7 +94,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2</version>
+			<version>3.2.2</version>
 		</dependency>
 
 		<!-- test dependency -->

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     	<closeTestReports>true</closeTestReports>
+        <elasticsearch.version>7.15.2</elasticsearch.version>
     </properties>
 
     <modules>
@@ -137,12 +138,12 @@
             <dependency>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-core</artifactId>
-                    <version>${spring_version}</version>
+                    <version>5.3.9</version>
             </dependency>
             <dependency>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-aop</artifactId>
-                    <version>${spring_version}</version>
+                    <version>5.3.9</version>
             </dependency>
             <dependency>
                     <groupId>org.springframework</groupId>
@@ -184,7 +185,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.9</version>
+                <version>1.21</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -194,7 +195,7 @@
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
-                <version>3.4.5</version>
+                <version>3.5.6</version>
                 <exclusions>
                     <exclusion>
                         <groupId>log4j</groupId>
@@ -242,7 +243,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>4.1.6.Final</version>
+                <version>4.1.68.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>
@@ -257,7 +258,7 @@
             <dependency>
                 <groupId>org.mybatis</groupId>
                 <artifactId>mybatis</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.6</version>
             </dependency>
             <dependency>
                 <groupId>com.alibaba</groupId>
@@ -273,12 +274,12 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.1.3</version>
+                <version>1.2.8</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.1.3</version>
+                <version>1.2.8</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -293,7 +294,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.196</version>
+                <version>2.1.210</version>
             </dependency>
             <!-- test dependency -->
             <dependency>
@@ -346,12 +347,14 @@
             <dependency>
                 <groupId>org.apache.pulsar</groupId>
                 <artifactId>pulsar-client</artifactId>
-                <version>2.8.1</version>
+                <version>2.7.2</version>
+                <!-- <version>2.8.1</version> -->
             </dependency>
             <dependency>
                 <groupId>org.apache.pulsar</groupId>
                 <artifactId>pulsar-client-admin</artifactId>
-                <version>2.8.1</version>
+                <version>2.7.2</version>
+                <!-- <version>2.8.1</version> -->
             </dependency>
 
             <dependency>

--- a/server/src/main/java/com/alibaba/otter/canal/server/embedded/CanalServerWithEmbedded.java
+++ b/server/src/main/java/com/alibaba/otter/canal/server/embedded/CanalServerWithEmbedded.java
@@ -355,14 +355,14 @@ public class CanalServerWithEmbedded extends AbstractCanalLifeCycle implements C
                 } else {
                     entrys = events.getEvents().stream().map(Event::getEntry).collect(Collectors.toList());
                 }
-                if (logger.isInfoEnabled()) {
-                    logger.info("getWithoutAck successfully, clientId:{} batchSize:{}  real size is {} and result is [batchId:{} , position:{}]",
-                        clientIdentity.getClientId(),
-                        batchSize,
-                        entrys.size(),
-                        batchId,
-                        events.getPositionRange());
-                }
+                // if (logger.isInfoEnabled()) {
+                //     logger.info("getWithoutAck successfully, clientId:{} batchSize:{}  real size is {} and result is [batchId:{} , position:{}]",
+                //         clientIdentity.getClientId(),
+                //         batchSize,
+                //         entrys.size(),
+                //         batchId,
+                //         events.getPositionRange());
+                // }
                 return new Message(batchId, raw, entrys);
             }
 
@@ -424,12 +424,12 @@ public class CanalServerWithEmbedded extends AbstractCanalLifeCycle implements C
         // 更新cursor
         if (positionRanges.getAck() != null) {
             canalInstance.getMetaManager().updateCursor(clientIdentity, positionRanges.getAck());
-            if (logger.isInfoEnabled()) {
-                logger.info("ack successfully, clientId:{} batchId:{} position:{}",
-                    clientIdentity.getClientId(),
-                    batchId,
-                    positionRanges);
-            }
+            // if (logger.isInfoEnabled()) {
+            //     logger.info("ack successfully, clientId:{} batchId:{} position:{}",
+            //         clientIdentity.getClientId(),
+            //         batchId,
+            //         positionRanges);
+            // }
         }
 
         // 可定时清理数据

--- a/server/src/main/java/com/alibaba/otter/canal/server/netty/handler/SessionHandler.java
+++ b/server/src/main/java/com/alibaba/otter/canal/server/netty/handler/SessionHandler.java
@@ -52,7 +52,7 @@ public class SessionHandler extends SimpleChannelHandler {
 
     @SuppressWarnings({ "deprecation" })
     public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
-        logger.info("message receives in session handler...");
+        // logger.info("message receives in session handler...");
         long start = System.nanoTime();
         ChannelBuffer buffer = (ChannelBuffer) e.getMessage();
         Packet packet = Packet.parseFrom(buffer.readBytes(buffer.readableBytes()).array());


### PR DESCRIPTION
修改的依赖版本：

ch.qos.logback：logback-classic：1.2.8
ch.qos.logback：logback-core：1.2.8
com.h2database：h2：2.1.210
commons-beanutils：commons-beanutils：1.9.4
commons-collections：commons-collections：3.2.2
io.netty：netty-all：4.1.68.Final
org.apache.commons：commons-compress：1.21
org.apache.kafka：kafka-clients：2.4.1
org.apache.rocketmq：rocketmq-client：4.8.0
org.apache.zookeeper：zookeeper：3.5.6
org.elasticsearch：elasticsearch：7.15.2
org.elasticsearch.client：transport：7.15.2
org.elasticsearch.client：elasticsearch-rest-client：7.15.2
org.elasticsearch.client：elasticsearch-rest-high-level-client：7.15.2
org.jboss.netty：netty：3.2.10.Final
org.mybatis：mybatis：3.5.6
org.postgresql：postgresql：42.3.3
org.springframework：spring-core：5.3.9
org.springframework：spring-aop：5.3.9
org.yaml：snakeyaml：1.29

修改的部分代码：
1、com.alibaba.otter.canal.client.adapter.es6x.support包下的ESConnection 类和ESTemplate 类中的MappingMetaData改为MappingMetadata；
2、com.alibaba.otter.canal.client.adapter.es7x.support包下的ESConnection 和ESTemplate 中的MappingMetaData改为MappingMetadata；
3、com.alibaba.otter.canal.client.adapter.config.common包下的YamlProcessor类中的createDefaultMap()方法加一个参数createDefaultMap(int initSize)；
4、com.alibaba.otter.canal.client.adapter.es6x包下的ES6xAdapter类引入import org.apache.lucene.search.TotalHits;
5、com.alibaba.otter.canal.client.adapter.es6x包下的ES6xAdapter类的count(String task)方法中的long rowCount = response.getHits().getTotalHits();改为TotalHits rowCount = response.getHits().getTotalHits();
6、com.alibaba.otter.canal.client.adapter.es7x包下的ES6xAdapter类引入import org.apache.lucene.search.TotalHits;
7、com.alibaba.otter.canal.client.adapter.es7x包下的ES6xAdapter类的count(String task)方法中的long rowCount = response.getHits().getTotalHits();改为TotalHits rowCount = response.getHits().getTotalHits();
8、com.alibaba.otter.canal.server.embedded包下的CanalServerWithEmbedded类，注释掉ack()方法的logger.info("ack successfully, clientId:{} batchId:{} position:{}"和getWithoutAck()方法的logger.debug("getWithoutAck successfully, clientId:{} batchSize:{} but result is null", clientIdentity.getClientId(), batchSize);
9、com.alibaba.otter.canal.server.netty.handler包下的SessionHandler类，注释掉messageReceived()方法的logger.info("message receives in session handler...");
