### PR TITLE
fix: close HttpClient after binlog download to prevent resource leak

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/rds/BinlogDownloadQueue.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/rds/BinlogDownloadQueue.java
@@ -189,19 +189,23 @@ public class BinlogDownloadQueue {
             httpClient = HttpClientBuilder.create().setMaxConnPerRoute(50).setMaxConnTotal(100).build();
         }
 
-        HttpGet httpGet = new HttpGet(downloadLink);
-        RequestConfig requestConfig = RequestConfig.custom()
-            .setConnectTimeout(TIMEOUT)
-            .setConnectionRequestTimeout(TIMEOUT)
-            .setSocketTimeout(TIMEOUT)
-            .build();
-        httpGet.setConfig(requestConfig);
-        HttpResponse response = httpClient.execute(httpGet);
-        int statusCode = response.getStatusLine().getStatusCode();
-        if (statusCode != HttpResponseStatus.OK.code()) {
-            throw new RuntimeException("download failed , url:" + downloadLink + " , statusCode:" + statusCode);
+        try {
+            HttpGet httpGet = new HttpGet(downloadLink);
+            RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(TIMEOUT)
+                .setConnectionRequestTimeout(TIMEOUT)
+                .setSocketTimeout(TIMEOUT)
+                .build();
+            httpGet.setConfig(requestConfig);
+            HttpResponse response = httpClient.execute(httpGet);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != HttpResponseStatus.OK.code()) {
+                throw new RuntimeException("download failed , url:" + downloadLink + " , statusCode:" + statusCode);
+            }
+            saveFile(new File(destDir), "mysql-bin." + fileName, response);
+        } finally {
+            httpClient.close();
         }
-        saveFile(new File(destDir), "mysql-bin." + fileName, response);
     }
 
     private static void saveFile(File parentFile, String fileName, HttpResponse response) throws IOException {


### PR DESCRIPTION
## Problem

`BinlogDownloadQueue.download()` creates a new `CloseableHttpClient` for each RDS binlog download but never closes it. Over time, this leaks HTTP connections and associated system resources (sockets, threads), potentially causing connection pool exhaustion.

## Root Cause

The `httpClient` variable is created and used to execute an HTTP request, but there is no `close()` call in any code path — neither in the normal flow nor in the error path when the status code is not 200.

## Fix

Wrap the HTTP execution logic in a `try-finally` block to ensure `httpClient.close()` is always called after the download completes or fails.

## Impact

Prevents HTTP connection leaks during RDS binlog downloads. Each download now properly releases its connection resources.