### PR TITLE
Fix UriUtils.parseQuery dropping query values that contain '='

### DIFF
--- a/common/src/main/java/com/alibaba/otter/canal/common/utils/UriUtils.java
+++ b/common/src/main/java/com/alibaba/otter/canal/common/utils/UriUtils.java
@@ -59,7 +59,7 @@ public final class UriUtils {
         scan.useDelimiter(SPLIT);
         while (scan.hasNext()) {
             String token = scan.next().trim();
-            String[] pair = token.split(EQUAL);
+            String[] pair = token.split(EQUAL, 2);
             String key = decode(pair[0], encoding);
             String value = null;
             if (pair.length == 2) {

--- a/common/src/test/java/com/alibaba/otter/canal/common/utils/UriUtilsTest.java
+++ b/common/src/test/java/com/alibaba/otter/canal/common/utils/UriUtilsTest.java
@@ -1,0 +1,51 @@
+package com.alibaba.otter.canal.common.utils;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class UriUtilsTest {
+
+    @Test
+    public void testParseQueryWithMultipleEqualsInValue() throws URISyntaxException {
+        // When a query parameter value contains '=' (e.g., a=b=c),
+        // the value should be "b=c", not truncated to "b".
+        // This is the standard URL query parsing behavior (split on first '=' only).
+        String uriString = "http://example.com?name=a=b=c";
+        URI uri = new URI(uriString);
+
+        Map<String, String> params = UriUtils.parseQuery(uri);
+
+        assertTrue(params.containsKey("name"));
+        assertEquals("a=b=c", params.get("name"));
+    }
+
+    @Test
+    public void testParseQueryWithMultipleEqualsInValueFromString() throws URISyntaxException {
+        // Same test using the String overload
+        Map<String, String> params = UriUtils.parseQuery("http://example.com?token=x=y=z&w=1");
+
+        assertEquals("x=y=z", params.get("token"));
+        assertEquals("1", params.get("w"));
+    }
+
+    @Test
+    public void testParseQueryNoEqualsSign() throws URISyntaxException {
+        // A parameter with no '=' should have null value
+        Map<String, String> params = UriUtils.parseQuery("http://example.com?flag");
+
+        assertTrue(params.containsKey("flag"));
+        assertNull(params.get("flag"));
+    }
+
+    @Test
+    public void testParseQuerySimpleParameter() throws URISyntaxException {
+        Map<String, String> params = UriUtils.parseQuery("http://example.com?foo=bar");
+
+        assertEquals("bar", params.get("foo"));
+    }
+}


### PR DESCRIPTION
## Problem

`UriUtils.parseQuery` splits each token with `token.split(EQUAL)`:

```java
String[] pair = token.split(EQUAL, /* no limit */);
String key = decode(pair[0], encoding);
String value = null;
if (pair.length == 2) {
    value = decode(pair[1], encoding);
}
```

A value that contains one or more `=` (for example `name=a=b=c`) splits into more than two segments, so `pair.length != 2` and the value is left `null` — the real value is silently dropped.

## Fix

Use `token.split(EQUAL, 2)` so only the first `=` separates the key from the value and the remainder of the value is kept intact (`name=a=b=c` → key `name`, value `a=b=c`).

## Test

Adds `UriUtilsTest` covering values with multiple `=`, a simple parameter, and a flag-only key. The multiple-`=` cases fail on `master` (the value comes back `null`) and pass with this change.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
