### PR TITLE
bugfix: 兼容MariaDB GTID 为空的情况

### DIFF
--- a/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/MariaGTIDSet.java
+++ b/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/MariaGTIDSet.java
@@ -24,8 +24,11 @@ public class MariaGTIDSet implements GTIDSet {
 
     @Override
     public void update(String str) {
-        MariaGtid mariaGtid = MariaGtid.parse(str);
-        gtidMap.put(mariaGtid.getDomainId(), mariaGtid);
+        if (StringUtils.isNotEmpty(str)) {
+            // 兼容 GTID 为空的情况，例如 mysql-bin.000001 的 GTID 是空的
+            MariaGtid mariaGtid = MariaGtid.parse(str);
+            gtidMap.put(mariaGtid.getDomainId(), mariaGtid);
+        }
     }
 
     public void add(MariaGtid mariaGtid) {


### PR DESCRIPTION
MariaDB 增量同步时报 java.lang.ArrayIndexOutOfBoundsException，这种情况在数据库主从切换，或者是一个新数据库的时候会出现。原因是数据库的binlog GTID 为空，解析时出现异常，现提供修复，增加GTID为空时的处理。