### PR TITLE
fix: close previous file resources before reopening in BufferedFileDataInput.seek()

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/local/BufferedFileDataInput.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/local/BufferedFileDataInput.java
@@ -50,6 +50,7 @@ public class BufferedFileDataInput {
     }
 
     public void seek(long seekBytes) throws FileNotFoundException, IOException, InterruptedException {
+        close();
         fileInput = new FileInputStream(file);
         fileChannel = fileInput.getChannel();
 


### PR DESCRIPTION
## Problem

`BufferedFileDataInput.seek()` creates new `FileInputStream` and `FileChannel` without closing the previously held ones. When `seek()` is called multiple times (e.g., when repositioning within a binlog file), the old file descriptors are leaked.

## Root Cause

The `seek()` method directly assigns new instances to `fileInput` and `fileChannel` fields without first closing the existing resources.

## Fix

Call `close()` at the beginning of `seek()` before creating new resources. The existing `close()` method already handles null checks and error logging gracefully, so it is safe to call even on first invocation when fields are still null.

## Impact

Prevents file descriptor leaks when binlog files are re-read or repositioned. This is particularly important for long-running canal instances that process many binlog files.