### PR TITLE
解决8.0.30+使用cahcing_sha2_password时Fastauth报错问题

### DIFF
--- a/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/MysqlConnector.java
+++ b/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/MysqlConnector.java
@@ -317,6 +317,9 @@ public class MysqlConnector {
                             // fixed issue https://github.com/alibaba/canal/pull/4767, support mysql 8.0.30+
                             header = cachingSha2PasswordFullAuth(channel, header, getPassword().getBytes(), scramble);
                             body = PacketManager.readBytes(channel, header.getPacketBodyLength(), timeout);
+                        } else {
+                            header = PacketManager.readHeader(channel, 4);
+                            body = PacketManager.readBytes(channel, header.getPacketBodyLength(), timeout);
                         }
                     }
                 } else {


### PR DESCRIPTION
环境描述:
MYSQL服务端版本：8.0.36
Canal:1.1.8
背景：MYSQL服务端版本为8.0.36时采用caching_sha2_password插件认证，使用caching_sha2_password登录插件账号FullAuth登录后服务端存在缓存，再次登录报错。断点发现非首次连接存在包未读的情况，导致后续访问越界。FullAuth情况正常
单元测试：
执行了com/alibaba/otter/canal/parse/driver/mysql/MysqlConnectorTest.java

报错如下：
```
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
	at com.alibaba.otter.canal.parse.driver.mysql.utils.ByteHelper.readUnsignedShortLittleEndian(ByteHelper.java:61)
	at com.alibaba.otter.canal.parse.driver.mysql.packets.server.EOFPacket.fromBytes(EOFPacket.java:31)
	at com.alibaba.otter.canal.parse.driver.mysql.MysqlQueryExecutor.parseEOFPacket(MysqlQueryExecutor.java:157)
	at com.alibaba.otter.canal.parse.driver.mysql.MysqlQueryExecutor.readEofPacket(MysqlQueryExecutor.java:151)
	at com.alibaba.otter.canal.parse.driver.mysql.MysqlQueryExecutor.query(MysqlQueryExecutor.java:74)
	at com.alibaba.otter.canal.parse.driver.mysql.MysqlConnector.printSslStatus(MysqlConnector.java:95)
	at com.alibaba.otter.canal.parse.driver.mysql.MysqlConnector.connect(MysqlConnector.java:82)
	at com.alibaba.otter.canal.parse.driver.mysql.MysqlConnectorTest.testQuery(MysqlConnectorTest.java:23)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
```

