### PR TITLE
fix: preserve commas inside regex grouping when splitting filter patterns

### DIFF
--- a/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/filter/AviaterRegexFilter.java
+++ b/connector/core/src/main/java/com/alibaba/otter/canal/connector/core/filter/AviaterRegexFilter.java
@@ -1,7 +1,6 @@
 package com.alibaba.otter.canal.connector.core.filter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -19,7 +18,6 @@ import com.googlecode.aviator.Expression;
  */
 public class AviaterRegexFilter {
 
-    private static final String             SPLIT             = ",";
     private static final String             PATTERN_SPLIT     = "|";
     private static final String             FILTER_EXPRESSION = "regex(pattern,target)";
     private static final RegexFunction      regexFunction     = new RegexFunction();
@@ -43,8 +41,9 @@ public class AviaterRegexFilter {
         if (StringUtils.isEmpty(pattern)) {
             list = new ArrayList<>();
         } else {
-            String[] ss = StringUtils.split(pattern, SPLIT);
-            list = Arrays.asList(ss);
+            // fix issue #5442: only split on commas outside regex grouping constructs,
+            // so quantifiers like \d{1,2} are kept intact.
+            list = splitPattern(pattern);
         }
 
         // 对pattern按照从长到短的排序
@@ -54,6 +53,60 @@ public class AviaterRegexFilter {
         // 对pattern进行头尾完全匹配
         list = completionPattern(list);
         this.pattern = StringUtils.join(list, PATTERN_SPLIT);
+    }
+
+    /**
+     * 按顶层逗号拆分多个正则表达式，跳过位于 {}, [], () 内的逗号，避免破坏类似 \d{1,2} 的量词写法。
+     */
+    private static List<String> splitPattern(String pattern) {
+        List<String> result = new ArrayList<>();
+        int braceDepth = 0;
+        int bracketDepth = 0;
+        int parenDepth = 0;
+        int start = 0;
+        int len = pattern.length();
+        for (int i = 0; i < len; i++) {
+            char c = pattern.charAt(i);
+            // 反斜杠转义：跳过下一个字符，避免把 \{ \[ \( 等误判为分组开始
+            if (c == '\\' && i + 1 < len) {
+                i++;
+                continue;
+            }
+            switch (c) {
+                case '{':
+                    braceDepth++;
+                    break;
+                case '}':
+                    if (braceDepth > 0) braceDepth--;
+                    break;
+                case '[':
+                    bracketDepth++;
+                    break;
+                case ']':
+                    if (bracketDepth > 0) bracketDepth--;
+                    break;
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    if (parenDepth > 0) parenDepth--;
+                    break;
+                case ',':
+                    if (braceDepth == 0 && bracketDepth == 0 && parenDepth == 0) {
+                        if (i > start) {
+                            result.add(pattern.substring(start, i));
+                        }
+                        start = i + 1;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        if (start < len) {
+            result.add(pattern.substring(start));
+        }
+        return result;
     }
 
     public boolean filter(String filtered) {

--- a/filter/src/main/java/com/alibaba/otter/canal/filter/aviater/AviaterRegexFilter.java
+++ b/filter/src/main/java/com/alibaba/otter/canal/filter/aviater/AviaterRegexFilter.java
@@ -1,7 +1,6 @@
 package com.alibaba.otter.canal.filter.aviater;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -21,7 +20,6 @@ import com.googlecode.aviator.Expression;
  */
 public class AviaterRegexFilter implements CanalEventFilter<String> {
 
-    private static final String             SPLIT             = ",";
     private static final String             PATTERN_SPLIT     = "|";
     private static final String             FILTER_EXPRESSION = "regex(pattern,target)";
     private static final RegexFunction      regexFunction     = new RegexFunction();
@@ -45,8 +43,9 @@ public class AviaterRegexFilter implements CanalEventFilter<String> {
         if (StringUtils.isEmpty(pattern)) {
             list = new ArrayList<>();
         } else {
-            String[] ss = StringUtils.split(pattern, SPLIT);
-            list = Arrays.asList(ss);
+            // fix issue #5442: only split on commas outside regex grouping constructs,
+            // so quantifiers like \d{1,2} are kept intact.
+            list = splitPattern(pattern);
         }
 
         // 对pattern按照从长到短的排序
@@ -56,6 +55,60 @@ public class AviaterRegexFilter implements CanalEventFilter<String> {
         // 对pattern进行头尾完全匹配
         list = completionPattern(list);
         this.pattern = StringUtils.join(list, PATTERN_SPLIT);
+    }
+
+    /**
+     * 按顶层逗号拆分多个正则表达式，跳过位于 {}, [], () 内的逗号，避免破坏类似 \d{1,2} 的量词写法。
+     */
+    private static List<String> splitPattern(String pattern) {
+        List<String> result = new ArrayList<>();
+        int braceDepth = 0;
+        int bracketDepth = 0;
+        int parenDepth = 0;
+        int start = 0;
+        int len = pattern.length();
+        for (int i = 0; i < len; i++) {
+            char c = pattern.charAt(i);
+            // 反斜杠转义：跳过下一个字符，避免把 \{ \[ \( 等误判为分组开始
+            if (c == '\\' && i + 1 < len) {
+                i++;
+                continue;
+            }
+            switch (c) {
+                case '{':
+                    braceDepth++;
+                    break;
+                case '}':
+                    if (braceDepth > 0) braceDepth--;
+                    break;
+                case '[':
+                    bracketDepth++;
+                    break;
+                case ']':
+                    if (bracketDepth > 0) bracketDepth--;
+                    break;
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    if (parenDepth > 0) parenDepth--;
+                    break;
+                case ',':
+                    if (braceDepth == 0 && bracketDepth == 0 && parenDepth == 0) {
+                        if (i > start) {
+                            result.add(pattern.substring(start, i));
+                        }
+                        start = i + 1;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+        if (start < len) {
+            result.add(pattern.substring(start));
+        }
+        return result;
     }
 
     public boolean filter(String filtered) throws CanalFilterException {

--- a/filter/src/test/java/com/alibaba/otter/canal/filter/AviaterFilterTest.java
+++ b/filter/src/test/java/com/alibaba/otter/canal/filter/AviaterFilterTest.java
@@ -78,6 +78,28 @@ public class AviaterFilterTest {
     }
 
     @Test
+    public void test_regex_with_quantifier_comma() {
+        // fix issue #5442: comma inside {n,m} quantifier should not split the pattern
+        AviaterRegexFilter filter = new AviaterRegexFilter("test\\.order_\\d{1,2}");
+        Assert.assertTrue(filter.filter("test.order_5"));
+        Assert.assertTrue(filter.filter("test.order_42"));
+        Assert.assertFalse(filter.filter("test.order_123"));
+        Assert.assertFalse(filter.filter("test.order_"));
+
+        // multiple patterns combined with quantifier should still split correctly
+        AviaterRegexFilter filter2 = new AviaterRegexFilter("test\\.order_\\d{1,2},test\\.user_\\d+");
+        Assert.assertTrue(filter2.filter("test.order_7"));
+        Assert.assertTrue(filter2.filter("test.user_99"));
+        Assert.assertFalse(filter2.filter("test.order_123"));
+
+        // open-ended quantifier {n,}
+        AviaterRegexFilter filter3 = new AviaterRegexFilter("test\\.t_\\d{2,}");
+        Assert.assertTrue(filter3.filter("test.t_12"));
+        Assert.assertTrue(filter3.filter("test.t_123"));
+        Assert.assertFalse(filter3.filter("test.t_1"));
+    }
+
+    @Test
     public void testDisordered() {
         AviaterRegexFilter filter = new AviaterRegexFilter("u\\..*,uvw\\..*,uv\\..*,a\\.x,a\\.xyz,a\\.xy,abc\\.x,abc\\.xyz,abc\\.xy,ab\\.x,ab\\.xyz,ab\\.xy");
 


### PR DESCRIPTION
## Problem

`AviaterRegexFilter#init` splits the configured filter pattern on every comma, so a regex such as `test\.order_\d{1,2}` is broken into two pieces (`test\.order_\d{1` and `2}`). The same issue affects any pattern that places a comma inside a grouping construct, e.g. `(a,b|c)` or character classes that intentionally contain commas.

Reproduction:

```java
AviaterRegexFilter filter = new AviaterRegexFilter("test\\.order_\\d{1,2}");
filter.filter("test.order_5"); // expected: true, actual: throws PatternSyntaxException
```

## Root Cause

```java
String[] ss = StringUtils.split(pattern, SPLIT); // SPLIT = ","
list = Arrays.asList(ss);
```

`StringUtils.split` is unaware of regex syntax — it splits on every comma. The comma inside `{n,m}` quantifiers and other grouping constructs is therefore treated as a top-level separator.

## Fix

Replace the unconditional split with a small parse-aware splitter that walks the pattern character by character, tracks the depth of `{}`, `[]`, `()` and respects backslash escapes, and only splits on commas when all three depths are zero.

Apply the change to both copies of `AviaterRegexFilter`:
- `filter/src/main/java/com/alibaba/otter/canal/filter/aviater/AviaterRegexFilter.java`
- `connector/core/src/main/java/com/alibaba/otter/canal/connector/core/filter/AviaterRegexFilter.java`

## Tests Added

| Change point | Test |
|--------------|------|
| Single-pattern `\d{1,2}` quantifier preserved | `test_regex_with_quantifier_comma()` — asserts `test.order_5` and `test.order_42` match, `test.order_123` does not |
| Multi-pattern list with `\d{1,2}` still splits at top-level commas | same test, second filter — `test.order_7` matches, `test.user_99` matches, `test.order_123` does not |
| Open-ended `{n,}` quantifier preserved | same test, third filter — `test.t_12` and `test.t_123` match, `test.t_1` does not |

`mvn -am -pl filter test -Dtest=AviaterFilterTest` — 5/5 tests pass locally (the 4 existing ones plus the new one).

## Impact

- Configured filter expressions that previously got silently misparsed (regex quantifiers, parenthesised alternations, character classes containing commas) now work as written.
- Existing filter expressions with no commas inside grouping constructs are unaffected — the splitter produces the same output as the old `StringUtils.split` for those inputs.

Fixes #5442