### PR TITLE
client adapter同个instance配置多个group会共享CanalMsgConsumer，从而出现并发问题

### DIFF
--- a/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/loader/AdapterProcessor.java
+++ b/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/loader/AdapterProcessor.java
@@ -1,16 +1,5 @@
 package com.alibaba.otter.canal.adapter.launcher.loader;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.alibaba.otter.canal.adapter.launcher.common.SyncSwitch;
 import com.alibaba.otter.canal.adapter.launcher.config.SpringContext;
 import com.alibaba.otter.canal.client.adapter.OuterAdapter;
@@ -23,6 +12,16 @@ import com.alibaba.otter.canal.connector.core.consumer.CommonMessage;
 import com.alibaba.otter.canal.connector.core.spi.CanalMsgConsumer;
 import com.alibaba.otter.canal.connector.core.spi.ExtensionLoader;
 import com.alibaba.otter.canal.connector.core.spi.ProxyCanalMsgConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * 适配处理器
@@ -63,8 +62,9 @@ public class AdapterProcessor {
 
         // load connector consumer
         ExtensionLoader<CanalMsgConsumer> loader = new ExtensionLoader<>(CanalMsgConsumer.class);
+        String key = destination + "_" + groupId;
         canalMsgConsumer = new ProxyCanalMsgConsumer(loader
-            .getExtension(canalClientConfig.getMode().toLowerCase(), destination, CONNECTOR_SPI_DIR,
+            .getExtension(canalClientConfig.getMode().toLowerCase(), key, CONNECTOR_SPI_DIR,
                 CONNECTOR_STANDBY_SPI_DIR));
 
         Properties properties = canalClientConfig.getConsumerProperties();


### PR DESCRIPTION
问题现象：
kafka模式下同个instance配置多个group，启动必然会出现：KafkaConsumer is not safe for multi-threaded access Error sync and rollback的问题
![image](https://github.com/alibaba/canal/assets/53174818/182241fe-a173-4964-9d12-b00fa6c82907)
原因：
每个group都会对应一个AdapterProcessor，AdapterProcessor初始化的时候会通过loader获取CanalMsgConsumer，CanalMsgConsumer实例会被ExtensionLoader缓存在EXTENSION_KEY_INSTANCE，key是name + "-" + key；而这里的key外部只会传入destination，所以导致同个instance多个group都会复用同一个CanalMsgConsumer，在kafka模式下就会出现多线程访问同一个kafkacomsumer的问题
解决方法：
传入destination + "-" + groupId作为key