### PR TITLE
本次修改旨在解决mq tps上限问题, 根据实际生产使用canal需求而来.canal.mq.maxTps建议设置为mq最大tps的1/10

### DIFF
--- a/common/src/main/java/com/alibaba/otter/canal/common/counter/TpsCounter.java
+++ b/common/src/main/java/com/alibaba/otter/canal/common/counter/TpsCounter.java
@@ -1,0 +1,101 @@
+package com.alibaba.otter.canal.common.counter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * tps计数器
+ * 当tps超过阈值时，等待阻塞，直到恢复tps
+ */
+public class TpsCounter {
+
+    /**
+     * 缓存tps实例
+     */
+    private static final Map<String, TpsCounter> TPS_COUNTERS = new java.util.concurrent.ConcurrentHashMap<>();
+
+    private static Logger logger = LoggerFactory.getLogger(TpsCounter.class);
+
+    /**
+     * 初始tps计数为0
+     */
+    private int currentTps = 0;
+    /**
+     * 最后一次更新时间
+     */
+    private long lastTimestamp = -1L;
+
+    /**
+     * 将构造私有化
+     */
+    private TpsCounter(){}
+
+    /**
+     * 双重校验锁, 和同步HashMap保证同一名称的实例唯一性
+     * @param name 名称
+     * @return tpsCounter实例
+     */
+    public static TpsCounter getInstance(String name){
+        TpsCounter tpsCounter = TPS_COUNTERS.get(name);
+        if (tpsCounter == null){
+            synchronized (TpsCounter.class){
+                tpsCounter = TPS_COUNTERS.computeIfAbsent(name, k -> new TpsCounter());
+            }
+        }
+        return tpsCounter;
+    }
+
+    /**
+     * 同步方法返回当前的tps计数
+     * @return tps
+     */
+    public synchronized int getCurrentTps(){
+        if (lastTimestamp == -1L){
+            lastTimestamp = timeGen();
+        }
+        if (timeGen() == lastTimestamp){
+            currentTps++;
+        } else {
+            lastTimestamp = timeGen();
+            currentTps = 1;
+        }
+        return currentTps;
+    }
+
+    /**
+     * 当前tps是否超过最大tps
+     * @param maxTps 最大tps
+     * @return true: 超过, false: 未超过
+     */
+    public synchronized boolean isOverTps(int maxTps){
+        return getCurrentTps() > maxTps;
+    }
+
+    /**
+     * 等待tps窗口, 如果在当前tps已超过最大tps, 则等待直到下一个时间窗口
+     * @param maxTps 最大tps
+     */
+    public synchronized void waitTps(int maxTps){
+        logger.info("current time {}, time:{}, current req count {}", timeGen(), timeGen(),this.currentTps);
+        while (isOverTps(maxTps)){
+            try {
+                long waitTime = 1000L - System.currentTimeMillis() % 1000L + 2L;
+                logger.info("tps over {}, sleep {}ms, current time {}, current req count {}", maxTps,  waitTime, timeGen(), this.currentTps);
+                Thread.sleep(waitTime);
+                logger.info("current time {}, current req count {}", timeGen(), this.currentTps);
+            } catch (Throwable ignore) {
+            }
+        }
+    }
+
+    /**
+     * 获取当前时间的秒数
+     * @return 秒
+     */
+    private long timeGen(){
+        return System.currentTimeMillis() / 1000;
+    }
+
+}

--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/config/CanalConstants.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/config/CanalConstants.java
@@ -25,4 +25,6 @@ public class CanalConstants {
     public static final String CANAL_ALIYUN_SECRET_KEY        = ROOT + "." + "aliyun.secretKey";
     public static final String CANAL_ALIYUN_UID               = ROOT + "." + "aliyun.uid";
 
+    public static final String CANAL_MQ_MAX_TPS               = ROOT + "." + "mq.maxTps";
+
 }

--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/config/MQProperties.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/config/MQProperties.java
@@ -20,6 +20,7 @@ public class MQProperties {
     private String  aliyunAccessKey         = "";
     private String  aliyunSecretKey         = "";
     private int     aliyunUid               = 0;
+    private int     maxTps                  = -1;
 
     public boolean isFlatMessage() {
         return flatMessage;
@@ -107,5 +108,13 @@ public class MQProperties {
 
     public void setAliyunUid(int aliyunUid) {
         this.aliyunUid = aliyunUid;
+    }
+
+    public int getMaxTps() {
+        return maxTps;
+    }
+
+    public void setMaxTps(int maxTps) {
+        this.maxTps = maxTps;
     }
 }

--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/AbstractMQProducer.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/AbstractMQProducer.java
@@ -126,6 +126,13 @@ public abstract class AbstractMQProducer implements CanalMQProducer {
         if (!StringUtils.isEmpty(aliyunUid)) {
             mqProperties.setAliyunUid(Integer.parseInt(aliyunUid));
         }
+        String maxTps = PropertiesUtils.getProperty(properties, CanalConstants.CANAL_MQ_MAX_TPS);
+        if (!StringUtils.isEmpty(maxTps)) {
+            int tps = Integer.parseInt(maxTps);
+            if (tps>0) {
+                mqProperties.setMaxTps(tps);
+            }
+        }
     }
 
     /**

--- a/deployer/src/main/resources/canal.properties
+++ b/deployer/src/main/resources/canal.properties
@@ -134,6 +134,8 @@ canal.mq.database.hash = true
 canal.mq.send.thread.size = 30
 canal.mq.build.thread.size = 8
 
+canal.mq.maxTps = -1
+
 ##################################################
 ######### 		     Kafka 		     #############
 ##################################################


### PR DESCRIPTION
新增tps计数器 com.alibaba.otter.canal.common.counter.TpsCounter

修改com.alibaba.otter.canal.connector.core.config.MQProperties, 新增maxTps属性

修改com.alibaba.otter.canal.connector.core.spi.ProxyCanalMQProducer, 新增tps控制

修改com.alibaba.otter.canal.connector.core.config.CanalConstants, 新增CANAL_MQ_MAX_TPS常量

修改com.alibaba.otter.canal.connector.core.producer.AbstractMQProducer, 新增CANAL_MQ_MAX_TPS读取和加载

修改canal.properties, 新增: canal.mq.maxTps = -1