### PR TITLE
fix(canal/prometheus): 修复延迟指标的缺陷

### DIFF
--- a/prometheus/src/main/java/com/alibaba/otter/canal/prometheus/impl/StoreCollector.java
+++ b/prometheus/src/main/java/com/alibaba/otter/canal/prometheus/impl/StoreCollector.java
@@ -162,7 +162,7 @@ public class StoreCollector extends Collector implements InstanceRegistry {
             Preconditions.checkNotNull(holder.putMemSize);
             Preconditions.checkNotNull(holder.ackMemSize);
         }
-        StoreMetricsHolder old = instances.putIfAbsent(destination, holder);
+        StoreMetricsHolder old = instances.put(destination, holder);
         if (old != null) {
             logger.warn("Remote stale StoreCollector for instance {}.", destination);
         }


### PR DESCRIPTION
-【缺陷描述】
   Admin控制台修改canal.properties配置后，Server自动进行重启，在Grafan上观测到同步实例的PUT/GET/ACK延迟居高不下。

-【原因定位】
   源库心跳正常触发，MemoryStoreWithBuffer正常推进位点，profiling 正常统计，但是延迟指标依然是越来越来越高。Prometheus调用collect接口采集到的exec time时间始终是固定不变的。经debug排查到StoreCollector采集器内存hold的StoreMetricsHolder与CanalInstance实例中的引用已经不同啦，CanalIntance重启时已经被重建过一份新的实例，但是StoreMetricsHolder却没有保存到内存Hold中。原因是Map.putIfAbsent调用引起。

-【修复效果】
- 修复后，重启Server心跳正常推进，延迟瞬间降下来。梳理其他Collector代码都是调用Map.put，只有这里使用putIfAbsent可能是粗心导致吧。修复效果