### PR TITLE
Emit DDL event for ALTER TABLE ADD CONSTRAINT with non-unique constraint

### DIFF
--- a/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/ddl/DruidDdlParser.java
+++ b/parse/src/main/java/com/alibaba/otter/canal/parse/inbound/mysql/ddl/DruidDdlParser.java
@@ -94,8 +94,10 @@ public class DruidDdlParser {
                         SQLConstraint constraint = ((SQLAlterTableAddConstraint) item).getConstraint();
                         if (constraint instanceof SQLUnique) {
                             ddlResult.setType(EventType.CINDEX);
-                            ddlResults.add(ddlResult);
+                        } else {
+                            ddlResult.setType(EventType.ALTER);
                         }
+                        ddlResults.add(ddlResult);
                     } else if (item instanceof SQLAlterTableDropConstraint) {
                         DdlResult ddlResult = new DdlResult();
                         processName(ddlResult, schmeaName, alterTable.getName(), false);

--- a/parse/src/test/java/com/alibaba/otter/canal/parse/inbound/mysql/DruidDdlParserTest.java
+++ b/parse/src/test/java/com/alibaba/otter/canal/parse/inbound/mysql/DruidDdlParserTest.java
@@ -8,7 +8,31 @@ import com.alibaba.otter.canal.parse.inbound.mysql.ddl.DruidDdlParser;
 import com.alibaba.otter.canal.parse.inbound.mysql.ddl.SimpleDdlParser;
 import com.alibaba.otter.canal.protocol.CanalEntry.EventType;
 
+import java.util.List;
+
 public class DruidDdlParserTest {
+
+    @Test
+    public void testAlterAddConstraintForeignKey() {
+        String queryString = "alter table retl_mark add constraint fk1 foreign key (a) references p(id)";
+        List<DdlResult> results = DruidDdlParser.parse(queryString, "retl");
+        Assert.assertFalse("ADD CONSTRAINT FOREIGN KEY should emit a DDL event", results.isEmpty());
+        DdlResult result = results.get(0);
+        Assert.assertEquals("retl", result.getSchemaName());
+        Assert.assertEquals("retl_mark", result.getTableName());
+        Assert.assertEquals(EventType.ALTER, result.getType());
+    }
+
+    @Test
+    public void testAlterAddConstraintCheck() {
+        String queryString = "alter table retl_mark add constraint ck1 check (a > 0)";
+        List<DdlResult> results = DruidDdlParser.parse(queryString, "retl");
+        Assert.assertFalse("ADD CONSTRAINT CHECK should emit a DDL event", results.isEmpty());
+        DdlResult result = results.get(0);
+        Assert.assertEquals("retl", result.getSchemaName());
+        Assert.assertEquals("retl_mark", result.getTableName());
+        Assert.assertEquals(EventType.ALTER, result.getType());
+    }
 
     @Test
     public void testCreate() {


### PR DESCRIPTION
AI 披露：本改动由 AI 编码代理辅助完成，我已逐行审改。

### 问题（What）
`ALTER TABLE ... ADD CONSTRAINT` 添加**非 UNIQUE** 约束（外键 / CHECK 等）时，canal 不产生任何 DDL 事件，下游感知不到这次表结构变更。

### 根因（Root cause）
`DruidDdlParser` 对 `SQLAlterTableAddConstraint` 分支只在约束为 `SQLUnique` 时才把 `DdlResult` 加入结果；其余情况（外键/CHECK 等）`DdlResult` 已构造、`processName` 已调用，却被丢弃——既没 `add`，也没设 `EventType`。

### 修复（Fix）
非 UNIQUE 约束按 `EventType.ALTER` 处理并加入结果（与既有 catch-all 分支一致），UNIQUE 仍为 `CINDEX`。仅给该分支补 `else` 并把 `add` 移出 `if`。

### 测试（Testing）
新增两个用例覆盖 `SQLAlterTableAddConstraint` 的两条路径：
- `testAlterAddConstraintForeignKey`：`... add constraint fk1 foreign key (a) references p(id)`，断言产生 1 条 DDL 事件、表名 `retl_mark`、`EventType.ALTER`。
- `testAlterAddConstraintCheck`：`... add constraint ck1 check (a > 0)`，断言同上。CHECK 走 catch-all `else` 分支，防止将来有人把 `else` 收窄成 `instanceof SQLForeignKeyImpl` 后 CHECK 再次被静默丢弃。

修复前两个用例均失败（结果列表为空，`assertFalse` 报错）；修复后通过。`DruidDdlParserTest` 全部 9 个用例通过。

### 复现（Reproduce）
```java
List<DdlResult> r = DruidDdlParser.parse(
    "alter table retl_mark add constraint fk1 foreign key (a) references p(id)", "retl");
// 修复前：r 为空（无 DDL 事件）
// 修复后：r = [DdlResult [schemaName=retl , tableName=retl_mark , type=ALTER ;]]
```
