### PR TITLE
fix parser failed when binlog_row_value_options=partial_json

### DIFF
--- a/dbsync/src/main/java/com/taobao/tddl/dbsync/binlog/event/RowsLogBuffer.java
+++ b/dbsync/src/main/java/com/taobao/tddl/dbsync/binlog/event/RowsLogBuffer.java
@@ -1086,6 +1086,7 @@ public final class RowsLogBuffer {
                         value = builder.toString();
                         buffer.position(position + len);
                     } catch (IllegalArgumentException e) {
+                        buffer.position(position);
                         // print_json_diff failed, fallback to parse_value
                         parseJsonFromFullValue(len);
                     }

--- a/dbsync/src/main/java/com/taobao/tddl/dbsync/binlog/event/RowsLogBuffer.java
+++ b/dbsync/src/main/java/com/taobao/tddl/dbsync/binlog/event/RowsLogBuffer.java
@@ -19,7 +19,7 @@ import com.taobao.tddl.dbsync.binlog.LogEvent;
 
 /**
  * Extracting JDBC type & value information from packed rows-buffer.
- * 
+ *
  * @see mysql-5.1.60/sql/log_event.cc - Rows_log_event::print_verbose_one_row
  * @author <a href="mailto:changyuan.lh@taobao.com">Changyuan.lh</a>
  * @version 1.0
@@ -70,7 +70,7 @@ public final class RowsLogBuffer {
 
     /**
      * Extracting next row from packed buffer.
-     * 
+     *
      * @see mysql-5.1.60/sql/log_event.cc -
      * Rows_log_event::print_verbose_one_row
      */
