### PR TITLE
Keep dots in RabbitMQ dynamic-topic routing key (#5464)

### DIFF
--- a/connector/rabbitmq-connector/pom.xml
+++ b/connector/rabbitmq-connector/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
+++ b/connector/rabbitmq-connector/src/main/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducer.java
@@ -148,7 +148,9 @@ public class CanalRabbitMQProducer extends AbstractMQProducer implements CanalMQ
                     .messageTopics(message, destination.getTopic(), destination.getDynamicTopic());
 
                 for (Map.Entry<String, com.alibaba.otter.canal.protocol.Message> entry : messageMap.entrySet()) {
-                    final String topicName = entry.getKey().replace('.', '_');
+                    // RabbitMQ routing key 以 '.' 为 topic exchange 路由分隔符，须保留动态 topic 原值；
+                    // 不能像 Kafka/RocketMQ/Pulsar producer 那样 replace('.', '_')（那里该值是 topic 名）
+                    final String topicName = entry.getKey();
                     final com.alibaba.otter.canal.protocol.Message messageSub = entry.getValue();
 
                     template.submit(() -> send(destination, topicName, messageSub));

--- a/connector/rabbitmq-connector/src/test/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducerTest.java
+++ b/connector/rabbitmq-connector/src/test/java/com/alibaba/otter/canal/connector/rabbitmq/producer/CanalRabbitMQProducerTest.java
@@ -1,0 +1,95 @@
+package com.alibaba.otter.canal.connector.rabbitmq.producer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.alibaba.otter.canal.connector.core.producer.AbstractMQProducer;
+import com.alibaba.otter.canal.connector.core.producer.MQDestination;
+import com.alibaba.otter.canal.connector.core.util.Callback;
+import com.alibaba.otter.canal.connector.rabbitmq.config.RabbitMQProducerConfig;
+import com.alibaba.otter.canal.protocol.CanalEntry.Entry;
+import com.alibaba.otter.canal.protocol.CanalEntry.EntryType;
+import com.alibaba.otter.canal.protocol.CanalEntry.Header;
+import com.alibaba.otter.canal.protocol.Message;
+import com.rabbitmq.client.Channel;
+
+public class CanalRabbitMQProducerTest {
+
+    /**
+     * Exercises the full send() -> sendMessage() -> channel.basicPublish() path with a
+     * dynamic-topic configuration, asserting the routing key passed to basicPublish
+     * retains its dot (instead of being mangled into an underscore at the call site).
+     * Guards against the call site being reverted to entry.getKey().replace('.', '_').
+     */
+    @Test
+    public void testDynamicTopicRoutingKeyRetainsDots() throws Exception {
+        // Build a canal Message containing one ROWDATA entry on schema retl / table retl_mark,
+        // which is matched by the dynamic-topic rule below.
+        Header header = Header.newBuilder().setSchemaName("retl").setTableName("retl_mark").build();
+        Entry entry = Entry.newBuilder().setHeader(header).setEntryType(EntryType.ROWDATA).build();
+        Message message = new Message(1L, Collections.singletonList(entry));
+
+        // dynamic-topic rule: route retl.retl_mark to the literal topic "canal.sync" (contains a dot).
+        // The part before ':' is the topic/routing key, the part after ':' is the match config.
+        MQDestination destination = new MQDestination();
+        destination.setCanalDestination("example");
+        destination.setTopic("canal.default");
+        destination.setDynamicTopic("canal.sync:retl.retl_mark");
+
+        CanalRabbitMQProducer producer = new CanalRabbitMQProducer();
+
+        // Inject a non-flat RabbitMQ config so send() takes the non-flat branch (no buildExecutor needed).
+        RabbitMQProducerConfig config = new RabbitMQProducerConfig();
+        config.setFlatMessage(false);
+        config.setExchange("canal.exchange");
+        setField(producer, getDeclaredField(AbstractMQProducer.class, "mqProperties"), config);
+
+        // Replace the send executor with a synchronous single-thread one so that basicPublish runs
+        // (and completes) before send() returns, making the verify deterministic.
+        ThreadPoolExecutor syncExecutor = new ThreadPoolExecutor(1, 1, 0, TimeUnit.SECONDS,
+            new ArrayBlockingQueue<>(4), r -> {
+                Thread t = new Thread(r, "test-sync-sender");
+                t.setDaemon(true);
+                return t;
+            }, new ThreadPoolExecutor.CallerRunsPolicy());
+        setField(producer, getDeclaredField(AbstractMQProducer.class, "sendExecutor"), syncExecutor);
+
+        // Mock the RabbitMQ channel (private field, no injection point in production code).
+        Channel mockChannel = mock(Channel.class);
+        setField(producer, getDeclaredField(CanalRabbitMQProducer.class, "channel"), mockChannel);
+
+        Callback callback = Mockito.mock(Callback.class);
+
+        producer.send(destination, message, callback);
+
+        // basicPublish(exchange, routingKey, props, body): the 2nd argument is the routing key.
+        // It must retain the dot from "canal.sync" and not be flattened to "canal_sync".
+        verify(mockChannel).basicPublish(eq("canal.exchange"), eq("canal.sync"), any(), any());
+        // also assert the routing key was never published in its underscore-mangled form
+        Mockito.verify(mockChannel, Mockito.never()).basicPublish(anyString(), eq("canal_sync"), any(), any());
+
+        syncExecutor.shutdownNow();
+    }
+
+    private static Field getDeclaredField(Class<?> clazz, String name) throws NoSuchFieldException {
+        Field f = clazz.getDeclaredField(name);
+        f.setAccessible(true);
+        return f;
+    }
+
+    private static void setField(Object target, Field field, Object value) throws IllegalAccessException {
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
AI 披露：本改动由 AI 编码代理辅助完成，我已逐行审改。

### 问题（What）
动态 topic 模式下，RabbitMQ 的 routing key 被错误地把 `.` 替换成 `_`，导致含 `.` 的动态 topic（如 `canal.sync`）消息能到 exchange 却无法路由到绑定的 queue。

issue：#5464

### 根因（Root cause）
`CanalRabbitMQProducer` 动态 topic 分支用 `entry.getKey().replace('.', '_')` 生成 routing key（从 Kafka producer 复制而来）。但 RabbitMQ 的 routing key 以 `.` 作为 topic exchange 的路由分隔符，替换后路由失效。

### 修复（Fix）
动态 topic 分支直接用 `entry.getKey()` 作为 routing key，保留原值中的 `.`，并在调用处注释说明为何与 Kafka/RocketMQ/Pulsar producer 不同：后三者该值是 topic 名（点号受命名约束），RabbitMQ 该值是 routing key（点号是路由分隔符）。其余三个 producer 不在本次范围。

### ⚠️ 行为变更 / 升级须知（Behavior change）
本修复改变了动态 topic 下 RabbitMQ 实际下发的 routing key：
- 显式 `topic:规则` 配置（如 `canal.sync:retl.retl_mark`）：旧 `canal_sync`（路由失效）-> 新 `canal.sync`（路由生效）。
- 无 `:` 回退用法（动态 topic 规则只写库表匹配、不显式指定 topic 名）：匹配到的 `schema.table` 会被当作 topic，旧 routing key = `retl_retl_mark` -> 新 `retl.retl_mark`。

后者是行为变更：升级前若 queue 按下划线形式绑定，升级后需改绑为带点的 routing key，否则消息无法路由到原 queue。附带好处：带点后 topic exchange 的通配绑定（如 `schema.*`）才真正可用。

### 测试（Testing）
新增 `CanalRabbitMQProducerTest.testDynamicTopicRoutingKeyRetainsDots`：mock Channel，跑真实 `send()` -> `basicPublish()` 路径，断言动态 topic（`canal.sync`）下发时 routing key 保留点号、且从不以 `canal_sync` 下发。JDK 21 下模块单测通过（1/1）。

### 复现（Reproduce）
动态 topic key 含点时（如 `canal\.sync`），修复前 routing key 被传为 `canal_sync`，修复后为 `canal.sync`（与 queue bind 的 key 一致，路由生效）。

Fixes #5464
