### PR TITLE
fix(canal/client-adapter): 修复adapter插件重试错误缺陷

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ test-output/
 .settings/
 tmp
 temp
+logs/
 *.log
 antx.properties
 otter.properties

--- a/prometheus/src/main/java/com/alibaba/otter/canal/prometheus/impl/StoreCollector.java
+++ b/prometheus/src/main/java/com/alibaba/otter/canal/prometheus/impl/StoreCollector.java
@@ -162,7 +162,7 @@ public class StoreCollector extends Collector implements InstanceRegistry {
             Preconditions.checkNotNull(holder.putMemSize);
             Preconditions.checkNotNull(holder.ackMemSize);
         }
-        StoreMetricsHolder old = instances.putIfAbsent(destination, holder);
+        StoreMetricsHolder old = instances.put(destination, holder);
         if (old != null) {
             logger.warn("Remote stale StoreCollector for instance {}.", destination);
         }


### PR DESCRIPTION
-【缺陷描述】
  adapter运行期间，针对server或者Instance进行过一次重启或者断网测试，发现adapter通过client拉取数据报错以后持续打印错误日志，永远不得恢复。虽然adapter processor 针对错误有重试逻辑，但是client的tcp连接已经发生中断，且无法恢复。

-【问题定位】
  adapter processor 针对错误的处理比较粗，需要细分是从上游get message报错，还是下游sync data报错？
  如果是 get message报错，特别是tcp 断开，需要跳出重试，重新尝试重连。如果是下游 sync data 报错，再考虑重试写入。下游插件开发者自行保证连接重连机制、写入幂等。框架只提供重试。

- 说明：顺带更新一下 .gitignore 文件