@@ -104,7 +104,7 @@ public final class RowsLogBuffer {
 
     /**
      * Extracting next field value from packed buffer.
-     * 
+     *
      * @see mysql-5.1.60/sql/log_event.cc -
      * Rows_log_event::print_verbose_one_row
      */
@@ -114,7 +114,7 @@ public final class RowsLogBuffer {
 
     /**
      * Extracting next field value from packed buffer.
-     * 
+     *
      * @see mysql-5.1.60/sql/log_event.cc -
      * Rows_log_event::print_verbose_one_row
      */
@@ -277,7 +277,7 @@ public final class RowsLogBuffer {
 
     /**
      * Extracting next field value from packed buffer.
-     * 
+     *
      * @see mysql-5.1.60/sql/log_event.cc - log_event_print_value
      */
     final Serializable fetchValue(String columnName, int columnIndex, int type, final int meta, boolean isBinary) {
@@ -1077,30 +1077,20 @@ public final class RowsLogBuffer {
                 if (partialBits.get(1)) {
                     // print_json_diff
                     int position = buffer.position();
-                    StringBuilder builder = JsonDiffConversion.print_json_diff(buffer,
-                        len,
-                        columnName,
-                        columnIndex,
-                            charset);
-                    value = builder.toString();
-                    buffer.position(position + len);
-                } else {
-                    if (0 == len) {
-                        // fixed issue #1 by lava, json column of zero length
-                        // has no
-                        // value, value parsing should be skipped
-                        value = "";
-                    } else {
-                        int position = buffer.position();
-                        Json_Value jsonValue = JsonConversion.parse_value(buffer.getUint8(),
-                            buffer,
-                            len - 1,
+                    try {
+                        StringBuilder builder = JsonDiffConversion.print_json_diff(buffer,
+                                len,
+                                columnName,
+                                columnIndex,
                                 charset);
-                        StringBuilder builder = new StringBuilder();
-                        jsonValue.toJsonString(builder, charset);
                         value = builder.toString();
                         buffer.position(position + len);
+                    } catch (IllegalArgumentException e) {
+                        // print_json_diff failed, fallback to parse_value
+                        parseJsonFromFullValue(len);
                     }
+                } else {
+                    parseJsonFromFullValue(len);
                 }
                 javaType = Types.VARCHAR;
                 length = len;
@@ -1153,6 +1143,25 @@ public final class RowsLogBuffer {
         }
 
         return value;
+    }
+
+    private void parseJsonFromFullValue(int len) {
+        if (0 == len) {
+            // fixed issue #1 by lava, json column of zero length
+            // has no
+            // value, value parsing should be skipped
+            value = "";
+        } else {
+            int position = buffer.position();
+            Json_Value jsonValue = JsonConversion.parse_value(buffer.getUint8(),
+                buffer,
+                len - 1,
+                    charset);
+            StringBuilder builder = new StringBuilder();
+            jsonValue.toJsonString(builder, charset);
+            value = builder.toString();
+            buffer.position(position + len);
+        }
     }
 
     public final boolean isNull() {


### PR DESCRIPTION
# 修复了binlog_row_value_options=partial_json情况下的解析问题

#5017 当mysql的binlog_row_value_options=partial_json时binlog解析失败

## 原因

MySQL源码中`sql\log_event.cc\print_json_diff`与canal中`com.taobao.tddl.dbsync.binlog.JsonDiffConversion#print_json_diff(com.taobao.tddl.dbsync.binlog.LogBuffer, long, java.lang.String, int, java.nio.charset.Charset)`这两个函数对于解析的边界取值上存在偏差

MySQL源码中的length仅为JSON部分更新内容的长度

![image-20231230112136655](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230112136655.png)

但是canal使用`buffer.hasRemaining`进行判断，会导致解析到溢出的部分，也就是不属于JSON部分更新的内容的部分。超解析。

![image-20231230112302620](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230112302620.png)

在本来循环应该结束的位置没有停止，buffer过消费。实际上应该对buffer解析到`len`长度就停止解析。



## 修复

在循环结尾处引入长度消费检测，如果消费长度超出上限就直接退出循环

![image-20231230112453034](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230112453034.png)

![image-20231230112522364](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230112522364.png)

同时在入口处进行捕捉。

在某些情况下，虽然开启了`binlog_row_value_options=partial_json`，但是after-image中的json字段的binlog记录仍然是完整的(主要出现在全量替换等情况下)，不使用json函数进行表达，因此需要返回原有的完整解析的逻辑。

![image-20231230114148630](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230114148630.png)

需要注意重新解析时需要做回退位点



## 正常解析结果

情况如下

![image-20231230113512497](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230113512497.png)

执行SQL

```sql
update test_json_table set c1 = json_set(c1, '$.id', 1) where id = 1;
```

解析情况

![image-20231230113620821](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230113620821.png)

执行SQL

```sql
update test_json_table set c1 = json_set(c1 , '$.name', 'go', '$.website', 'golang.com') where id = 1;
```

解析情况

![image-20231230113724425](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230113724425.png)

执行SQL

```sql
update test_json_table set c2 = json_array_insert(c2, '$[1]', cast('{"id": 1}' as json)) where id = 1;
```

执行情况

![image-20231230114249290](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230114249290.png)

上述即为开启`partial_json`情况下after-image完整的情况

执行SQL

```SQL
update test_json_table set c2 = json_set(c2, '$[1].name', 'wangminan') where id = 1;
```

执行情况

![image-20231230114446790](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230114446790.png)

执行SQL

```sql
update test_json_table set c2 = json_set(c2, '$[1].id', 2, '$[100]', 'y') where id = 1;
```

执行结果

![image-20231230114559640](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230114559640.png)

嵌套解析正常，能够成功获取多层函数

执行SQL

```sql
update test_json_table set c1 = json_remove(c1, '$.website') where id = 1;
```

执行结果

![image-20231230141451990](https://cdn.jsdelivr.net/gh/WangMinan/Pics/image-20231230141451990.png)

上述用例包含了`JSON_INSERT`,`JSON_REPLACE`,`JSON_ARRAY_INSERT`,`JSON_REMOVE`以及partial_json下完整after-image，即可能出现的所有情况。