### PR TITLE
fix issue 4806, make Common.init success

### DIFF
--- a/client-adapter/es6x/src/test/java/com/alibaba/otter/canal/client/adapter/es6x/test/sync/Common.java
+++ b/client-adapter/es6x/src/test/java/com/alibaba/otter/canal/client/adapter/es6x/test/sync/Common.java
@@ -5,6 +5,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import javax.sql.DataSource;
 
@@ -26,7 +27,7 @@ public class Common {
         outerAdapterConfig.setProperties(properties);
 
         ES6xAdapter esAdapter = new ES6xAdapter();
-        esAdapter.init(outerAdapterConfig, null);
+        esAdapter.init(outerAdapterConfig, new Properties());
         return esAdapter;
     }
 


### PR DESCRIPTION
修复issue 4806 中提到的 es6x 中多个单元测试用到的公共Common.init()方法抛空指针异常问题