### PR TITLE
修复mysql rds oss订阅本地binlog过期需要再次订阅oss

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/exception/ServerLogPurgedException.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/exception/ServerLogPurgedException.java
@@ -1,0 +1,8 @@
+package com.alibaba.otter.canal.parse.exception;
+import com.alibaba.otter.canal.common.CanalException;
+
+public class ServerLogPurgedException extends CanalException {
+    public ServerLogPurgedException(String errorCode) {
+        super("ServerLogPurged0: " + errorCode);
+    }
+}

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/DirectLogFetcher.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/DirectLogFetcher.java
@@ -4,7 +4,8 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.SocketTimeoutException;
 import java.nio.channels.ClosedByInterruptException;
-import org.apache.commons.lang3.StringUtils;
+
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/DirectLogFetcher.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/dbsync/DirectLogFetcher.java
@@ -4,12 +4,13 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.SocketTimeoutException;
 import java.nio.channels.ClosedByInterruptException;
-
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.alibaba.otter.canal.parse.driver.mysql.socket.SocketChannel;
 import com.taobao.tddl.dbsync.binlog.LogFetcher;
+import com.alibaba.otter.canal.parse.exception.ServerLogPurgedException;
 
 /**
  * 基于socket的logEvent实现
@@ -99,6 +100,11 @@ public class DirectLogFetcher extends LogFetcher {
                     final int errno = getInt16();
                     String sqlstate = forward(1).getFixString(SQLSTATE_LENGTH);
                     String errmsg = getFixString(limit - position);
+                    if (StringUtils.containsIgnoreCase(errmsg, "not find first log file name")
+                            || StringUtils.containsIgnoreCase(errmsg, "purged binary logs")) {
+                        // 开始 dump 后，server 位点过期，DUMP 和 DUMP_GTID 两种错误信息
+                        throw new ServerLogPurgedException(errmsg);
+                    }
                     throw new IOException("Received error packet:" + " errno = " + errno + ", sqlstate = " + sqlstate
                                           + " errmsg = " + errmsg);
                 } else if (mark == 254) {

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/rds/RdsBinlogEventParserProxy.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/rds/RdsBinlogEventParserProxy.java
@@ -92,8 +92,10 @@ public class RdsBinlogEventParserProxy extends MysqlEventParser {
     }
 
     private void handleMysqlParserException(Throwable throwable) {
-        if (throwable instanceof PositionNotFoundException) {
-            logger.info("remove rds not found position, try download rds binlog!");
+        if (throwable instanceof PositionNotFoundException
+                || throwable instanceof ServerLogPurgedException) {
+            logger.info("remove rds not found position, try download rds binlog! {} : {}",
+                    throwable.getClass().getSimpleName(), throwable.getMessage());
             executorService.execute(() -> {
                 try {
                     logger.info("stop mysql parser!");

--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/rds/RdsBinlogEventParserProxy.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/rds/RdsBinlogEventParserProxy.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Executors;
 import org.apache.commons.lang.StringUtils;
 
 import com.alibaba.otter.canal.parse.exception.PositionNotFoundException;
+import com.alibaba.otter.canal.parse.exception.ServerLogPurgedException;
 import com.alibaba.otter.canal.parse.inbound.ParserExceptionHandler;
 import com.alibaba.otter.canal.parse.inbound.mysql.MysqlEventParser;
 


### PR DESCRIPTION
如下图所示，同步开始时初始化查询当前最新本地日志是mysql-bin.101，没有找到用户指定的位点，然后开始同步去拉oss的数据。oss的数据同步完成后，开始去订阅本地日志mysql-bin.101，但此时实际已经被清理了 导致Could not find first log file name in binary log index file异常。

<img width="1350" height="1406" alt="image" src="https://github.com/user-attachments/assets/1436f1d7-d7a9-4e04-9c4d-2a5a98842e8f" />
