### PR TITLE
fixed clickhouse etl bug

### DIFF
--- a/client-adapter/clickhouse/src/main/java/com/alibaba/otter/canal/client/adapter/clickhouse/ClickHouseAdapter.java
+++ b/client-adapter/clickhouse/src/main/java/com/alibaba/otter/canal/client/adapter/clickhouse/ClickHouseAdapter.java
@@ -229,7 +229,7 @@ public class ClickHouseAdapter implements OuterAdapter {
     public Map<String, Object> count(String task) {
         MappingConfig config = clickHouseMapping.get(task);
         MappingConfig.DbMapping dbMapping = config.getDbMapping();
-        String sql = "SELECT COUNT(1) AS cnt FROM " + SyncUtil.getDbTableName(dbMapping, dataSource.getDbType());
+        String sql = "SELECT COUNT(1) AS cnt FROM " + SyncUtil.getTargetDbTableName(dbMapping, dataSource.getDbType());
         Connection conn = null;
         Map<String, Object> res = new LinkedHashMap<>();
         try {
@@ -255,7 +255,7 @@ public class ClickHouseAdapter implements OuterAdapter {
                 }
             }
         }
-        res.put("targetTable", SyncUtil.getDbTableName(dbMapping, dataSource.getDbType()));
+        res.put("targetTable", SyncUtil.getTargetDbTableName(dbMapping, dataSource.getDbType()));
 
         return res;
     }

