### PR TITLE
只对字段某个操作过滤(create/update/delete).

### DIFF
--- a/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/AbstractEtlService.java
+++ b/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/AbstractEtlService.java
@@ -50,7 +50,7 @@ public abstract class AbstractEtlService {
                     values.add(param);
                 }
 
-                sql += " " + etlCondition;
+                sql = setCondition(sql, etlCondition);
             }
 
             if (logger.isDebugEnabled()) {
@@ -117,6 +117,22 @@ public abstract class AbstractEtlService {
             etlResult.setErrorMessage(Joiner.on("\n").join(errMsg));
         }
         return etlResult;
+    }
+
+    public static String setCondition(String sql, String condition) {
+        sql = sql.replaceAll("group\\s+by","GROUP BY");
+        int groupByIndex = sql.lastIndexOf("GROUP BY");
+        if(groupByIndex > -1){
+            if(sql.substring(groupByIndex).indexOf(")") > -1){
+                sql += " " + condition;
+            }else{
+                //当主sql存在group by时，condition正确拼接
+                sql = sql.substring(0,groupByIndex) + " " + condition + " "+sql.substring(groupByIndex);
+            }
+        }else{
+            sql += " " + condition;
+        }
+        return sql;
     }
 
     protected abstract boolean executeSqlImport(DataSource ds, String sql, List<Object> values,

--- a/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ES6xTemplate.java
+++ b/client-adapter/es6x/src/main/java/com/alibaba/otter/canal/client/adapter/es6x/support/ES6xTemplate.java
@@ -68,7 +68,7 @@ public class ES6xTemplate implements ESTemplate {
     public void insert(ESSyncConfig.ESMapping mapping, Object pkVal, Map<String, Object> esFieldData) {
         if (mapping.getId() != null) {
             String parentVal = (String) esFieldData.remove("$parent_routing");
-            if (mapping.isUpsert()) {
+            if (mapping.getJoinTable().isEnabled() || mapping.isUpsert()) {
                 ESUpdateRequest updateRequest = esConnection.new ES6xUpdateRequest(mapping.getIndex(),
                     mapping.getType(),
                     pkVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);
@@ -355,7 +355,7 @@ public class ES6xTemplate implements ESTemplate {
     private void append4Update(ESMapping mapping, Object pkVal, Map<String, Object> esFieldData) {
         if (mapping.getId() != null) {
             String parentVal = (String) esFieldData.remove("$parent_routing");
-            if (mapping.isUpsert()) {
+            if (!mapping.getJoinTable().isEnabled() && mapping.isUpsert()) {
                 ESUpdateRequest esUpdateRequest = this.esConnection.new ES6xUpdateRequest(mapping.getIndex(),
                     mapping.getType(),
                     pkVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);

--- a/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
+++ b/client-adapter/es7x/src/main/java/com/alibaba/otter/canal/client/adapter/es7x/support/ES7xTemplate.java
@@ -68,7 +68,7 @@ public class ES7xTemplate implements ESTemplate {
     public void insert(ESMapping mapping, Object pkVal, Map<String, Object> esFieldData) {
         if (mapping.getId() != null) {
             String parentVal = (String) esFieldData.remove("$parent_routing");
-            if (mapping.isUpsert()) {
+            if (mapping.getJoinTable().isEnabled() || mapping.isUpsert()) {
                 ESUpdateRequest updateRequest = esConnection.new ES7xUpdateRequest(mapping.getIndex(),
                     pkVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);
                 if (StringUtils.isNotEmpty(parentVal)) {
@@ -350,7 +350,7 @@ public class ES7xTemplate implements ESTemplate {
     private void append4Update(ESMapping mapping, Object pkVal, Map<String, Object> esFieldData) {
         if (mapping.getId() != null) {
             String parentVal = (String) esFieldData.remove("$parent_routing");
-            if (mapping.isUpsert()) {
+            if (!mapping.getJoinTable().isEnabled() && mapping.isUpsert()) {
                 ESUpdateRequest esUpdateRequest = this.esConnection.new ES7xUpdateRequest(mapping.getIndex(),
                     pkVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);
                 if (StringUtils.isNotEmpty(parentVal)) {

--- a/client-adapter/es8x/src/main/java/com/alibaba/otter/canal/client/adapter/es8x/support/ES8xTemplate.java
+++ b/client-adapter/es8x/src/main/java/com/alibaba/otter/canal/client/adapter/es8x/support/ES8xTemplate.java
@@ -64,7 +64,7 @@ public class ES8xTemplate implements ESTemplate {
     public void insert(ESMapping mapping, Object pkVal, Map<String, Object> esFieldData) {
         if (mapping.getId() != null) {
             String parentVal = (String) esFieldData.remove("$parent_routing");
-            if (mapping.isUpsert()) {
+            if (mapping.getJoinTable().isEnabled() || mapping.isUpsert()) {
                 ESUpdateRequest updateRequest = esConnection.new ES8xUpdateRequest(mapping.getIndex(),
                     pkVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);
                 if (StringUtils.isNotEmpty(parentVal)) {
@@ -315,7 +315,7 @@ public class ES8xTemplate implements ESTemplate {
         Object resultIdVal = null;
         for (FieldItem fieldItem : schemaItem.getSelectFields().values()) {
             ColumnItem columnItem = fieldItem.getColumnItems().iterator().next();
-            if (!columnItem.getOwner().equals(owner)) {
+            if (columnItem.getOwner() != null && !columnItem.getOwner().equals(owner)) {
                 continue;
             }
             String columnName = columnItem.getColumnName();
@@ -347,7 +347,7 @@ public class ES8xTemplate implements ESTemplate {
     private void append4Update(ESMapping mapping, Object pkVal, Map<String, Object> esFieldData) {
         if (mapping.getId() != null) {
             String parentVal = (String) esFieldData.remove("$parent_routing");
-            if (mapping.isUpsert()) {
+            if (!mapping.getJoinTable().isEnabled() && mapping.isUpsert()) {
                 ESUpdateRequest esUpdateRequest = this.esConnection.new ES8xUpdateRequest(mapping.getIndex(),
                     pkVal.toString()).setDoc(esFieldData).setDocAsUpsert(true);
                 if (StringUtils.isNotEmpty(parentVal)) {

--- a/client-adapter/es8x/src/main/resources/es8/article.yml
+++ b/client-adapter/es8x/src/main/resources/es8/article.yml
@@ -1,0 +1,9 @@
+dataSourceKey: defaultDS
+destination: example
+groupId: g1
+esMapping:
+  _index: article
+  _id: id
+  sql: "select id,user_id,title,avatar,body,create_time from article"
+  etlCondition: "where id ={}"
+  commitBatch: 3000

--- a/client-adapter/es8x/src/main/resources/es8/article_attr.yml
+++ b/client-adapter/es8x/src/main/resources/es8/article_attr.yml
@@ -1,0 +1,15 @@
+dataSourceKey: defaultDS
+destination: example
+groupId: g1
+esMapping:
+  _index: article
+  _id: id
+  #外表(仅部分字段),只执行更新操作(为索引更新部分字段，delete改update————非整个索引文档,不进行delete)
+  joinTable:
+    enabled: true
+    defaultValue:
+      #delete时默认值
+      click: 0
+    sql: "select article_id as id,click from article_attr"
+    etlCondition: "where id={}"
+    commitBatch: 3000

--- a/client-adapter/es8x/src/main/resources/es8/article_category.yml
+++ b/client-adapter/es8x/src/main/resources/es8/article_category.yml
@@ -1,0 +1,16 @@
+dataSourceKey: defaultDS
+destination: example
+groupId: g1
+esMapping:
+  _index: article
+  _id: id
+  #外表(仅部分字段),只执行更新操作(为索引更新部分字段，delete改update————非整个索引文档,不进行delete)
+  joinTable:
+    enabled: true
+    #defaultValue:
+      #click: 0
+  sql: "select article_id as id,GROUP_CONCAT(category_id) as labels from dt_article_category_join group by article_id"
+  objFields:
+    labels: array:,
+  etlCondition: "where id={}"
+  commitBatch: 3000

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/ESSyncConfig.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/config/ESSyncConfig.java
@@ -105,6 +105,7 @@ public class ESSyncConfig implements AdapterConfig {
 
         @Value("${_id}")
         private String id;
+        private JoinTable                    joinTable    = new JoinTable();
         private boolean                      upsert          = false;
         private String                       pk;
         private Map<String, RelationMapping> relations       = new LinkedHashMap<>();
@@ -142,6 +143,14 @@ public class ESSyncConfig implements AdapterConfig {
 
         public void setId(String id) {
             this.id = id;
+        }
+
+        public JoinTable getJoinTable() {
+            return joinTable;
+        }
+
+        public void setJoinTable(JoinTable joinTable) {
+            this.joinTable = joinTable;
         }
 
         public boolean isUpsert() {
@@ -230,6 +239,34 @@ public class ESSyncConfig implements AdapterConfig {
 
         public void setSchemaItem(SchemaItem schemaItem) {
             this.schemaItem = schemaItem;
+        }
+
+        /**
+         * 外表(仅部分字段),只执行更新操作(为索引更新部分字段，delete改update————非整个索引文档,不进行delete)
+         * delete改update:更新索引值且不进行upsert
+         * insert:固定进行upsert
+         *
+         */
+        public static class JoinTable{
+            private boolean enabled = false;
+            //delete改update时设置defaultValue
+            private Map<String, String> defaultValue = new LinkedHashMap<>();
+
+            public boolean isEnabled() {
+                return enabled;
+            }
+
+            public void setEnabled(boolean enabled) {
+                this.enabled = enabled;
+            }
+
+            public Map<String, String> getDefaultValue() {
+                return defaultValue;
+            }
+
+            public void setDefaultValue(Map<String, String> defaultValue) {
+                this.defaultValue = defaultValue;
+            }
         }
     }
 

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/service/ESSyncService.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/service/ESSyncService.java
@@ -799,20 +799,7 @@ public class ESSyncService {
                         }
                     }
 
-                    Map<String, Object> paramsTmp = new LinkedHashMap<>();
-                    for (Map.Entry<FieldItem, List<FieldItem>> entry : tableItem.getRelationTableFields().entrySet()) {
-                        for (FieldItem fieldItem : entry.getValue()) {
-                            Object value = esTemplate
-                                .getValFromRS(mapping, rs, fieldItem.getFieldName(), fieldItem.getFieldName());
-                            String fieldName = fieldItem.getFieldName();
-                            // 判断是否是主键
-                            if (fieldName.equals(mapping.getId())) {
-                                fieldName = "_id";
-                            }
-                            paramsTmp.put(fieldName, value);
-                        }
-                    }
-
+                    Object idVal = esTemplate.getIdValFromRS(mapping, rs);
                     if (logger.isDebugEnabled()) {
                         logger.trace(
                             "Join table update es index by query whole sql, destination:{}, table: {}, index: {}",
@@ -820,7 +807,7 @@ public class ESSyncService {
                             dml.getTable(),
                             mapping.getIndex());
                     }
-                    esTemplate.updateByQuery(config, paramsTmp, esFieldData);
+                    esTemplate.update(mapping,idVal,esFieldData);
                 }
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/service/ESSyncService.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/service/ESSyncService.java
@@ -881,6 +881,17 @@ public class ESSyncService {
                         Map<String, Object> esFieldData = new LinkedHashMap<>();
                         Object idVal = esTemplate.getESDataFromRS(mapping, rs, old, esFieldData);
 
+                        if(idVal == null){
+                        //聚合函数会导致rs.next()=true(无数据情况),此时idVal=null
+                            if(mapping.getJoinTable().isEnabled()){
+                                //外表(部分字段索引完全删除时，对字段进行设置初始值/null)
+                                esFieldData = new LinkedHashMap<>();
+                                idVal = esTemplate.getESDataFromDmlData(mapping, data,esFieldData);
+                                esTemplate.update(mapping,idVal,esFieldData);
+                            }
+                            continue;
+                        }
+
                         if (logger.isTraceEnabled()) {
                             logger.trace(
                                     "Main table update to es index by query sql, destination:{}, table: {}, index: {}, id: {}",

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/service/ESSyncService.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/service/ESSyncService.java
@@ -1,9 +1,11 @@
 package com.alibaba.otter.canal.client.adapter.es.core.service;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
+import org.apache.commons.lang.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,6 +92,7 @@ public class ESSyncService {
 
             long begin = System.currentTimeMillis();
 
+            delete2update(config, dml);
             String type = dml.getType();
             if (type != null && type.equalsIgnoreCase("INSERT")) {
                 insert(config, dml);
@@ -110,6 +113,34 @@ public class ESSyncService {
         } catch (Throwable e) {
             logger.error("sync error, es index: {}, DML : {}", config.getEsMapping().getIndex(), dml);
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 外表(仅部分字段),只执行更新操作(为索引更新部分字段，delete改update————非整个索引文档,不进行delete)
+     * @param config
+     * @param dml
+     */
+    public void delete2update(ESSyncConfig config,Dml dml){
+        if(!config.getEsMapping().getJoinTable().isEnabled()) return;
+
+        if(dml.getType().equalsIgnoreCase("DELETE")){
+            dml.setType("UPDATE");
+            List<Map<String, Object>> old = new ArrayList<>();
+            Map<String, String> defaultValue = config.getEsMapping().getJoinTable().getDefaultValue();
+            List<String> idColumns = config.getMapping().getSchemaItem().getIdFieldItem(config.getMapping()).getColumnItems().stream().map(ColumnItem::getColumnName).collect(Collectors.toList());
+            for (Map<String, Object> item : dml.getData()) {
+                Map<String, Object> clone = (Map<String, Object>) ObjectUtils.clone(item);
+                old.add(clone);
+                item.entrySet().forEach(entry->{
+                    if(!idColumns.contains(entry.getKey()) && !entry.getKey().equals("id")){
+                        entry.setValue(defaultValue.getOrDefault(entry.getKey(),null));
+                    }else{
+                        clone.remove(entry.getKey());
+                    }
+                });
+            }
+            dml.setOld(old);
         }
     }
 
@@ -845,19 +876,26 @@ public class ESSyncService {
         }
         Util.sqlRS(ds, sql, rs -> {
             try {
-                while (rs.next()) {
-                    Map<String, Object> esFieldData = new LinkedHashMap<>();
-                    Object idVal = esTemplate.getESDataFromRS(mapping, rs, old, esFieldData);
+                if(rs.next()){
+                    do{
+                        Map<String, Object> esFieldData = new LinkedHashMap<>();
+                        Object idVal = esTemplate.getESDataFromRS(mapping, rs, old, esFieldData);
 
-                    if (logger.isTraceEnabled()) {
-                        logger.trace(
-                            "Main table update to es index by query sql, destination:{}, table: {}, index: {}, id: {}",
-                            config.getDestination(),
-                            dml.getTable(),
-                            mapping.getIndex(),
-                            idVal);
-                    }
-                    esTemplate.update(mapping, idVal, esFieldData);
+                        if (logger.isTraceEnabled()) {
+                            logger.trace(
+                                    "Main table update to es index by query sql, destination:{}, table: {}, index: {}, id: {}",
+                                    config.getDestination(),
+                                    dml.getTable(),
+                                    mapping.getIndex(),
+                                    idVal);
+                        }
+                        esTemplate.update(mapping, idVal, esFieldData);
+                    }while (rs.next());
+                }else if(mapping.getJoinTable().isEnabled()){
+                    //外表(部分字段索引完全删除时，对字段进行设置初始值/null)
+                    Map<String, Object> esFieldData = new LinkedHashMap<>();
+                    Object idVal = esTemplate.getESDataFromDmlData(mapping, data,esFieldData);
+                    esTemplate.update(mapping,idVal,esFieldData);
                 }
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/support/ESSyncUtil.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/support/ESSyncUtil.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.commons.codec.binary.Base64;
 import org.joda.time.DateTime;
@@ -310,18 +311,16 @@ public class ESSyncUtil {
         return condition.toString();
     }
 
+
+
+    private static final Pattern endGroupByPattern = Pattern.compile("GROUP\\ BY(?!(.*)ON)",Pattern.CASE_INSENSITIVE);
     public static String appendCondition(String sql, String condition) {
-        sql = sql.replaceAll("group\\s+by","GROUP BY");
-        int groupByIndex = sql.lastIndexOf("GROUP BY");
-        if(groupByIndex > -1){
-            if(sql.substring(groupByIndex).indexOf(")") > -1){
-                sql = sql + " WHERE " + condition + " ";
-            }else{
-                //当主sql存在group by时，condition正确拼接
-                sql = sql.substring(0,groupByIndex) + " WHERE " + condition + " "+sql.substring(groupByIndex);
-            }
+        String[] split = endGroupByPattern.split(sql);
+        if(split.length > 1){
+            //当主sql存在group by时，condition正确拼接
+            sql = split[0] + " WHERE " + condition + " GROUP BY "+split[1];
         }else{
-            sql = sql + " WHERE " + condition + " ";
+            sql = split[0] + " WHERE " + condition + " ";
         }
         return sql;
     }

--- a/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/support/ESSyncUtil.java
+++ b/client-adapter/escore/src/main/java/com/alibaba/otter/canal/client/adapter/es/core/support/ESSyncUtil.java
@@ -311,7 +311,19 @@ public class ESSyncUtil {
     }
 
     public static String appendCondition(String sql, String condition) {
-        return sql + " WHERE " + condition + " ";
+        sql = sql.replaceAll("group\\s+by","GROUP BY");
+        int groupByIndex = sql.lastIndexOf("GROUP BY");
+        if(groupByIndex > -1){
+            if(sql.substring(groupByIndex).indexOf(")") > -1){
+                sql = sql + " WHERE " + condition + " ";
+            }else{
+                //当主sql存在group by时，condition正确拼接
+                sql = sql.substring(0,groupByIndex) + " WHERE " + condition + " "+sql.substring(groupByIndex);
+            }
+        }else{
+            sql = sql + " WHERE " + condition + " ";
+        }
+        return sql;
     }
 
     public static void appendCondition(StringBuilder sql, Object value, String owner, String columnName) {

--- a/deployer/src/main/resources/example/instance.properties
+++ b/deployer/src/main/resources/example/instance.properties
@@ -43,8 +43,8 @@ canal.instance.filter.regex=.*\\..*
 canal.instance.filter.black.regex=mysql\\.slave_.*
 # table field filter(format: schema1.tableName1:field1/field2,schema2.tableName2:field1/field2)
 #canal.instance.filter.field=test1.t_product:id/subject/keywords,test2.t_company:id/name/contact/ch
-# table field black filter(format: schema1.tableName1:field1/field2,schema2.tableName2:field1/field2)
-#canal.instance.filter.black.field=test1.t_product:subject/product_image,test2.t_company:id/name/contact/ch
+# table field black filter(format: schema1.tableName1:field1/field2,schema2.tableName2:field1/field2,schema3.tableName3:field1^update/field2)
+#canal.instance.filter.black.field=test1.t_product:subject/product_image,test2.t_company:id/name/update_time^update/ch
 
 # mq config
 canal.mq.topic=example


### PR DESCRIPTION
例：field1^update  对field1的update操作忽略不同步(对create,delete无影响) 在某些批量update场景中(大数据),可手动对同步目标执行批量update操作，不需要通过canal同步