### PR TITLE
feat: add dynamicTag for RocketMQ

### DIFF
--- a/admin/admin-web/src/main/resources/instance-template.properties
+++ b/admin/admin-web/src/main/resources/instance-template.properties
@@ -50,6 +50,7 @@ canal.instance.filter.black.regex=
 canal.mq.topic=example
 # dynamic topic route by schema or table regex
 #canal.mq.dynamicTopic=mytest1.user,mytest2\\..*,.*\\..*
+#canal.mq.dynamicTag=mytest1.user,mytest2\\..*,.*\\..*
 canal.mq.partition=0
 # hash partition config
 #canal.mq.partitionsNum=3

--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQDestination.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/producer/MQDestination.java
@@ -14,6 +14,7 @@ public class MQDestination {
     private Integer partitionsNum;
     private String  partitionHash;
     private String  dynamicTopic;
+    private String  dynamicTag;
     private String  dynamicTopicPartitionNum;
     private Boolean enableDynamicQueuePartition;
 
@@ -63,6 +64,14 @@ public class MQDestination {
 
     public void setDynamicTopic(String dynamicTopic) {
         this.dynamicTopic = dynamicTopic;
+    }
+
+    public String getDynamicTag() {
+        return dynamicTag;
+    }
+
+    public void setDynamicTag(String dynamicTag) {
+        this.dynamicTag = dynamicTag;
     }
 
     public String getDynamicTopicPartitionNum() {

--- a/deployer/src/main/resources/example/instance.properties
+++ b/deployer/src/main/resources/example/instance.properties
@@ -63,6 +63,7 @@ canal.instance.filter.black.regex=mysql\\.slave_.*
 canal.mq.topic=example
 # dynamic topic route by schema or table regex
 #canal.mq.dynamicTopic=mytest1.user,topic2:mytest2\\..*,.*\\..*
+#canal.mq.dynamicTag=mytest1.user,tag2:mytest2\\..*,.*\\..*
 canal.mq.partition=0
 # hash partition config
 #canal.mq.enableDynamicQueuePartition=false

--- a/deployer/src/main/resources/spring/default-instance.xml
+++ b/deployer/src/main/resources/spring/default-instance.xml
@@ -229,6 +229,7 @@
 	<bean id="mqConfig" class="com.alibaba.otter.canal.instance.core.CanalMQConfig">
 		<property name="topic" value="${canal.mq.topic}" />
 		<property name="dynamicTopic" value="${canal.mq.dynamicTopic}" />
+		<property name="dynamicTag" value="${canal.mq.dynamicTag}" />
 		<property name="partition" value="${canal.mq.partition}" />
 		<property name="partitionsNum" value="${canal.mq.partitionsNum}" />
 		<property name="partitionHash" value="${canal.mq.partitionHash}" />

--- a/deployer/src/main/resources/spring/file-instance.xml
+++ b/deployer/src/main/resources/spring/file-instance.xml
@@ -215,6 +215,7 @@
 	<bean id="mqConfig" class="com.alibaba.otter.canal.instance.core.CanalMQConfig">
         <property name="topic" value="${canal.mq.topic}" />
 		<property name="dynamicTopic" value="${canal.mq.dynamicTopic}" />
+		<property name="dynamicTag" value="${canal.mq.dynamicTag}" />
         <property name="partition" value="${canal.mq.partition}" />
         <property name="partitionsNum" value="${canal.mq.partitionsNum}" />
         <property name="partitionHash" value="${canal.mq.partitionHash}" />

--- a/deployer/src/main/resources/spring/group-instance.xml
+++ b/deployer/src/main/resources/spring/group-instance.xml
@@ -331,6 +331,7 @@
     <bean id="mqConfig" class="com.alibaba.otter.canal.instance.core.CanalMQConfig">
         <property name="topic" value="${canal.mq.topic}" />
 		<property name="dynamicTopic" value="${canal.mq.dynamicTopic}" />
+		<property name="dynamicTag" value="${canal.mq.dynamicTag}" />
         <property name="partition" value="${canal.mq.partition}" />
         <property name="partitionsNum" value="${canal.mq.partitionsNum}" />
         <property name="partitionHash" value="${canal.mq.partitionHash}" />

--- a/deployer/src/main/resources/spring/memory-instance.xml
+++ b/deployer/src/main/resources/spring/memory-instance.xml
@@ -203,6 +203,7 @@
 	<bean id="mqConfig" class="com.alibaba.otter.canal.instance.core.CanalMQConfig">
 		<property name="topic" value="${canal.mq.topic}" />
 		<property name="dynamicTopic" value="${canal.mq.dynamicTopic}" />
+		<property name="dynamicTag" value="${canal.mq.dynamicTag}" />
 		<property name="partition" value="${canal.mq.partition}" />
 		<property name="partitionsNum" value="${canal.mq.partitionsNum}" />
 		<property name="partitionHash" value="${canal.mq.partitionHash}" />

--- a/instance/core/src/main/java/com/alibaba/otter/canal/instance/core/CanalMQConfig.java
+++ b/instance/core/src/main/java/com/alibaba/otter/canal/instance/core/CanalMQConfig.java
@@ -7,6 +7,7 @@ public class CanalMQConfig {
     private Integer partitionsNum;
     private String  partitionHash;
     private String  dynamicTopic;
+    private String  dynamicTag;
     private String  dynamicTopicPartitionNum;
     private Boolean enableDynamicQueuePartition;
 
@@ -48,6 +49,14 @@ public class CanalMQConfig {
 
     public void setDynamicTopic(String dynamicTopic) {
         this.dynamicTopic = dynamicTopic;
+    }
+
+    public String getDynamicTag() {
+        return dynamicTag;
+    }
+
+    public void setDynamicTag(String dynamicTag) {
+        this.dynamicTag = dynamicTag;
     }
 
     public String getDynamicTopicPartitionNum() {

--- a/server/src/main/java/com/alibaba/otter/canal/server/CanalMQStarter.java
+++ b/server/src/main/java/com/alibaba/otter/canal/server/CanalMQStarter.java
@@ -160,6 +160,7 @@ public class CanalMQStarter {
                 canalDestination.setTopic(mqConfig.getTopic());
                 canalDestination.setPartition(mqConfig.getPartition());
                 canalDestination.setDynamicTopic(mqConfig.getDynamicTopic());
+                canalDestination.setDynamicTag(mqConfig.getDynamicTag());
                 canalDestination.setPartitionsNum(mqConfig.getPartitionsNum());
                 canalDestination.setPartitionHash(mqConfig.getPartitionHash());
                 canalDestination.setDynamicTopicPartitionNum(mqConfig.getDynamicTopicPartitionNum());


### PR DESCRIPTION
提交了dynamicTag的支持，使用dynamicTopic相同的匹配分隔逻辑。遗憾的是，对于目前支持的所有MQ，感觉仅RocketMQ对tag的支持是更有意义的，因此该提交仅处理了CanalRocketMQProducer的支持。这样的实现看起来有些异味，只是目前存在这样的需求，对RocketMQ同个topic下的消息标记tag，消费端按需过滤不同的tag。另外在issues中也看到一些同样的对dynamicTag的需求，如：[5375](https://github.com/alibaba/canal/issues/5375)，[4468](https://github.com/alibaba/canal/issues/4468)，[3409](https://github.com/alibaba/canal/issues/3409)，[1793](https://github.com/alibaba/canal/issues/1793) 等。
请评估下是否可以支持该功能，谢谢。