--- a/client-adapter/clickhouse/src/main/java/com/alibaba/otter/canal/client/adapter/clickhouse/service/ClickHouseBatchSyncService.java
+++ b/client-adapter/clickhouse/src/main/java/com/alibaba/otter/canal/client/adapter/clickhouse/service/ClickHouseBatchSyncService.java
@@ -294,7 +294,7 @@ public class ClickHouseBatchSyncService {
         Map<String, String> columnsMap = SyncUtil.getColumnsMap(dbMapping, clearDmls.get(0).getData());
 
         StringBuilder insertSql = new StringBuilder();
-        insertSql.append("INSERT INTO ").append(SyncUtil.getDbTableName(dbMapping, dataSource.getDbType())).append(" (");
+        insertSql.append("INSERT INTO ").append(SyncUtil.getTargetDbTableName(dbMapping, dataSource.getDbType())).append(" (");
 
         columnsMap.forEach((targetColumnName, srcColumnName) -> insertSql.append(backtick)
             .append(targetColumnName)
@@ -380,7 +380,7 @@ public class ClickHouseBatchSyncService {
         Map<String, Integer> ctype = getTargetColumnType(batchExecutor.getConn(), config);
 
         StringBuilder updateSql = new StringBuilder();
-        updateSql.append("ALTER TABLE ").append(SyncUtil.getDbTableName(dbMapping, dataSource.getDbType())).append(" UPDATE ");
+        updateSql.append("ALTER TABLE ").append(SyncUtil.getTargetDbTableName(dbMapping, dataSource.getDbType())).append(" UPDATE ");
         List<Map<String, ?>> values = new ArrayList<>();
         boolean hasMatched = false;
         for (String srcColumnName : old.keySet()) {
@@ -433,7 +433,7 @@ public class ClickHouseBatchSyncService {
         Map<String, Integer> ctype = getTargetColumnType(batchExecutor.getConn(), config);
 
         StringBuilder sql = new StringBuilder();
-        sql.append("ALTER TABLE ").append(SyncUtil.getDbTableName(dbMapping, dataSource.getDbType())).append(" DELETE WHERE ");
+        sql.append("ALTER TABLE ").append(SyncUtil.getTargetDbTableName(dbMapping, dataSource.getDbType())).append(" DELETE WHERE ");
 
         List<Map<String, ?>> values = new ArrayList<>();
         // 拼接主键
@@ -452,7 +452,7 @@ public class ClickHouseBatchSyncService {
     private void truncate(BatchExecutor batchExecutor, MappingConfig config) throws SQLException {
         DbMapping dbMapping = config.getDbMapping();
         StringBuilder sql = new StringBuilder();
-        sql.append("TRUNCATE TABLE ").append(SyncUtil.getDbTableName(dbMapping, dataSource.getDbType()));
+        sql.append("TRUNCATE TABLE ").append(SyncUtil.getTargetDbTableName(dbMapping, dataSource.getDbType()));
         batchExecutor.execute(sql.toString(), new ArrayList<>());
         if (logger.isTraceEnabled()) {
             logger.trace("Truncate target table, sql: {}", sql);
@@ -476,7 +476,7 @@ public class ClickHouseBatchSyncService {
                 if (columnType == null) {
                     columnType = new LinkedHashMap<>();
                     final Map<String, Integer> columnTypeTmp = columnType;
-                    String sql = "SELECT * FROM " + SyncUtil.getDbTableName(dbMapping, dataSource.getDbType()) + " WHERE 1=2";
+                    String sql = "SELECT * FROM " + SyncUtil.getTargetDbTableName(dbMapping, dataSource.getDbType()) + " WHERE 1=2";
                     Util.sqlRS(conn, sql, rs -> {
                         try {
                             ResultSetMetaData rsd = rs.getMetaData();

--- a/client-adapter/clickhouse/src/main/java/com/alibaba/otter/canal/client/adapter/clickhouse/service/ClickHouseEtlService.java
+++ b/client-adapter/clickhouse/src/main/java/com/alibaba/otter/canal/client/adapter/clickhouse/service/ClickHouseEtlService.java
@@ -40,7 +40,7 @@ public class ClickHouseEtlService extends AbstractEtlService {
     public EtlResult importData(List<String> params) {
         DbMapping dbMapping = config.getDbMapping();
         DruidDataSource dataSource = DatasourceConfig.DATA_SOURCES.get(config.getDataSourceKey());
-        String sql = "SELECT * FROM " + SyncUtil.getDbTableName(dbMapping, dataSource.getDbType());
+        String sql = "SELECT * FROM " + SyncUtil.getSourceDbTableName(dbMapping, dataSource.getDbType());
         return importData(sql, params);
     }
 
@@ -57,7 +57,7 @@ public class ClickHouseEtlService extends AbstractEtlService {
             String backtick = SyncUtil.getBacktickByDbType(dataSource.getDbType());
 
             Util.sqlRS(targetDS,
-                "SELECT * FROM " + SyncUtil.getDbTableName(dbMapping, dataSource.getDbType()) + " LIMIT 1 ",
+                "SELECT * FROM " + SyncUtil.getTargetDbTableName(dbMapping, dataSource.getDbType()) + " LIMIT 1 ",
                 rs -> {
                     try {
 
@@ -85,7 +85,7 @@ public class ClickHouseEtlService extends AbstractEtlService {
 
                     StringBuilder insertSql = new StringBuilder();
                     insertSql.append("INSERT INTO ")
-                        .append(SyncUtil.getDbTableName(dbMapping, dataSource.getDbType()))
+                        .append(SyncUtil.getTargetDbTableName(dbMapping, dataSource.getDbType()))
                         .append(" (");
                     columnsMap.forEach((targetColumnName, srcColumnName) -> insertSql.append(backtick)
                         .append(targetColumnName)
@@ -113,7 +113,7 @@ public class ClickHouseEtlService extends AbstractEtlService {
                             // 删除数据
                             Map<String, Object> pkVal = new LinkedHashMap<>();
                             StringBuilder deleteSql = new StringBuilder(
-                                "ALTER TABLE " + SyncUtil.getDbTableName(dbMapping, dataSource.getDbType())
+                                "ALTER TABLE " + SyncUtil.getTargetDbTableName(dbMapping, dataSource.getDbType())
                                                                         + " DELETE WHERE ");
                             appendCondition(dbMapping, deleteSql, pkVal, rs, backtick);
                             try (PreparedStatement pstmt2 = connTarget.prepareStatement(deleteSql.toString())) {

--- a/client-adapter/clickhouse/src/main/java/com/alibaba/otter/canal/client/adapter/clickhouse/support/SyncUtil.java
+++ b/client-adapter/clickhouse/src/main/java/com/alibaba/otter/canal/client/adapter/clickhouse/support/SyncUtil.java
@@ -258,7 +258,7 @@ public class SyncUtil {
         }
     }
 
-    public static String getDbTableName(MappingConfig.DbMapping dbMapping, String dbType) {
+    public static String getTargetDbTableName(MappingConfig.DbMapping dbMapping, String dbType) {
         String result = "";
         String backtick = getBacktickByDbType(dbType);
         if (StringUtils.isNotEmpty(dbMapping.getTargetDb())) {
@@ -266,6 +266,11 @@ public class SyncUtil {
         }
         result += (backtick + dbMapping.getTargetTable() + backtick);
         return result;
+    }
+
+    public static String getSourceDbTableName(MappingConfig.DbMapping dbMapping, String dbType) {
+        String backtick = getBacktickByDbType(dbType);
+        return backtick + dbMapping.getDatabase() + backtick + "." + backtick + dbMapping.getTable() + backtick;
     }
 
     /**


### PR DESCRIPTION
当使用clickhouse `adapter的etl同步数据时，报错如下：
`
com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: Table 'default.test_user' doesn't exist
java.lang.RuntimeException: com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: Table 'default.test_user' doesn't exist
	at com.alibaba.otter.canal.client.adapter.support.Util.sqlRS(Util.java:67)
	at com.alibaba.otter.canal.client.adapter.support.AbstractEtlService.importData(AbstractEtlService.java:62)
	at com.alibaba.otter.canal.client.adapter.clickhouse.service.ClickHouseEtlService.importData(ClickHouseEtlService.java:44)
	at com.alibaba.otter.canal.client.adapter.clickhouse.ClickHouseAdapter.etl(ClickHouseAdapter.java:191)
	at com.alibaba.otter.canal.adapter.launcher.rest.CommonRest.etl(CommonRest.java:101)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
`
而我的配置是如下：
`
dataSourceKey: defaultDS
destination: example
groupId: g1
outerAdapterKey: clickhouse1
concurrent: true
dbMapping:
  database: test
  table: sys_user
  targetDb: default
  targetTable: test_user
  targetPk:
    id: id
  targetColumns:
    id:
    user_name:
    email:
    sex:
    password:
    status:  
  etlCondition: "where id>={}"
  commitBatch: 3000 # 批量提交的大小
`
明显，取错了数据库的表，应该取的是源数据库的表，而取成了目标数据库的表。