### PR TITLE
refactor(canal/adapter): improve perf

### DIFF
--- a/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/MariaGtid.java
+++ b/driver/src/main/java/com/alibaba/otter/canal/parse/driver/mysql/packets/MariaGtid.java
@@ -72,6 +72,10 @@ public class MariaGtid {
 
     @Override
     public String toString() {
-        return String.format("%s-%s-%s", domainId, serverId, sequence);
+        StringBuilder sb = new StringBuilder(16);
+        sb.append(domainId).append("-");
+        sb.append(serverId).append("-");
+        return sb.append(sequence).toString();
+        // return String.format("%s-%s-%s", domainId, serverId, sequence);
     }
 }


### PR DESCRIPTION
- String.format is lower than StringBuilder. Benchmark like below:

code snippet:

String str = String.format("%s-%s-%s", 0, 1, 10);

Benchmark                         Mode     Cnt         Score    Error  Units
StringBenchmark.append           thrpt          46431458.255           ops/s
StringBenchmark.format           thrpt            985724.313           ops/s
StringBenchmark.append            avgt                ≈ 10⁻⁸            s/op
StringBenchmark.format            avgt                ≈ 10⁻⁶            s/op
StringBenchmark.append          sample  364232        ≈ 10⁻⁷            s/op
StringBenchmark.append:p0.00    sample                ≈ 10⁻⁸            s/op
StringBenchmark.append:p0.50    sample                ≈ 10⁻⁷            s/op
StringBenchmark.append:p0.90    sample                ≈ 10⁻⁷            s/op
StringBenchmark.append:p0.95    sample                ≈ 10⁻⁷            s/op
StringBenchmark.append:p0.99    sample                ≈ 10⁻⁷            s/op
StringBenchmark.append:p0.999   sample                ≈ 10⁻⁷            s/op
StringBenchmark.append:p0.9999  sample                ≈ 10⁻⁵            s/op
StringBenchmark.append:p1.00    sample                 0.001            s/op
StringBenchmark.format          sample  336220        ≈ 10⁻⁶            s/op
StringBenchmark.format:p0.00    sample                ≈ 10⁻⁶            s/op
StringBenchmark.format:p0.50    sample                ≈ 10⁻⁶            s/op
StringBenchmark.format:p0.90    sample                ≈ 10⁻⁶            s/op
StringBenchmark.format:p0.95    sample                ≈ 10⁻⁶            s/op
StringBenchmark.format:p0.99    sample                ≈ 10⁻⁶            s/op
StringBenchmark.format:p0.999   sample                ≈ 10⁻⁵            s/op
StringBenchmark.format:p0.9999  sample                ≈ 10⁻⁴            s/op
StringBenchmark.format:p1.00    sample                 0.001            s/op
StringBenchmark.append              ss                ≈ 10⁻⁶            s/op
StringBenchmark.format              ss                ≈ 10⁻⁵            s/op