### PR TITLE
very very major：Adapter rdb bug fix

### DIFF
--- a/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/loader/AdapterProcessor.java
+++ b/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/loader/AdapterProcessor.java
@@ -87,6 +87,7 @@ public class AdapterProcessor {
     public void writeOut(final List<CommonMessage> commonMessages) {
         List<Future<Boolean>> futures = new ArrayList<>();
         // 组间适配器并行运行
+        // 当 canalOuterAdapters 初始化失败时，消息将会全部丢失
         canalOuterAdapters.forEach(outerAdapters -> {
             futures.add(groupInnerExecutorService.submit(() -> {
                 try {

--- a/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/RdbAdapter.java
+++ b/client-adapter/rdb/src/main/java/com/alibaba/otter/canal/client/adapter/rdb/RdbAdapter.java
@@ -84,6 +84,7 @@ public class RdbAdapter implements OuterAdapter {
         // 从jdbc url获取db类型
         Map<String, String> properties = configuration.getProperties();
         String dbType = JdbcUtils.getDbType(properties.get("jdbc.url"), null);
+        // 当.yml文件编码格式存在问题，此处rdb yml文件构建 可能会抛出异常
         Map<String, MappingConfig> rdbMappingTmp = ConfigLoader.load(envProperties);
         // 过滤不匹配的key的配置
         rdbMappingTmp.forEach((key, config) -> {


### PR DESCRIPTION
### 问题分类：canal adapter 数据丢失
### 问题等级：非常严重
### 问题描述：canal adapter launcher启动会加载rdb目录下的所有.yml文件，根据一定规则进行
过滤，加载完rdb文件，接着完成各个group下outerAdapter的初始化，最终由outerAdapter进行消息的消费。
当编写的rdb .yml文件编码格式存在问题，比如在window编写，上传到服务器成为乱码文件，这时会导致
outerAdapter的初始化失败，导致消息全部丢失，影响范围是所有adapter；
### 问题影响：该问题导致线上60+业务库数据同步的丢失，最终将错误rdb文件移除，回调binlog位点解决。