### PR TITLE
fix: resource loading failure caused by incorrect parameter order in StringUtils.startsWithIgnoreCase

### DIFF
--- a/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/YamlUtils.java
+++ b/client-adapter/common/src/main/java/com/alibaba/otter/canal/client/adapter/support/YamlUtils.java
@@ -25,7 +25,7 @@ import org.springframework.util.PropertyPlaceholderHelper;
 public class YamlUtils {
 
     public static <T> T resourceYmlToObj(String resource, String prefix, Class<T> clazz) {
-        if (!StringUtils.startsWithIgnoreCase("classpath:", resource)) {
+        if (!StringUtils.startsWithIgnoreCase(resource, "classpath:")) {
             resource = "classpath:" + resource;
         }
         ClassPathResource classPathResource = new ClassPathResource(resource);

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -90,7 +90,6 @@
 		<dependency>
 			<groupId>com.alibaba</groupId>
 			<artifactId>druid</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/PlainCanalInstanceGenerator.java
+++ b/instance/manager/src/main/java/com/alibaba/otter/canal/instance/manager/PlainCanalInstanceGenerator.java
@@ -18,7 +18,7 @@ import com.alibaba.otter.canal.parse.CanalEventParser;
 
 /**
  * 基于manager生成对应的{@linkplain CanalInstance}
- * 
+ *
  * @author jianghang 2012-7-12 下午05:37:09
  * @version 1.0.0
  */
@@ -70,7 +70,7 @@ public class PlainCanalInstanceGenerator implements CanalInstanceGenerator {
     // ================ setter / getter ================
 
     private BeanFactory getBeanFactory(String springXml) {
-        if (!StringUtils.startsWithIgnoreCase("classpath:", springXml)) {
+        if (!StringUtils.startsWithIgnoreCase(springXml, "classpath:")) {
             springXml = "classpath:" + springXml;
         }
         ApplicationContext applicationContext = new ClassPathXmlApplicationContext(springXml);

--- a/instance/spring/src/main/java/com/alibaba/otter/canal/instance/spring/SpringCanalInstanceGenerator.java
+++ b/instance/spring/src/main/java/com/alibaba/otter/canal/instance/spring/SpringCanalInstanceGenerator.java
@@ -45,7 +45,7 @@ public class SpringCanalInstanceGenerator implements CanalInstanceGenerator {
     }
 
     private BeanFactory getBeanFactory(String springXml) {
-        if (!StringUtils.startsWithIgnoreCase("classpath:", springXml)) {
+        if (!StringUtils.startsWithIgnoreCase(springXml, "classpath:")) {
             springXml = "classpath:" + springXml;
         }
         ApplicationContext applicationContext = new ClassPathXmlApplicationContext(springXml);

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/TableMetaTSDBBuilder.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/tsdb/TableMetaTSDBBuilder.java
@@ -30,7 +30,7 @@ public class TableMetaTSDBBuilder {
             if (applicationContext == null) {
                 synchronized (contexts) {
                     if (applicationContext == null) {
-                        if (!StringUtils.startsWithIgnoreCase("classpath:", springXml)) {
+                        if (!StringUtils.startsWithIgnoreCase(springXml, "classpath:")) {
                             springXml = "classpath:" + springXml;
                         }
                         applicationContext = new ClassPathXmlApplicationContext(springXml);


### PR DESCRIPTION
**What happened？**

- Resource loading failure caused by incorrect parameter order in StringUtils.startsWithIgnoreCase.
- Changing  druid dependency in canal.common's pom to optional which leads to DruidDataSource class not found when using tsdb.

**What did I do？**

Fix these bugs.

**What did you expect to happen？**

Fix these bugs.

**How was this patch tested?**

**The specification of the pull request**

[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS