### PR TITLE
fix(adapter): add args into adapter/restart.sh

### DIFF
--- a/client-adapter/launcher/src/main/bin/restart.sh
+++ b/client-adapter/launcher/src/main/bin/restart.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+args=$@
+
 case $(uname) in
 Linux)
   bin_abs_path=$(readlink -f $(dirname $0))
@@ -9,5 +11,5 @@ Linux)
   ;;
 esac
 
-sh "$bin_abs_path"/stop.sh
-sh "$bin_abs_path"/startup.sh
+sh "$bin_abs_path"/stop.sh $args
+sh "$bin_abs_path"/startup.sh $args


### PR DESCRIPTION
Fix issue:  https://github.com/alibaba/canal/issues/5148

### Description
- The `client-adapter/launcher/src/main/bin/restart.sh` file does not accept arguments. So that we cannot pass the debug options to the `startup.sh` script.
- In this MR, I have added the argument support to the `restart.sh` script.