### PR TITLE
feat: upgraded rocketmq to 5.1.1(fastjson 1.2.83)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <javadoc_skip>true</javadoc_skip>
         <spring_version>5.3.9</spring_version>
         <log4j_version>2.17.0</log4j_version>
-        <rocketmq_version>4.8.0</rocketmq_version>
+        <rocketmq_version>5.1.1</rocketmq_version>
         <rabbitmq_version>5.18.0</rabbitmq_version>
         <mq_amqp_client>1.0.3</mq_amqp_client>
         <kafka_version>2.4.0</kafka_version>


### PR DESCRIPTION
软件:fastjson(jar) 1.2.69
命中:["fastjson(jar) extendField.safemode equals false","fastjson(jar) version less than equals 1.2.80"]
路径:/usr/local/canal/plugin/connector.rocketmq-1.1.7-jar-with-dependencies.jar(META-INF/maven/com.alibaba/fastjson/pom.xml)
扩展信息:{"safemode": "false"}