### PR TITLE
直接close socket，解决TLS half-close policy报错问题

### DIFF
--- a/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/socket/BioSocketChannel.java
+++ b/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/socket/BioSocketChannel.java
@@ -168,16 +168,6 @@ public class BioSocketChannel implements SocketChannel {
         Socket socket = this.socket;
         if (socket != null) {
             try {
-                socket.shutdownInput();
-            } catch (IOException e) {
-                // Ignore, could not do anymore
-            }
-            try {
-                socket.shutdownOutput();
-            } catch (IOException e) {
-                // Ignore, could not do anymore
-            }
-            try {
                 socket.close();
             } catch (IOException e) {
                 // Ignore, could not do anymore


### PR DESCRIPTION
直接使用socket.close，解决TLS half-close policy问题，socket.close会自动关闭input/outputstream