### PR TITLE
feat(canal/adapter): adapter支持prometheus暴露jvm指标

### DIFF
--- a/client-adapter/launcher/pom.xml
+++ b/client-adapter/launcher/pom.xml
@@ -68,7 +68,6 @@
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-shaded-client</artifactId>
@@ -77,6 +76,18 @@
         <dependency>
             <groupId>ru.yandex.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
+        </dependency>
+
+        <!-- prometheus hotspot exporter -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>0.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>0.4.0</version>
         </dependency>
 
         <!-- outer adapter jar with dependencies-->

--- a/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/CanalAdapterApplication.java
+++ b/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/CanalAdapterApplication.java
@@ -13,6 +13,7 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
  */
 @SpringBootApplication(exclude= { DataSourceAutoConfiguration.class})
 public class CanalAdapterApplication {
+
     public static void main(String[] args) {
         // 支持rocketmq client 配置日志路径
         System.setProperty("rocketmq.client.logUseSlf4j","true");

--- a/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/prometheus/CanalAdapterExports.java
+++ b/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/prometheus/CanalAdapterExports.java
@@ -1,0 +1,33 @@
+package com.alibaba.otter.canal.adapter.launcher.prometheus;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author sunxien
+ * @date 2025/5/19
+ * @since 1.0.0-SNAPSHOT
+ */
+public class CanalAdapterExports {
+
+    private static final Logger logger = LoggerFactory.getLogger(CanalAdapterExports.class);
+
+    private CanalAdapterExports() {
+    }
+
+    private static class SingletonHolder {
+        private static final CanalAdapterExports SINGLETON = new CanalAdapterExports();
+    }
+
+    public static CanalAdapterExports instance() {
+        return SingletonHolder.SINGLETON;
+    }
+
+    public void initialize() {
+        // TODO
+    }
+
+    public void terminate() {
+        // TODO
+    }
+}

--- a/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/prometheus/PrometheusService.java
+++ b/client-adapter/launcher/src/main/java/com/alibaba/otter/canal/adapter/launcher/prometheus/PrometheusService.java
@@ -1,0 +1,98 @@
+package com.alibaba.otter.canal.adapter.launcher.prometheus;
+
+import io.prometheus.client.exporter.HTTPServer;
+import io.prometheus.client.hotspot.DefaultExports;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * @author sunxien
+ * @date 2025/5/19
+ * @since 1.0.0-SNAPSHOT
+ */
+@Component
+public class PrometheusService implements InitializingBean, DisposableBean {
+
+    private static final Logger logger = LoggerFactory.getLogger(PrometheusService.class);
+
+    private final CanalAdapterExports adapterExports;
+    private volatile boolean running = false;
+
+    /**
+     * <pre>
+     * Canal Server admin port: 11112
+     * Canal Server tcp port: 11111
+     * Canal Adapter metric port: 11113
+     * </pre>
+     */
+    private int port = 11113;
+    private HTTPServer httpServer;
+
+    private PrometheusService() {
+        this.adapterExports = CanalAdapterExports.instance();
+    }
+
+    private static class SingletonHolder {
+        private static final PrometheusService SINGLETON = new PrometheusService();
+    }
+
+    public static PrometheusService getInstance() {
+        return SingletonHolder.SINGLETON;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        PrometheusService.getInstance().initialize();
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        PrometheusService.getInstance().terminate();
+    }
+
+    public void initialize() {
+        try {
+            logger.info("Starting prometheus HTTPServer on port {}....", port);
+            // TODO 2.Https?
+            httpServer = new HTTPServer(port);
+            logger.info("Start prometheus HTTPServer on port {} success", port);
+        } catch (IOException e) {
+            logger.error("Unable to start prometheus HTTPServer on port {}.", port, e);
+            return;
+        }
+        try {
+            // JVM exports
+            DefaultExports.initialize();
+            // adapterExports.initialize();
+            this.running = true;
+        } catch (Throwable t) {
+            logger.error("Unable to initialize adapter exports. (Register the default Hotspot collectors)", t);
+        }
+    }
+
+    public void terminate() {
+        try {
+            this.running = false;
+            adapterExports.terminate();
+            if (httpServer != null) {
+                httpServer.stop();
+                logger.info("Stop prometheus HTTPServer on port {} success", port);
+            }
+        } catch (Throwable t) {
+            logger.error("Something happened while terminating prometheus HTTPServer.", t);
+        }
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    public void setServerPort(int port) {
+        this.port = port;
+    }
+}


### PR DESCRIPTION
- adapter 默认提供prometheus暴露JVM指标

- 指定 maven-antrun-plugin 未指定版本号，默认是 3.0.0，但是配置中使用 <tasks> 标签，编译报错。
   - 降级版本号，显式指定 1.8 版本
   - 或者把配置中的 <tasks> 标签改成 <target>