### PR TITLE
fix: ensure super.stop() called exactly once in CanalRabbitMQProducer

### DIFF
--- a/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
+++ b/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
@@ -210,13 +210,12 @@ public class CanalRabbitMQProducer extends AbstractMQProducer implements CanalMQ
         try {
             this.channel.close();
             this.connect.close();
-            super.stop();
         } catch (AlreadyClosedException ex) {
             logger.error("Connection is already closed", ex);
         } catch (IOException | TimeoutException ex) {
             throw new CanalException("Stop RabbitMQ producer error", ex);
+        } finally {
+            super.stop();
         }
-
-        super.stop();
     }
 }


### PR DESCRIPTION
## Problem

In `CanalRabbitMQProducer.stop()`, `super.stop()` is called in two places: inside the try block (line 213) and after the catch blocks (line 220). This causes `super.stop()` to be invoked twice on success, and not at all when `IOException`/`TimeoutException` is thrown (since line 217 re-throws before reaching line 220).

## Root Cause

Logic error in the stop() method structure — the `super.stop()` call was placed both inside the try and outside the catch blocks.

## Fix

Move `super.stop()` to a `finally` block so it executes exactly once regardless of whether `channel.close()` and `connect.close()` succeed or fail. This ensures the producer is always properly stopped.

## Impact

- Prevents double invocation of `super.stop()` on normal shutdown
- Ensures `super.stop()` is always called even when `IOException`/`TimeoutException` occurs during close