### PR TITLE
fixed MQ serverMode lost default topic

### DIFF
--- a/connector/kafka-connector/src/main/java/com/alibaba/otter/canal/connector/kafka/producer/CanalKafkaProducer.java
+++ b/connector/kafka-connector/src/main/java/com/alibaba/otter/canal/connector/kafka/producer/CanalKafkaProducer.java
@@ -151,7 +151,9 @@ public class CanalKafkaProducer extends AbstractMQProducer implements CanalMQPro
 
                 // 针对不同的topic,引入多线程提升效率
                 for (Map.Entry<String, Message> entry : messageMap.entrySet()) {
-                    final String topicName = entry.getKey().replace('.', '_');
+                    // 与默认topic匹配直接返回默认topic
+                    final String topicName = mqDestination.getTopic().equals(entry.getKey()) ?
+                            entry.getKey() : entry.getKey().replace('.', '_');
                     final Message messageSub = entry.getValue();
                     template.submit((Callable) () -> {
                         try {

--- a/connector/pulsarmq-connector/src/main/java/com/alibaba/otter/canal/connector/pulsarmq/producer/CanalPulsarMQProducer.java
+++ b/connector/pulsarmq-connector/src/main/java/com/alibaba/otter/canal/connector/pulsarmq/producer/CanalPulsarMQProducer.java
@@ -158,7 +158,9 @@ public class CanalPulsarMQProducer extends AbstractMQProducer implements CanalMQ
                     .messageTopics(message, destination.getTopic(), destination.getDynamicTopic());
 
                 for (Map.Entry<String, com.alibaba.otter.canal.protocol.Message> entry : messageMap.entrySet()) {
-                    String topicName = entry.getKey().replace('.', '_');
+                    // 与默认topic匹配直接返回默认topic
+                    String topicName = destination.getTopic().equals(entry.getKey()) ?
+                            entry.getKey() : entry.getKey().replace('.', '_');
                     com.alibaba.otter.canal.protocol.Message messageSub = entry.getValue();
                     template.submit(() -> {
                         try {

--- a/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
+++ b/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
@@ -142,7 +142,9 @@ public class CanalRabbitMQProducer extends AbstractMQProducer implements CanalMQ
                     .messageTopics(message, destination.getTopic(), destination.getDynamicTopic());
 
                 for (Map.Entry<String, com.alibaba.otter.canal.protocol.Message> entry : messageMap.entrySet()) {
-                    final String topicName = entry.getKey().replace('.', '_');
+                    // 与默认topic匹配直接返回默认topic
+                    final String topicName = destination.getTopic().equals(entry.getKey()) ?
+                            entry.getKey() : entry.getKey().replace('.', '_');
                     final com.alibaba.otter.canal.protocol.Message messageSub = entry.getValue();
 
                     template.submit(() -> send(destination, topicName, messageSub));

--- a/connector/rocketmq-connector/src/main/java/com/alibaba/otter/canal/connector/rocketmq/producer/CanalRocketMQProducer.java
+++ b/connector/rocketmq-connector/src/main/java/com/alibaba/otter/canal/connector/rocketmq/producer/CanalRocketMQProducer.java
@@ -154,7 +154,9 @@ import java.util.stream.Collectors;
                         destination.getDynamicTopic());
 
                 for (Map.Entry<String, com.alibaba.otter.canal.protocol.Message> entry : messageMap.entrySet()) {
-                    String topicName = entry.getKey().replace('.', '_');
+                    // 与默认topic匹配直接返回默认topic
+                    String topicName = destination.getTopic().equals(entry.getKey()) ?
+                            entry.getKey() : entry.getKey().replace('.', '_');
                     com.alibaba.otter.canal.protocol.Message messageSub = entry.getValue();
                     template.submit(() -> {
                         try {


### PR DESCRIPTION
尊敬的作者您好，MQ模式启动触发以下场景问题。”默认topic和动态topic同时存在，指定需同步的数据库.数据表走指定的动态topic，未指定的数据库.数据表统一走默认topic“，结果经过源码DEBUG发现只要动态topic存在会把topic字符串中所有的”.“替换成”_“导致默认topic丢失。
配置：
![无标题_03](https://github.com/alibaba/canal/assets/62550261/9b18f6d0-ae95-4fc7-a095-984b120201e8)
修改前输出日志：
![无标题](https://github.com/alibaba/canal/assets/62550261/c19e50c2-5cc0-4b23-95bd-df2717b41cae)
我的建议是动态topic与默认topic匹配直接返回默认topic。
修改后代码：
![02](https://github.com/alibaba/canal/assets/62550261/56805512-4e12-4fff-a348-17ad0b265ed6)
修改后输出日志：
![无标题_01](https://github.com/alibaba/canal/assets/62550261/2b823196-3623-4e47-94e5-dbbb22b8dbce)
希望得到采纳，感谢。