### PR TITLE
fix(canal/startup.sh): 修复生产环境ZK启用sasl安全认证

### DIFF
--- a/client-adapter/launcher/src/main/bin/startup.sh
+++ b/client-adapter/launcher/src/main/bin/startup.sh
@@ -9,7 +9,10 @@ case "`uname`" in
 		bin_abs_path=`cd $(dirname $0); pwd`
 		;;
 esac
+
 base=${bin_abs_path}/..
+jaas_conf=$base/conf/jaas.conf
+
 export LANG=en_US.UTF-8
 export BASE=$base
 
@@ -81,6 +84,9 @@ fi
 
 JAVA_OPTS=" $JAVA_OPTS -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8"
 ADAPTER_OPTS="-DappName=canal-adapter"
+if [ -f "$jaas_conf" ]; then
+  ADAPTER_OPTS="$ADAPTER_OPTS -Djava.security.auth.login.config=$jaas_conf"
+fi
 
 for i in $base/lib/*;
     do CLASSPATH=$i:"$CLASSPATH";

--- a/deployer/src/main/bin/startup.sh
+++ b/deployer/src/main/bin/startup.sh
@@ -9,10 +9,14 @@ case "`uname`" in
 		bin_abs_path=`cd $(dirname $0); pwd`
 		;;
 esac
+
 base=${bin_abs_path}/..
+
+jaas_conf=$base/conf/jaas.conf
 canal_conf=$base/conf/canal.properties
 canal_local_conf=$base/conf/canal_local.properties
 logback_configurationFile=$base/conf/logback.xml
+
 export LANG=en_US.UTF-8
 export BASE=$base
 
@@ -104,6 +108,9 @@ fi
 
 JAVA_OPTS=" $JAVA_OPTS -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8"
 CANAL_OPTS="-DappName=otter-canal -Dlogback.configurationFile=$logback_configurationFile -Dcanal.conf=$canal_conf"
+if [ -f "$jaas_conf" ]; then
+  CANAL_OPTS="$CANAL_OPTS -Djava.security.auth.login.config=$jaas_conf"
+fi
 
 if [ -e $canal_conf -a -e $logback_configurationFile ]
 then 

--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>2.1.210</version>
+                <version>2.2.224</version>
             </dependency>
             <dependency>
                 <groupId>mysql</groupId>


### PR DESCRIPTION
背景：生产启用 Zookeeper SASL 安全认证

- 如果生产环境zk启用sasl安全认证，canal-server/canal-adapter启动无法连接zk进行读写操作
- 默认支持用户将 jaas.conf 放置在 ./conf/ 目录下，启动脚本增加-Djava.security.auth.login.config 启动参数即可
