### PR TITLE
fixed Rocketmq can not batch send messages when producer set namespace

### DIFF
--- a/connector/rocketmq-connector/src/main/java/com/alibaba/otter/canal/connector/rocketmq/producer/CanalRocketMQProducer.java
+++ b/connector/rocketmq-connector/src/main/java/com/alibaba/otter/canal/connector/rocketmq/producer/CanalRocketMQProducer.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 
     private              DefaultMQProducer  defaultMQProducer;
     private static final String             CLOUD_ACCESS_CHANNEL = "cloud";
+    private static final String             NAMESPACE_SEPARATOR  = "%";
     protected            ThreadPoolExecutor sendPartitionExecutor;
 
     @Override public void init(Properties properties) {
@@ -311,7 +312,11 @@ import java.util.stream.Collectors;
 
         // 获取一下messageQueue
         DefaultMQProducerImpl innerProducer = this.defaultMQProducer.getDefaultMQProducerImpl();
-        TopicPublishInfo topicInfo = innerProducer.getTopicPublishInfoTable().get(messages.get(0).getTopic());
+        String topic = messages.get(0).getTopic();
+        if (StringUtils.isNotBlank(this.defaultMQProducer.getNamespace())) {
+            topic = this.defaultMQProducer.getNamespace() + NAMESPACE_SEPARATOR + topic;
+        }
+        TopicPublishInfo topicInfo = innerProducer.getTopicPublishInfoTable().get(topic);
         if (topicInfo == null) {
             for (Message message : messages) {
                 sendMessage(message, partition);


### PR DESCRIPTION
What happened？
There are a bug found in com.alibaba.otter.canal.connector.rocketmq.producer.CanalRocketMQProducer. It can not batch send messages when set namespace in "rocketmq.namespace"
in file canal.properties.Because DefaultMQProducerImpl#getTopicPublishInfoTable() return a hashmap which key is concat with namespace and '%' and topicname.For example,when namespace is 'MQ_INST_89' and topic name is 'BINLOG_TOPIC', then the key will be 'MQ_INST_89%BINLOG_TOPIC'

What did I do？

concat the rocketmq namespace , '%' and topic name

What did you expect to happen？
fix the problem

How can we automate the detection of these types of issues?

You can set namespace in file of canal.properties, and print log of DefaultMQProducerImpl#getTopicPublishInfoTable(), it will show the format of key

The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS