### PR TITLE
Fix issue #5126: Upgrade the default TLS version to 1.2 in AbstractRequest.java

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/rds/request/AbstractRequest.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/rds/request/AbstractRequest.java
@@ -195,7 +195,7 @@ public abstract class AbstractRequest<T> {
     private final HttpResponse executeHttpRequest(HttpGet getMethod, String host) throws Exception {
         SSLContext sslContext = SSLContexts.custom().loadTrustMaterial(null, (TrustStrategy) (arg0, arg1) -> true).build();
         SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(sslContext,
-            new String[] { "TLSv1" },
+            new String[] { "TLSv1.2" },
             null,
             SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
         Registry registry = RegistryBuilder.create()


### PR DESCRIPTION
Refer to #5126.
The origin TLSv1 is deprecated, we upgrade it to TLSv1.2 for better security.
