### PR TITLE
fix dynamicTopic simpleName mode

### DIFF
--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQMessageUtils.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQMessageUtils.java
@@ -85,7 +85,12 @@ public class MQMessageUtils {
                                                                                     DynamicTopicData data = new DynamicTopicData();
 
                                                                                     if (!isWildCard(dynamicTopic)) {
-                                                                                        data.simpleName = dynamicTopic;
+                                                                                        int i = dynamicTopic.indexOf(":");
+                                                                                        if (i > 0) {
+                                                                                            data.simpleName = dynamicTopic.substring(0, i);
+                                                                                        } else {
+                                                                                            data.simpleName = dynamicTopic;
+                                                                                        }
                                                                                     } else {
                                                                                         if (dynamicTopic.contains("\\.")) {
                                                                                             data.tableRegexFilter = new AviaterRegexFilter(dynamicTopic);
@@ -582,10 +587,9 @@ public class MQMessageUtils {
         for (String item : router) {
             int i = item.indexOf(":");
             if (i > -1) {
-                String topic = item.substring(0, i).trim();
                 String topicConfigs = item.substring(i + 1).trim();
-                if (matchDynamicTopic(name, topicConfigs)) {
-                    topics.add(topic);
+                if (matchDynamicTopic(name, item)) {
+                    topics.add(topicConfigs);
                     // 匹配了一个就退出
                     break;
                 }


### PR DESCRIPTION
修复一个canal消费binlog后，单表设置canal.mq.dynamicTopic后，无法动态匹配问题
原DynamicTopicData赋值中，没有处理testdb.testtable:testdb_testtable_new_topic_name的场景，导致matchDynamicTopic方法无法匹配此场景